### PR TITLE
chore: bump cookie to ^0.7.0 (security)

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,7 @@
     "@aws-sdk/s3-request-presigner": "^3.294.0",
     "@edgestore/shared": "0.5.6",
     "@panva/hkdf": "^1.0.4",
-    "cookie": "^0.5.0",
+    "cookie": "^0.7.0",
     "jose": "^4.13.1",
     "uuid": "^9.0.0"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -112,7 +112,7 @@
   "dependencies": {
     "@edgestore/shared": "0.5.6",
     "@panva/hkdf": "^1.0.4",
-    "cookie": "^0.5.0",
+    "cookie": "^0.7.0",
     "jose": "^4.13.1",
     "uuid": "^9.0.0"
   },


### PR DESCRIPTION
Bumps cookie to ^0.7.0 in packages/react and packages/server to address a security advisory reported by pnpm audit. This updates the transitive cookie dependency used by downstream projects. I ran local build/tests before opening this PR.

Closes: https://github.com/edgestorejs/edgestore/issues/93