### PR TITLE
[codex] fix lint and type checks

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "dev": "next dev --turbo",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../.gitignore --report-unused-disable-directives src",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/examples/basic-access-control/package.json
+++ b/examples/basic-access-control/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
   "dependencies": {
     "@edgestore/react": "^0.7.0",

--- a/examples/components/package.json
+++ b/examples/components/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
   "dependencies": {
     "@edgestore/react": "^0.7.0",

--- a/examples/next-advanced/package.json
+++ b/examples/next-advanced/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
   "dependencies": {
     "@edgestore/react": "^0.7.0",

--- a/examples/next-basic-aws/package.json
+++ b/examples/next-basic-aws/package.json
@@ -7,7 +7,7 @@
     "dev:minio": "docker-compose up -d && next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.420.0",

--- a/examples/next-basic-with-intl/package.json
+++ b/examples/next-basic-with-intl/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
   "dependencies": {
     "@edgestore/react": "^0.7.0",

--- a/examples/next-basic/package.json
+++ b/examples/next-basic/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
   "dependencies": {
     "@edgestore/react": "^0.7.0",

--- a/examples/next-complete/src/pages/index.tsx
+++ b/examples/next-complete/src/pages/index.tsx
@@ -2,13 +2,13 @@ import { Button } from '@/components/ui/button';
 import { SingleImageDropzone } from '@/components/upload/single-image';
 import {
   UploaderProvider,
-  UploadFn,
   useUploader,
 } from '@/components/upload/uploader-provider';
+import type { UploadFn } from '@/components/upload/uploader-provider';
 import { useEdgeStore } from '@/lib/edgestore';
 import { cn } from '@/lib/utils';
 import { UploadCloudIcon } from 'lucide-react';
-import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
+import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import Image from 'next/image';
 import { useCallback, useEffect, useState } from 'react';
 import { edgeStoreClient } from './api/edgestore/[...edgestore]';

--- a/examples/start-basic/app/components/DefaultCatchBoundary.tsx
+++ b/examples/start-basic/app/components/DefaultCatchBoundary.tsx
@@ -22,7 +22,7 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
       <div className="flex gap-2 items-center flex-wrap">
         <button
           onClick={() => {
-            router.invalidate()
+            void router.invalidate()
           }}
           className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
         >

--- a/examples/start-basic/app/components/NotFound.tsx
+++ b/examples/start-basic/app/components/NotFound.tsx
@@ -8,7 +8,9 @@ export function NotFound({ children }: { children?: any }) {
       </div>
       <p className="flex items-center gap-2 flex-wrap">
         <button
-          onClick={() => window.history.back()}
+          onClick={() => {
+            window.history.back()
+          }}
           className="bg-emerald-500 text-white px-2 py-1 rounded uppercase font-black text-sm"
         >
           Go back

--- a/examples/start-basic/app/utils/posts.tsx
+++ b/examples/start-basic/app/utils/posts.tsx
@@ -30,7 +30,7 @@ export const fetchPosts = createServerFn({ method: 'GET' }).handler(
   async () => {
     console.info('Fetching posts...')
     return axios
-      .get<Array<PostType>>('https://jsonplaceholder.typicode.com/posts')
+      .get<PostType[]>('https://jsonplaceholder.typicode.com/posts')
       .then((r) => r.data.slice(0, 10))
   },
 )

--- a/examples/vite-basic/src/main.tsx
+++ b/examples/vite-basic/src/main.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';

--- a/packages/react/src/contextProvider.tsx
+++ b/packages/react/src/contextProvider.tsx
@@ -8,6 +8,7 @@ const DEFAULT_BASE_URL =
   (typeof process !== 'undefined'
     ? process.env.NEXT_PUBLIC_EDGE_STORE_BASE_URL
     : // @ts-expect-error - In Vite, the env variables are available on `import.meta`.
+      // eslint-disable-next-line turbo/no-undeclared-env-vars
       import.meta.env?.EDGE_STORE_BASE_URL) ?? 'https://files.edgestore.dev';
 
 type EdgeStoreContextValue<TRouter extends AnyRouter> = {

--- a/packages/react/src/contextProvider.tsx
+++ b/packages/react/src/contextProvider.tsx
@@ -8,7 +8,6 @@ const DEFAULT_BASE_URL =
   (typeof process !== 'undefined'
     ? process.env.NEXT_PUBLIC_EDGE_STORE_BASE_URL
     : // @ts-expect-error - In Vite, the env variables are available on `import.meta`.
-      // eslint-disable-next-line turbo/no-undeclared-env-vars
       import.meta.env?.EDGE_STORE_BASE_URL) ?? 'https://files.edgestore.dev';
 
 type EdgeStoreContextValue<TRouter extends AnyRouter> = {

--- a/packages/shared/src/errors/EdgeStoreError.ts
+++ b/packages/shared/src/errors/EdgeStoreError.ts
@@ -1,6 +1,5 @@
 import { type Simplify } from '../types';
 
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 export const EDGE_STORE_ERROR_CODES = {
   BAD_REQUEST: 400,
   FILE_TOO_LARGE: 400,


### PR DESCRIPTION
## What changed

- Replaced deprecated `next lint` package scripts with direct ESLint commands for Next 16 compatibility.
- Removed stale unused eslint-disable comments.
- Converted type-only imports and fixed focused lint issues in examples.
- Added a local Turbo env lint suppression for the Vite env fallback.

## Why

After resetting the working tree, lint failed on stale directives and Next 16 no longer supporting `next lint` as used by the package scripts. Direct ESLint commands restore the existing lint intent without broad formatting changes.

## Validation

- `pnpm lint`
- `pnpm exec tsc --noEmit -p packages/shared/tsconfig.json --skipLibCheck`
- `pnpm exec tsc --noEmit -p packages/react/tsconfig.json --skipLibCheck`
- `pnpm exec tsc --noEmit -p packages/server/tsconfig.json --skipLibCheck`
- `pnpm build`
