### PR TITLE
[codex] format code files

### DIFF
--- a/docs/src/app/(main)/pricing/_components/campaign-countdown.tsx
+++ b/docs/src/app/(main)/pricing/_components/campaign-countdown.tsx
@@ -16,7 +16,9 @@ export function CampaignCountdown(props: {
       setTimeLeft(getTimeDifference(new Date(), campaign.endDate));
     }, 1000);
 
-    return () => { clearInterval(intervalId); };
+    return () => {
+      clearInterval(intervalId);
+    };
   }, [campaign.endDate]);
 
   if (timeLeft.diff < 0) {
@@ -24,37 +26,37 @@ export function CampaignCountdown(props: {
   }
 
   return (
-    <div className="mx-auto w-full rounded-lg border bg-background p-8 sm:w-min sm:min-w-96">
+    <div className="bg-background mx-auto w-full rounded-lg border p-8 sm:w-min sm:min-w-96">
       <div className="space-y-4">
         <div className="text-center">
           <h2 className="text-xl font-bold sm:text-nowrap sm:text-3xl">
             {campaign.name} Ends Soon
           </h2>
-          <p className="text-sm text-muted-foreground sm:text-base">
+          <p className="text-muted-foreground text-sm sm:text-base">
             {campaign.description}
           </p>
         </div>
         <div className="mx-auto grid max-w-md grid-cols-4 gap-2 text-center sm:gap-4">
           <div className="space-y-1">
             <div
-              className="text-4xl font-bold text-primary sm:text-5xl"
+              className="text-primary text-4xl font-bold sm:text-5xl"
               suppressHydrationWarning
             >
               {timeLeft.days}
             </div>
-            <div className="text-sm text-muted-foreground sm:text-base">
+            <div className="text-muted-foreground text-sm sm:text-base">
               Days
             </div>
           </div>
           <div className="space-y-1">
             <div
-              className="text-4xl font-bold text-primary sm:text-5xl"
+              className="text-primary text-4xl font-bold sm:text-5xl"
               suppressHydrationWarning
             >
               {timeLeft.hours}
             </div>
             <div
-              className="text-sm text-muted-foreground sm:text-base"
+              className="text-muted-foreground text-sm sm:text-base"
               suppressHydrationWarning
             >
               Hours
@@ -62,23 +64,23 @@ export function CampaignCountdown(props: {
           </div>
           <div className="space-y-1">
             <div
-              className="text-4xl font-bold text-primary sm:text-5xl"
+              className="text-primary text-4xl font-bold sm:text-5xl"
               suppressHydrationWarning
             >
               {timeLeft.minutes}
             </div>
-            <div className="text-sm text-muted-foreground sm:text-base">
+            <div className="text-muted-foreground text-sm sm:text-base">
               Minutes
             </div>
           </div>
           <div className="space-y-1">
             <div
-              className="text-4xl font-bold text-primary sm:text-5xl"
+              className="text-primary text-4xl font-bold sm:text-5xl"
               suppressHydrationWarning
             >
               {timeLeft.seconds}
             </div>
-            <div className="text-sm text-muted-foreground sm:text-base">
+            <div className="text-muted-foreground text-sm sm:text-base">
               Seconds
             </div>
           </div>

--- a/docs/src/app/(main)/pricing/_components/pricing.tsx
+++ b/docs/src/app/(main)/pricing/_components/pricing.tsx
@@ -14,8 +14,8 @@ export async function Pricing() {
   return (
     <div className="px-4">
       <div className="mt-10 text-center">
-        <div className="mb-4 text-5xl font-medium text-foreground">Pricing</div>
-        <div className="mb-6 text-muted-foreground">
+        <div className="text-foreground mb-4 text-5xl font-medium">Pricing</div>
+        <div className="text-muted-foreground mb-6">
           {"Choose the plan that's right for you."}
         </div>
       </div>
@@ -58,7 +58,7 @@ function PricingBlock(props: {
         className,
       )}
     >
-      <div className="text-xl font-bold text-primary">{title}</div>
+      <div className="text-primary text-xl font-bold">{title}</div>
       <div>{description}</div>
       <div className="mb-4 mt-4 flex items-baseline gap-1">
         {price === undefined ? (
@@ -75,7 +75,7 @@ function PricingBlock(props: {
           </>
         ) : price > 0 ? (
           <>
-            <div className="text-3xl font-bold text-primary">${price}</div>
+            <div className="text-primary text-3xl font-bold">${price}</div>
             <div className="text-muted-foreground">/month</div>
           </>
         ) : (
@@ -87,7 +87,7 @@ function PricingBlock(props: {
       <div className="flex flex-col gap-2">
         {features.map((feature, i) => (
           <div key={i} className="flex items-center gap-2">
-            <CheckCircleIcon size={22} className="shrink-0 text-primary" />
+            <CheckCircleIcon size={22} className="text-primary shrink-0" />
             <div>{feature}</div>
           </div>
         ))}
@@ -128,11 +128,11 @@ function Strikethrough(props: {
 }) {
   const { children, size = 'sm' } = props;
   return (
-    <div className="relative inline-block text-nowrap text-muted-foreground">
+    <div className="text-muted-foreground relative inline-block text-nowrap">
       <div className="h-full w-full">
         <div
           className={cn(
-            'absolute bottom-[40%] left-0 right-0 -rotate-[10deg] border-primary/80',
+            'border-primary/80 absolute bottom-[40%] left-0 right-0 -rotate-[10deg]',
             size === 'sm' && 'border-t-2',
             size === 'lg' && 'border-t-4',
           )}
@@ -369,7 +369,7 @@ function PlanLimitItem(props: {
         <Strikethrough size="sm">
           <>{formatter?.(defaultValue) ?? defaultValue}</>
         </Strikethrough>{' '}
-        <span className="text-nowrap font-bold text-primary">
+        <span className="text-primary text-nowrap font-bold">
           {formatter?.(campaignValue) ?? campaignValue}
         </span>
       </>

--- a/docs/src/components/action-button.tsx
+++ b/docs/src/components/action-button.tsx
@@ -25,14 +25,14 @@ export function ActionButton({
       asChild
       size={size}
       className={cn(
-        'dark:text-shadow-[0_2px_4px_rgba(0,0,0,0.5)] group relative inline-flex items-center justify-center overflow-hidden bg-gradient-to-r from-primary to-primary/80 text-white shadow-lg transition-all duration-300 hover:shadow-[0_0_30px_rgba(170,153,255,0.4)]',
+        'dark:text-shadow-[0_2px_4px_rgba(0,0,0,0.5)] from-primary to-primary/80 group relative inline-flex items-center justify-center overflow-hidden bg-gradient-to-r text-white shadow-lg transition-all duration-300 hover:shadow-[0_0_30px_rgba(170,153,255,0.4)]',
         className,
       )}
       {...props}
     >
       <LinkComp {...linkProps}>
         {/* Animated background gradient */}
-        <div className="absolute inset-0 bg-gradient-to-r from-primary to-primary/80 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+        <div className="from-primary to-primary/80 absolute inset-0 bg-gradient-to-r opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
 
         {/* Shimmer effect */}
         <div className="absolute inset-0 -translate-x-full skew-x-12 bg-gradient-to-r from-transparent via-white/20 to-transparent transition-transform duration-700 group-hover:translate-x-full" />

--- a/docs/src/components/demo-block.tsx
+++ b/docs/src/components/demo-block.tsx
@@ -22,14 +22,14 @@ export function DemoBlock({
 }: DemoBlockProps) {
   return (
     <div className="not-prose flex items-center justify-center pb-4">
-      <div className="flex w-full max-w-lg flex-col items-center rounded-lg border border-solid border-border bg-background px-4 pb-8 pt-2">
+      <div className="border-border bg-background flex w-full max-w-lg flex-col items-center rounded-lg border border-solid px-4 pb-8 pt-2">
         <div className="flex w-full items-center gap-2">
           {externalLink && (
             <Button
               asChild
               variant="outline"
               size="sm"
-              className="flex items-center gap-2 text-foreground"
+              className="text-foreground flex items-center gap-2"
             >
               <a href={externalLink} target="_blank" rel="noreferrer">
                 <span>See it in action</span>
@@ -43,7 +43,7 @@ export function DemoBlock({
               asChild
               variant="outline"
               size="sm"
-              className="flex items-center gap-1 text-foreground no-underline"
+              className="text-foreground flex items-center gap-1 no-underline"
             >
               <a
                 href={`https://v0.dev/chat/api/open?title=${v0Config.title}&prompt=${v0Config.description}&url=${v0Config.registryUrl}`}

--- a/docs/src/components/ui/open-tabs.tsx
+++ b/docs/src/components/ui/open-tabs.tsx
@@ -13,7 +13,7 @@ const OpenTabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-9 w-full items-center justify-start rounded-none border-b bg-transparent p-0 text-muted-foreground',
+      'text-muted-foreground inline-flex h-9 w-full items-center justify-start rounded-none border-b bg-transparent p-0',
       className,
     )}
     {...props}
@@ -28,7 +28,7 @@ const OpenTabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'relative inline-flex h-9 cursor-pointer items-center justify-center whitespace-nowrap rounded-none border-b-2 border-b-transparent bg-transparent px-4 py-1 pb-3 pt-2 text-sm font-semibold text-muted-foreground shadow-none ring-offset-background transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-b-primary data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-none',
+      'text-muted-foreground ring-offset-background focus-visible:ring-ring data-[state=active]:border-b-primary data-[state=active]:bg-background data-[state=active]:text-foreground relative inline-flex h-9 cursor-pointer items-center justify-center whitespace-nowrap rounded-none border-b-2 border-b-transparent bg-transparent px-4 py-1 pb-3 pt-2 text-sm font-semibold shadow-none transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-none',
       className,
     )}
     {...props}
@@ -43,7 +43,7 @@ const OpenTabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'relative mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 [&_h3.font-heading]:text-base [&_h3.font-heading]:font-semibold',
+      'ring-offset-background focus-visible:ring-ring relative mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 [&_h3.font-heading]:text-base [&_h3.font-heading]:font-semibold',
       className,
     )}
     {...props}

--- a/docs/src/components/upload/dropzone.tsx
+++ b/docs/src/components/upload/dropzone.tsx
@@ -149,7 +149,7 @@ const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
           })}
         >
           <input ref={ref} {...getInputProps()} {...props} />
-          <div className="flex flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+          <div className="text-muted-foreground flex flex-col items-center justify-center gap-2 text-center">
             <UploadCloudIcon className="h-10 w-10" />
             <div className="text-sm font-medium">
               {isDragActive ? dropMessageActive : dropMessageDefault}
@@ -166,7 +166,7 @@ const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
 
         {/* Error Text */}
         {error && (
-          <div className="mt-1 flex items-center text-xs text-destructive">
+          <div className="text-destructive mt-1 flex items-center text-xs">
             <AlertCircleIcon className="mr-1 h-4 w-4" />
             <span>{error}</span>
           </div>

--- a/docs/src/components/upload/multi-file.tsx
+++ b/docs/src/components/upload/multi-file.tsx
@@ -41,24 +41,24 @@ const FileList = React.forwardRef<
         return (
           <div
             key={key}
-            className="shadow-xs flex flex-col justify-center rounded border border-border px-4 py-3"
+            className="shadow-xs border-border flex flex-col justify-center rounded border px-4 py-3"
           >
-            <div className="flex items-center gap-3 text-foreground">
-              <FileIcon className="h-8 w-8 shrink-0 text-muted-foreground" />
+            <div className="text-foreground flex items-center gap-3">
+              <FileIcon className="text-muted-foreground h-8 w-8 shrink-0" />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center justify-between text-xs">
                   <div className="truncate text-sm">
                     <div className="overflow-hidden text-ellipsis whitespace-nowrap font-medium">
                       {file.name}
                     </div>
-                    <div className="text-xs text-muted-foreground">
+                    <div className="text-muted-foreground text-xs">
                       {formatFileSize(file.size)}
                     </div>
                   </div>
 
                   <div className="ml-2 flex items-center gap-2">
                     {status === 'ERROR' && (
-                      <div className="flex items-center text-xs text-destructive">
+                      <div className="text-destructive flex items-center text-xs">
                         <AlertCircleIcon className="mr-1 h-4 w-4" />
                       </div>
                     )}
@@ -68,13 +68,13 @@ const FileList = React.forwardRef<
                         {abortController && (
                           <button
                             type="button"
-                            className="rounded-md p-0.5 transition-colors duration-200 hover:bg-secondary"
+                            className="hover:bg-secondary rounded-md p-0.5 transition-colors duration-200"
                             disabled={progress === 100}
                             onClick={() => {
                               cancelUpload(key);
                             }}
                           >
-                            <XIcon className="block h-4 w-4 shrink-0 text-muted-foreground" />
+                            <XIcon className="text-muted-foreground block h-4 w-4 shrink-0" />
                           </button>
                         )}
                         <div>{Math.round(progress)}%</div>
@@ -84,7 +84,7 @@ const FileList = React.forwardRef<
                     {status !== 'UPLOADING' && status !== 'COMPLETE' && (
                       <button
                         type="button"
-                        className="rounded-md p-1 text-muted-foreground transition-colors duration-200 hover:bg-secondary hover:text-destructive"
+                        className="text-muted-foreground hover:bg-secondary hover:text-destructive rounded-md p-1 transition-colors duration-200"
                         onClick={() => {
                           removeFile(key);
                         }}
@@ -95,7 +95,7 @@ const FileList = React.forwardRef<
                     )}
 
                     {status === 'COMPLETE' && (
-                      <CheckCircleIcon className="h-5 w-5 shrink-0 text-primary" />
+                      <CheckCircleIcon className="text-primary h-5 w-5 shrink-0" />
                     )}
                   </div>
                 </div>

--- a/docs/src/components/upload/multi-image.tsx
+++ b/docs/src/components/upload/multi-image.tsx
@@ -68,7 +68,7 @@ const ImageList = React.forwardRef<HTMLDivElement, ImageListProps>(
             <div
               key={fileState.key}
               className={
-                'relative aspect-square h-full w-full rounded-md border-0 bg-muted p-0 shadow-md'
+                'bg-muted relative aspect-square h-full w-full rounded-md border-0 p-0 shadow-md'
               }
             >
               {displayUrl ? (
@@ -78,8 +78,8 @@ const ImageList = React.forwardRef<HTMLDivElement, ImageListProps>(
                   alt={fileState.file.name}
                 />
               ) : (
-                <div className="flex h-full w-full items-center justify-center bg-secondary">
-                  <span className="text-xs text-muted-foreground">
+                <div className="bg-secondary flex h-full w-full items-center justify-center">
+                  <span className="text-muted-foreground text-xs">
                     No Preview
                   </span>
                 </div>
@@ -96,7 +96,7 @@ const ImageList = React.forwardRef<HTMLDivElement, ImageListProps>(
               {displayUrl && !initialDisabled && (
                 <button
                   type="button"
-                  className="group pointer-events-auto absolute right-1 top-1 z-10 -translate-y-1/4 translate-x-1/4 transform rounded-full border border-muted-foreground bg-background p-1 shadow-md transition-all hover:scale-110"
+                  className="border-muted-foreground bg-background group pointer-events-auto absolute right-1 top-1 z-10 -translate-y-1/4 translate-x-1/4 transform rounded-full border p-1 shadow-md transition-all hover:scale-110"
                   onClick={(e) => {
                     e.stopPropagation();
                     if (fileState.status === 'UPLOADING') {
@@ -107,9 +107,9 @@ const ImageList = React.forwardRef<HTMLDivElement, ImageListProps>(
                   }}
                 >
                   {fileState.status === 'UPLOADING' ? (
-                    <XIcon className="block h-4 w-4 text-muted-foreground" />
+                    <XIcon className="text-muted-foreground block h-4 w-4" />
                   ) : (
-                    <Trash2Icon className="block h-4 w-4 text-muted-foreground" />
+                    <Trash2Icon className="text-muted-foreground block h-4 w-4" />
                   )}
                 </button>
               )}

--- a/docs/src/components/upload/progress-bar.tsx
+++ b/docs/src/components/upload/progress-bar.tsx
@@ -27,9 +27,9 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   ({ progress, className, ...props }, ref) => {
     return (
       <div ref={ref} className={cn('relative h-0', className)} {...props}>
-        <div className="absolute top-1 h-1 w-full overflow-clip rounded-full bg-muted">
+        <div className="bg-muted absolute top-1 h-1 w-full overflow-clip rounded-full">
           <div
-            className="h-full bg-primary transition-all duration-300 ease-in-out"
+            className="bg-primary h-full transition-all duration-300 ease-in-out"
             style={{ width: `${progress}%` }}
           />
         </div>

--- a/docs/src/components/upload/single-image.tsx
+++ b/docs/src/components/upload/single-image.tsx
@@ -185,7 +185,7 @@ const SingleImageDropzone = React.forwardRef<
           // Placeholder content shown when no image is selected
           <div
             className={cn(
-              'flex flex-col items-center justify-center gap-2 text-center text-xs text-muted-foreground',
+              'text-muted-foreground flex flex-col items-center justify-center gap-2 text-center text-xs',
               isDisabled && 'opacity-50',
             )}
           >
@@ -213,7 +213,7 @@ const SingleImageDropzone = React.forwardRef<
           fileState.status !== 'COMPLETE' && (
             <button
               type="button"
-              className="group pointer-events-auto absolute right-1 top-1 z-10 transform rounded-full border border-muted-foreground bg-background p-1 shadow-md transition-all hover:scale-110"
+              className="border-muted-foreground bg-background group pointer-events-auto absolute right-1 top-1 z-10 transform rounded-full border p-1 shadow-md transition-all hover:scale-110"
               onClick={(e) => {
                 e.stopPropagation(); // Prevent triggering dropzone click
                 if (fileState.status === 'UPLOADING') {
@@ -225,9 +225,9 @@ const SingleImageDropzone = React.forwardRef<
               }}
             >
               {fileState.status === 'UPLOADING' ? (
-                <XIcon className="block h-4 w-4 text-muted-foreground" />
+                <XIcon className="text-muted-foreground block h-4 w-4" />
               ) : (
-                <Trash2Icon className="block h-4 w-4 text-muted-foreground" />
+                <Trash2Icon className="text-muted-foreground block h-4 w-4" />
               )}
             </button>
           )}
@@ -235,7 +235,7 @@ const SingleImageDropzone = React.forwardRef<
 
       {/* Error message display */}
       {errorMessage && (
-        <div className="mt-2 flex items-center text-xs text-destructive">
+        <div className="text-destructive mt-2 flex items-center text-xs">
           <AlertCircleIcon className="mr-1 h-4 w-4" />
           <span>{errorMessage}</span>
         </div>

--- a/docs/src/hooks/use-mock-progress.ts
+++ b/docs/src/hooks/use-mock-progress.ts
@@ -13,7 +13,9 @@ export function useMockProgress() {
       }, 1000);
       // Cleanup function for this effect run: clear the timeout if the component
       // unmounts or if 'progress' changes before the timeout fires.
-      return () => { clearTimeout(timerId); };
+      return () => {
+        clearTimeout(timerId);
+      };
     } else {
       // If progress is less than 100, set an interval to increment it.
       const intervalId = setInterval(() => {
@@ -27,7 +29,9 @@ export function useMockProgress() {
       }, 300);
       // Cleanup function for this effect run: clear the interval if the component
       // unmounts or if 'progress' changes (e.g., hits 100).
-      return () => { clearInterval(intervalId); };
+      return () => {
+        clearInterval(intervalId);
+      };
     }
   }, [progress]); // Re-run this effect whenever 'progress' changes.
 

--- a/examples/basic-access-control/next.config.js
+++ b/examples/basic-access-control/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/examples/basic-access-control/src/app/globals.css
+++ b/examples/basic-access-control/src/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
+  --font-mono:
+    ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
     'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
     'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
 

--- a/examples/basic-access-control/src/app/page.module.css
+++ b/examples/basic-access-control/src/app/page.module.css
@@ -51,7 +51,9 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition: background 200ms, border 200ms;
+  transition:
+    background 200ms,
+    border 200ms;
 }
 
 .card span {

--- a/examples/components/src/app/(tabs)/multi-file-instant/page.tsx
+++ b/examples/components/src/app/(tabs)/multi-file-instant/page.tsx
@@ -96,7 +96,7 @@ function MultiFileInstantDetails() {
   return (
     <div className="flex flex-col">
       <h3 className="mt-4 text-base font-bold">See in GitHub</h3>
-      <ul className="text-sm text-foreground/80">
+      <ul className="text-foreground/80 text-sm">
         <li>
           <a
             href="https://github.com/edgestorejs/edgestore/blob/main/examples/components/src/app/(tabs)/multi-file-instant/page.tsx"
@@ -119,7 +119,7 @@ function MultiFileInstantDetails() {
         </li>
       </ul>
       <h3 className="mt-4 text-base font-bold">About</h3>
-      <div className="flex flex-col gap-2 text-sm text-foreground/80">
+      <div className="text-foreground/80 flex flex-col gap-2 text-sm">
         <p>
           This component is a dropzone to upload multiple files. It is
           configured with a max file size of 1 MB and a max number of files of

--- a/examples/components/src/app/(tabs)/multi-file/page.tsx
+++ b/examples/components/src/app/(tabs)/multi-file/page.tsx
@@ -114,7 +114,7 @@ function MultiFileDetails() {
   return (
     <div className="flex flex-col">
       <h3 className="mt-4 text-base font-bold">See in GitHub</h3>
-      <ul className="text-sm text-foreground/80">
+      <ul className="text-foreground/80 text-sm">
         <li>
           <a
             href="https://github.com/edgestorejs/edgestore/blob/main/examples/components/src/app/(tabs)/multi-file/page.tsx"
@@ -137,7 +137,7 @@ function MultiFileDetails() {
         </li>
       </ul>
       <h3 className="mt-4 text-base font-bold">About</h3>
-      <div className="flex flex-col gap-2 text-sm text-foreground/80">
+      <div className="text-foreground/80 flex flex-col gap-2 text-sm">
         <p>
           This component is a dropzone to upload multiple files. It is
           configured with a max file size of 1 MB and a max number of files of

--- a/examples/components/src/app/(tabs)/single-image/page.tsx
+++ b/examples/components/src/app/(tabs)/single-image/page.tsx
@@ -71,7 +71,7 @@ function SingleImageDetails() {
   return (
     <div className="flex flex-col">
       <h3 className="mt-4 text-base font-bold">See in GitHub</h3>
-      <ul className="text-sm text-foreground/80">
+      <ul className="text-foreground/80 text-sm">
         <li>
           <a
             href="https://github.com/edgestorejs/edgestore/blob/main/examples/components/src/app/(tabs)/single-image/page.tsx"
@@ -94,14 +94,14 @@ function SingleImageDetails() {
         </li>
       </ul>
       <h3 className="mt-4 text-base font-bold">About</h3>
-      <div className="text-sm text-foreground/80">
+      <div className="text-foreground/80 text-sm">
         <p>
           This component is a dropzone to upload an image. It is configured with
           a max file size of 1 MB. And since it&apos;s using an EdgeStore image
           bucket, it will only accept images.
         </p>
       </div>
-      <table className="mt-2 inline-block text-xs text-foreground/80">
+      <table className="text-foreground/80 mt-2 inline-block text-xs">
         <tbody>
           <tr className="border">
             <td className="p-1">image/jpeg</td>

--- a/examples/components/src/components/ui/dropdown-menu.tsx
+++ b/examples/components/src/components/ui/dropdown-menu.tsx
@@ -26,7 +26,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'focus:bg-accent data-[state=open]:bg-accent flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden',
+      'focus:bg-accent data-[state=open]:bg-accent outline-hidden flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm',
       inset && 'pl-8',
       className,
     )}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50',
+      'focus:bg-accent focus:text-accent-foreground outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm transition-colors',
       inset && 'pl-8',
       className,
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50',
+      'focus:bg-accent focus:text-accent-foreground outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm transition-colors',
       className,
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50',
+      'focus:bg-accent focus:text-accent-foreground outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm transition-colors',
       className,
     )}
     {...props}

--- a/examples/components/src/components/ui/input.tsx
+++ b/examples/components/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'border-input placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50',
+          'border-input placeholder:text-muted-foreground focus-visible:ring-ring shadow-xs focus-visible:outline-hidden flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/examples/components/src/components/ui/popover.tsx
+++ b/examples/components/src/components/ui/popover.tsx
@@ -18,7 +18,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md outline-hidden',
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 outline-hidden z-50 w-72 rounded-md border p-4 shadow-md',
         className,
       )}
       {...props}

--- a/examples/components/src/components/ui/tabs.tsx
+++ b/examples/components/src/components/ui/tabs.tsx
@@ -52,7 +52,7 @@ const TabsTrigger = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'ring-offset-background focus-visible:ring-ring inline-flex w-full items-center justify-start whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm sm:w-auto sm:justify-center',
+      'ring-offset-background focus-visible:ring-ring focus-visible:outline-hidden inline-flex w-full items-center justify-start whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm sm:w-auto sm:justify-center',
       active && 'bg-background text-foreground',
       className,
     )}

--- a/examples/components/src/components/upload/dropzone.tsx
+++ b/examples/components/src/components/upload/dropzone.tsx
@@ -149,7 +149,7 @@ const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
           })}
         >
           <input ref={ref} {...getInputProps()} {...props} />
-          <div className="flex flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+          <div className="text-muted-foreground flex flex-col items-center justify-center gap-2 text-center">
             <UploadCloudIcon className="h-10 w-10" />
             <div className="text-sm font-medium">
               {isDragActive ? dropMessageActive : dropMessageDefault}
@@ -166,7 +166,7 @@ const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
 
         {/* Error Text */}
         {error && (
-          <div className="mt-1 flex items-center text-xs text-destructive">
+          <div className="text-destructive mt-1 flex items-center text-xs">
             <AlertCircleIcon className="mr-1 h-4 w-4" />
             <span>{error}</span>
           </div>

--- a/examples/components/src/components/upload/multi-file.tsx
+++ b/examples/components/src/components/upload/multi-file.tsx
@@ -41,24 +41,24 @@ const FileList = React.forwardRef<
         return (
           <div
             key={key}
-            className="shadow-xs flex flex-col justify-center rounded border border-border px-4 py-3"
+            className="shadow-xs border-border flex flex-col justify-center rounded border px-4 py-3"
           >
-            <div className="flex items-center gap-3 text-foreground">
-              <FileIcon className="h-8 w-8 shrink-0 text-muted-foreground" />
+            <div className="text-foreground flex items-center gap-3">
+              <FileIcon className="text-muted-foreground h-8 w-8 shrink-0" />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center justify-between text-xs">
                   <div className="truncate text-sm">
                     <div className="overflow-hidden text-ellipsis whitespace-nowrap font-medium">
                       {file.name}
                     </div>
-                    <div className="text-xs text-muted-foreground">
+                    <div className="text-muted-foreground text-xs">
                       {formatFileSize(file.size)}
                     </div>
                   </div>
 
                   <div className="ml-2 flex items-center gap-2">
                     {status === 'ERROR' && (
-                      <div className="flex items-center text-xs text-destructive">
+                      <div className="text-destructive flex items-center text-xs">
                         <AlertCircleIcon className="mr-1 h-4 w-4" />
                       </div>
                     )}
@@ -68,13 +68,13 @@ const FileList = React.forwardRef<
                         {abortController && (
                           <button
                             type="button"
-                            className="rounded-md p-0.5 transition-colors duration-200 hover:bg-secondary"
+                            className="hover:bg-secondary rounded-md p-0.5 transition-colors duration-200"
                             disabled={progress === 100}
                             onClick={() => {
                               cancelUpload(key);
                             }}
                           >
-                            <XIcon className="block h-4 w-4 shrink-0 text-muted-foreground" />
+                            <XIcon className="text-muted-foreground block h-4 w-4 shrink-0" />
                           </button>
                         )}
                         <div>{Math.round(progress)}%</div>
@@ -84,7 +84,7 @@ const FileList = React.forwardRef<
                     {status !== 'UPLOADING' && status !== 'COMPLETE' && (
                       <button
                         type="button"
-                        className="rounded-md p-1 text-muted-foreground transition-colors duration-200 hover:bg-secondary hover:text-destructive"
+                        className="text-muted-foreground hover:bg-secondary hover:text-destructive rounded-md p-1 transition-colors duration-200"
                         onClick={() => {
                           removeFile(key);
                         }}
@@ -95,7 +95,7 @@ const FileList = React.forwardRef<
                     )}
 
                     {status === 'COMPLETE' && (
-                      <CheckCircleIcon className="h-5 w-5 shrink-0 text-primary" />
+                      <CheckCircleIcon className="text-primary h-5 w-5 shrink-0" />
                     )}
                   </div>
                 </div>

--- a/examples/components/src/components/upload/multi-image.tsx
+++ b/examples/components/src/components/upload/multi-image.tsx
@@ -68,7 +68,7 @@ const ImageList = React.forwardRef<HTMLDivElement, ImageListProps>(
             <div
               key={fileState.key}
               className={
-                'relative aspect-square h-full w-full rounded-md border-0 bg-muted p-0 shadow-md'
+                'bg-muted relative aspect-square h-full w-full rounded-md border-0 p-0 shadow-md'
               }
             >
               {displayUrl ? (
@@ -78,8 +78,8 @@ const ImageList = React.forwardRef<HTMLDivElement, ImageListProps>(
                   alt={fileState.file.name}
                 />
               ) : (
-                <div className="flex h-full w-full items-center justify-center bg-secondary">
-                  <span className="text-xs text-muted-foreground">
+                <div className="bg-secondary flex h-full w-full items-center justify-center">
+                  <span className="text-muted-foreground text-xs">
                     No Preview
                   </span>
                 </div>
@@ -96,7 +96,7 @@ const ImageList = React.forwardRef<HTMLDivElement, ImageListProps>(
               {displayUrl && !initialDisabled && (
                 <button
                   type="button"
-                  className="group pointer-events-auto absolute right-1 top-1 z-10 -translate-y-1/4 translate-x-1/4 transform rounded-full border border-muted-foreground bg-background p-1 shadow-md transition-all hover:scale-110"
+                  className="border-muted-foreground bg-background group pointer-events-auto absolute right-1 top-1 z-10 -translate-y-1/4 translate-x-1/4 transform rounded-full border p-1 shadow-md transition-all hover:scale-110"
                   onClick={(e) => {
                     e.stopPropagation();
                     if (fileState.status === 'UPLOADING') {
@@ -107,9 +107,9 @@ const ImageList = React.forwardRef<HTMLDivElement, ImageListProps>(
                   }}
                 >
                   {fileState.status === 'UPLOADING' ? (
-                    <XIcon className="block h-4 w-4 text-muted-foreground" />
+                    <XIcon className="text-muted-foreground block h-4 w-4" />
                   ) : (
-                    <Trash2Icon className="block h-4 w-4 text-muted-foreground" />
+                    <Trash2Icon className="text-muted-foreground block h-4 w-4" />
                   )}
                 </button>
               )}

--- a/examples/components/src/components/upload/progress-bar.tsx
+++ b/examples/components/src/components/upload/progress-bar.tsx
@@ -27,9 +27,9 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   ({ progress, className, ...props }, ref) => {
     return (
       <div ref={ref} className={cn('relative h-0', className)} {...props}>
-        <div className="absolute top-1 h-1 w-full overflow-clip rounded-full bg-muted">
+        <div className="bg-muted absolute top-1 h-1 w-full overflow-clip rounded-full">
           <div
-            className="h-full bg-primary transition-all duration-300 ease-in-out"
+            className="bg-primary h-full transition-all duration-300 ease-in-out"
             style={{ width: `${progress}%` }}
           />
         </div>

--- a/examples/components/src/components/upload/single-image.tsx
+++ b/examples/components/src/components/upload/single-image.tsx
@@ -185,7 +185,7 @@ const SingleImageDropzone = React.forwardRef<
           // Placeholder content shown when no image is selected
           <div
             className={cn(
-              'flex flex-col items-center justify-center gap-2 text-center text-xs text-muted-foreground',
+              'text-muted-foreground flex flex-col items-center justify-center gap-2 text-center text-xs',
               isDisabled && 'opacity-50',
             )}
           >
@@ -213,7 +213,7 @@ const SingleImageDropzone = React.forwardRef<
           fileState.status !== 'COMPLETE' && (
             <button
               type="button"
-              className="group pointer-events-auto absolute right-1 top-1 z-10 transform rounded-full border border-muted-foreground bg-background p-1 shadow-md transition-all hover:scale-110"
+              className="border-muted-foreground bg-background group pointer-events-auto absolute right-1 top-1 z-10 transform rounded-full border p-1 shadow-md transition-all hover:scale-110"
               onClick={(e) => {
                 e.stopPropagation(); // Prevent triggering dropzone click
                 if (fileState.status === 'UPLOADING') {
@@ -225,9 +225,9 @@ const SingleImageDropzone = React.forwardRef<
               }}
             >
               {fileState.status === 'UPLOADING' ? (
-                <XIcon className="block h-4 w-4 text-muted-foreground" />
+                <XIcon className="text-muted-foreground block h-4 w-4" />
               ) : (
-                <Trash2Icon className="block h-4 w-4 text-muted-foreground" />
+                <Trash2Icon className="text-muted-foreground block h-4 w-4" />
               )}
             </button>
           )}
@@ -235,7 +235,7 @@ const SingleImageDropzone = React.forwardRef<
 
       {/* Error message display */}
       {errorMessage && (
-        <div className="mt-2 flex items-center text-xs text-destructive">
+        <div className="text-destructive mt-2 flex items-center text-xs">
           <AlertCircleIcon className="mr-1 h-4 w-4" />
           <span>{errorMessage}</span>
         </div>

--- a/examples/fastify-basic/src/index.ts
+++ b/examples/fastify-basic/src/index.ts
@@ -1,8 +1,8 @@
 import { initEdgeStore } from '@edgestore/server';
 import { createEdgeStoreFastifyHandler } from '@edgestore/server/adapters/fastify';
-import fastify from 'fastify';
 import fastifyCookie from '@fastify/cookie';
 import fastifyCors from '@fastify/cors';
+import fastify from 'fastify';
 
 // --- FASTIFY CONFIG ---
 
@@ -67,7 +67,7 @@ const start = async () => {
 };
 
 // Handle the promise properly
-start().catch(err => {
+start().catch((err) => {
   console.error('Failed to start server:', err);
   process.exit(1);
 });

--- a/examples/next-advanced/next.config.js
+++ b/examples/next-advanced/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/examples/next-advanced/src/app/globals.css
+++ b/examples/next-advanced/src/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
+  --font-mono:
+    ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
     'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
     'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
 

--- a/examples/next-advanced/src/app/page.module.css
+++ b/examples/next-advanced/src/app/page.module.css
@@ -51,7 +51,9 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition: background 200ms, border 200ms;
+  transition:
+    background 200ms,
+    border 200ms;
 }
 
 .card span {

--- a/examples/next-basic-aws/next.config.js
+++ b/examples/next-basic-aws/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/examples/next-basic-aws/src/app/globals.css
+++ b/examples/next-basic-aws/src/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
+  --font-mono:
+    ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
     'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
     'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
 

--- a/examples/next-basic-aws/src/app/page.module.css
+++ b/examples/next-basic-aws/src/app/page.module.css
@@ -51,7 +51,9 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition: background 200ms, border 200ms;
+  transition:
+    background 200ms,
+    border 200ms;
 }
 
 .card span {

--- a/examples/next-basic-with-intl/src/app/globals.css
+++ b/examples/next-basic-with-intl/src/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
+  --font-mono:
+    ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
     'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
     'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
 

--- a/examples/next-basic-with-intl/src/app/page.module.css
+++ b/examples/next-basic-with-intl/src/app/page.module.css
@@ -51,7 +51,9 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition: background 200ms, border 200ms;
+  transition:
+    background 200ms,
+    border 200ms;
 }
 
 .card span {

--- a/examples/next-basic/next.config.js
+++ b/examples/next-basic/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/examples/next-basic/src/app/globals.css
+++ b/examples/next-basic/src/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
+  --font-mono:
+    ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
     'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
     'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
 

--- a/examples/next-basic/src/app/page.module.css
+++ b/examples/next-basic/src/app/page.module.css
@@ -51,7 +51,9 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition: background 200ms, border 200ms;
+  transition:
+    background 200ms,
+    border 200ms;
 }
 
 .card span {

--- a/examples/next-complete/postcss.config.mjs
+++ b/examples/next-complete/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ['@tailwindcss/postcss'],
 };
 
 export default config;

--- a/examples/next-complete/src/components/ui/button.tsx
+++ b/examples/next-complete/src/components/ui/button.tsx
@@ -1,8 +1,7 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
-
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -10,30 +9,30 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -41,11 +40,11 @@ function Button({
   size,
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : 'button';
 
   return (
     <Comp
@@ -53,7 +52,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/examples/next-complete/src/components/upload/single-image.tsx
+++ b/examples/next-complete/src/components/upload/single-image.tsx
@@ -185,7 +185,7 @@ const SingleImageDropzone = React.forwardRef<
           // Placeholder content shown when no image is selected
           <div
             className={cn(
-              'flex flex-col items-center justify-center gap-2 text-center text-xs text-muted-foreground',
+              'text-muted-foreground flex flex-col items-center justify-center gap-2 text-center text-xs',
               isDisabled && 'opacity-50',
             )}
           >
@@ -213,7 +213,7 @@ const SingleImageDropzone = React.forwardRef<
           fileState.status !== 'COMPLETE' && (
             <button
               type="button"
-              className="group pointer-events-auto absolute right-1 top-1 z-10 transform rounded-full border border-muted-foreground bg-background p-1 shadow-md transition-all hover:scale-110"
+              className="border-muted-foreground bg-background group pointer-events-auto absolute right-1 top-1 z-10 transform rounded-full border p-1 shadow-md transition-all hover:scale-110"
               onClick={(e) => {
                 e.stopPropagation(); // Prevent triggering dropzone click
                 if (fileState.status === 'UPLOADING') {
@@ -225,9 +225,9 @@ const SingleImageDropzone = React.forwardRef<
               }}
             >
               {fileState.status === 'UPLOADING' ? (
-                <XIcon className="block h-4 w-4 text-muted-foreground" />
+                <XIcon className="text-muted-foreground block h-4 w-4" />
               ) : (
-                <Trash2Icon className="block h-4 w-4 text-muted-foreground" />
+                <Trash2Icon className="text-muted-foreground block h-4 w-4" />
               )}
             </button>
           )}
@@ -235,7 +235,7 @@ const SingleImageDropzone = React.forwardRef<
 
       {/* Error message display */}
       {errorMessage && (
-        <div className="mt-2 flex items-center text-xs text-destructive">
+        <div className="text-destructive mt-2 flex items-center text-xs">
           <AlertCircleIcon className="mr-1 h-4 w-4" />
           <span>{errorMessage}</span>
         </div>

--- a/examples/next-complete/src/lib/utils.ts
+++ b/examples/next-complete/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/examples/start-basic/app.config.ts
+++ b/examples/start-basic/app.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from '@tanstack/start/config'
-import tsConfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from '@tanstack/start/config';
+import tsConfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   vite: {
@@ -9,4 +9,4 @@ export default defineConfig({
       }),
     ],
   },
-})
+});

--- a/examples/start-basic/app/api.ts
+++ b/examples/start-basic/app/api.ts
@@ -1,6 +1,6 @@
 import {
   createStartAPIHandler,
   defaultAPIFileRouteHandler,
-} from '@tanstack/start/api'
+} from '@tanstack/start/api';
 
-export default createStartAPIHandler(defaultAPIFileRouteHandler)
+export default createStartAPIHandler(defaultAPIFileRouteHandler);

--- a/examples/start-basic/app/client.tsx
+++ b/examples/start-basic/app/client.tsx
@@ -1,8 +1,8 @@
 /// <reference types="vinxi/types/client" />
-import { hydrateRoot } from 'react-dom/client'
-import { StartClient } from '@tanstack/start'
-import { createRouter } from './router'
+import { StartClient } from '@tanstack/start';
+import { hydrateRoot } from 'react-dom/client';
+import { createRouter } from './router';
 
-const router = createRouter()
+const router = createRouter();
 
-hydrateRoot(document, <StartClient router={router} />)
+hydrateRoot(document, <StartClient router={router} />);

--- a/examples/start-basic/app/components/DefaultCatchBoundary.tsx
+++ b/examples/start-basic/app/components/DefaultCatchBoundary.tsx
@@ -4,44 +4,44 @@ import {
   rootRouteId,
   useMatch,
   useRouter,
-} from '@tanstack/react-router'
-import type { ErrorComponentProps } from '@tanstack/react-router'
+} from '@tanstack/react-router';
+import type { ErrorComponentProps } from '@tanstack/react-router';
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
-  const router = useRouter()
+  const router = useRouter();
   const isRoot = useMatch({
     strict: false,
     select: (state) => state.id === rootRouteId,
-  })
+  });
 
-  console.error('DefaultCatchBoundary Error:', error)
+  console.error('DefaultCatchBoundary Error:', error);
 
   return (
-    <div className="min-w-0 flex-1 p-4 flex flex-col items-center justify-center gap-6">
+    <div className="flex min-w-0 flex-1 flex-col items-center justify-center gap-6 p-4">
       <ErrorComponent error={error} />
-      <div className="flex gap-2 items-center flex-wrap">
+      <div className="flex flex-wrap items-center gap-2">
         <button
           onClick={() => {
-            void router.invalidate()
+            void router.invalidate();
           }}
-          className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
+          className={`rounded bg-gray-600 px-2 py-1 font-extrabold uppercase text-white dark:bg-gray-700`}
         >
           Try Again
         </button>
         {isRoot ? (
           <Link
             to="/"
-            className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
+            className={`rounded bg-gray-600 px-2 py-1 font-extrabold uppercase text-white dark:bg-gray-700`}
           >
             Home
           </Link>
         ) : (
           <Link
             to="/"
-            className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
+            className={`rounded bg-gray-600 px-2 py-1 font-extrabold uppercase text-white dark:bg-gray-700`}
             onClick={(e) => {
-              e.preventDefault()
-              window.history.back()
+              e.preventDefault();
+              window.history.back();
             }}
           >
             Go Back
@@ -49,5 +49,5 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/examples/start-basic/app/components/NotFound.tsx
+++ b/examples/start-basic/app/components/NotFound.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router';
 
 export function NotFound({ children }: { children?: any }) {
   return (
@@ -6,22 +6,22 @@ export function NotFound({ children }: { children?: any }) {
       <div className="text-gray-600 dark:text-gray-400">
         {children || <p>The page you are looking for does not exist.</p>}
       </div>
-      <p className="flex items-center gap-2 flex-wrap">
+      <p className="flex flex-wrap items-center gap-2">
         <button
           onClick={() => {
-            window.history.back()
+            window.history.back();
           }}
-          className="bg-emerald-500 text-white px-2 py-1 rounded uppercase font-black text-sm"
+          className="rounded bg-emerald-500 px-2 py-1 text-sm font-black uppercase text-white"
         >
           Go back
         </button>
         <Link
           to="/"
-          className="bg-cyan-600 text-white px-2 py-1 rounded uppercase font-black text-sm"
+          className="rounded bg-cyan-600 px-2 py-1 text-sm font-black uppercase text-white"
         >
           Start Over
         </Link>
       </p>
     </div>
-  )
+  );
 }

--- a/examples/start-basic/app/router.tsx
+++ b/examples/start-basic/app/router.tsx
@@ -1,7 +1,7 @@
-import { createRouter as createTanStackRouter } from '@tanstack/react-router'
-import { routeTree } from './routeTree.gen'
-import { DefaultCatchBoundary } from './components/DefaultCatchBoundary'
-import { NotFound } from './components/NotFound'
+import { createRouter as createTanStackRouter } from '@tanstack/react-router';
+import { DefaultCatchBoundary } from './components/DefaultCatchBoundary';
+import { NotFound } from './components/NotFound';
+import { routeTree } from './routeTree.gen';
 
 export function createRouter() {
   const router = createTanStackRouter({
@@ -10,13 +10,13 @@ export function createRouter() {
     defaultErrorComponent: DefaultCatchBoundary,
     defaultNotFoundComponent: () => <NotFound />,
     scrollRestoration: true,
-  })
+  });
 
-  return router
+  return router;
 }
 
 declare module '@tanstack/react-router' {
   interface Register {
-    router: ReturnType<typeof createRouter>
+    router: ReturnType<typeof createRouter>;
   }
 }

--- a/examples/start-basic/app/ssr.tsx
+++ b/examples/start-basic/app/ssr.tsx
@@ -1,13 +1,12 @@
 /// <reference types="vinxi/types/server" />
+import { getRouterManifest } from '@tanstack/start/router-manifest';
 import {
   createStartHandler,
   defaultStreamHandler,
-} from '@tanstack/start/server'
-import { getRouterManifest } from '@tanstack/start/router-manifest'
-
-import { createRouter } from './router'
+} from '@tanstack/start/server';
+import { createRouter } from './router';
 
 export default createStartHandler({
   createRouter,
   getRouterManifest,
-})(defaultStreamHandler)
+})(defaultStreamHandler);

--- a/examples/start-basic/app/styles/app.css
+++ b/examples/start-basic/app/styles/app.css
@@ -13,7 +13,7 @@
 
   html,
   body {
-    @apply text-gray-900 bg-gray-50 dark:bg-gray-950 dark:text-gray-200;
+    @apply bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-200;
   }
 
   .using-mouse * {

--- a/examples/start-basic/app/utils/loggingMiddleware.tsx
+++ b/examples/start-basic/app/utils/loggingMiddleware.tsx
@@ -1,8 +1,8 @@
-import { createMiddleware } from '@tanstack/start'
+import { createMiddleware } from '@tanstack/start';
 
 export const logMiddleware = createMiddleware()
   .client(async (ctx) => {
-    const clientTime = new Date()
+    const clientTime = new Date();
 
     return ctx.next({
       context: {
@@ -11,10 +11,10 @@ export const logMiddleware = createMiddleware()
       sendContext: {
         clientTime,
       },
-    })
+    });
   })
   .server(async (ctx) => {
-    const serverTime = new Date()
+    const serverTime = new Date();
 
     return ctx.next({
       sendContext: {
@@ -22,16 +22,16 @@ export const logMiddleware = createMiddleware()
         durationToServer:
           serverTime.getTime() - ctx.context.clientTime.getTime(),
       },
-    })
+    });
   })
   .clientAfter(async (ctx) => {
-    const now = new Date()
+    const now = new Date();
 
     console.log('Client Req/Res:', {
       duration: ctx.context.clientTime.getTime() - now.getTime(),
       durationToServer: ctx.context.durationToServer,
       durationFromServer: now.getTime() - ctx.context.serverTime.getTime(),
-    })
+    });
 
-    return ctx.next()
-  })
+    return ctx.next();
+  });

--- a/examples/start-basic/app/utils/posts.tsx
+++ b/examples/start-basic/app/utils/posts.tsx
@@ -1,36 +1,36 @@
-import { notFound } from '@tanstack/react-router'
-import { createServerFn } from '@tanstack/start'
-import axios from 'redaxios'
+import { notFound } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/start';
+import axios from 'redaxios';
 
 export type PostType = {
-  id: string
-  title: string
-  body: string
-}
+  id: string;
+  title: string;
+  body: string;
+};
 
 export const fetchPost = createServerFn({ method: 'GET' })
   .validator((d: string) => d)
   .handler(async ({ data }) => {
-    console.info(`Fetching post with id ${data}...`)
+    console.info(`Fetching post with id ${data}...`);
     const post = await axios
       .get<PostType>(`https://jsonplaceholder.typicode.com/posts/${data}`)
       .then((r) => r.data)
       .catch((err) => {
-        console.error(err)
+        console.error(err);
         if (err.status === 404) {
-          throw notFound()
+          throw notFound();
         }
-        throw err
-      })
+        throw err;
+      });
 
-    return post
-  })
+    return post;
+  });
 
 export const fetchPosts = createServerFn({ method: 'GET' }).handler(
   async () => {
-    console.info('Fetching posts...')
+    console.info('Fetching posts...');
     return axios
       .get<PostType[]>('https://jsonplaceholder.typicode.com/posts')
-      .then((r) => r.data.slice(0, 10))
+      .then((r) => r.data.slice(0, 10));
   },
-)
+);

--- a/examples/start-basic/app/utils/seo.ts
+++ b/examples/start-basic/app/utils/seo.ts
@@ -4,10 +4,10 @@ export const seo = ({
   keywords,
   image,
 }: {
-  title: string
-  description?: string
-  image?: string
-  keywords?: string
+  title: string;
+  description?: string;
+  image?: string;
+  keywords?: string;
 }) => {
   const tags = [
     { title },
@@ -27,7 +27,7 @@ export const seo = ({
           { name: 'og:image', content: image },
         ]
       : []),
-  ]
+  ];
 
-  return tags
-}
+  return tags;
+};

--- a/examples/start-basic/app/utils/users.tsx
+++ b/examples/start-basic/app/utils/users.tsx
@@ -1,7 +1,7 @@
 export type User = {
-  id: number
-  name: string
-  email: string
-}
+  id: number;
+  name: string;
+  email: string;
+};
 
-export const DEPLOY_URL = 'http://localhost:3000'
+export const DEPLOY_URL = 'http://localhost:3000';

--- a/examples/start-basic/postcss.config.mjs
+++ b/examples/start-basic/postcss.config.mjs
@@ -3,4 +3,4 @@ export default {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/examples/start-basic/tailwind.config.mjs
+++ b/examples/start-basic/tailwind.config.mjs
@@ -1,4 +1,4 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./app/**/*.{js,jsx,ts,tsx}'],
-}
+};

--- a/examples/vite-basic/vite.config.ts
+++ b/examples/vite-basic/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/packages/server/src/providers/aws/index.ts
+++ b/packages/server/src/providers/aws/index.ts
@@ -7,8 +7,8 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
-  type MaybePromise,
   type Provider as EdgeStoreProvider,
+  type MaybePromise,
   type RequestUploadParams,
 } from '@edgestore/shared';
 import { v4 as uuidv4 } from 'uuid';

--- a/packages/shared/src/errors/EdgeStoreError.ts
+++ b/packages/shared/src/errors/EdgeStoreError.ts
@@ -20,11 +20,11 @@ export type EdgeStoreErrorDetails<TCode extends EdgeStoreErrorCodeKey> =
         fileSize: number;
       }
     : TCode extends 'MIME_TYPE_NOT_ALLOWED'
-    ? {
-        allowedMimeTypes: string[];
-        mimeType: string;
-      }
-    : never;
+      ? {
+          allowedMimeTypes: string[];
+          mimeType: string;
+        }
+      : never;
 
 export type EdgeStoreJsonResponse = Simplify<
   | {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -21,8 +21,8 @@ export type FlatOverwrite<TType, TWith> = InferOptional<
     [TKey in keyof TType | keyof TWith]: TKey extends keyof TWith
       ? TWith[TKey]
       : TKey extends keyof TType
-      ? TType[TKey]
-      : never;
+        ? TType[TKey]
+        : never;
   },
   UndefinedKeys<TType> | UndefinedKeys<TWith>
 >;
@@ -49,9 +49,8 @@ export type Maybe<TType> = TType | null | undefined;
 /**
  * @internal
  */
-export type ThenArg<TType> = TType extends PromiseLike<infer U>
-  ? ThenArg<U>
-  : TType;
+export type ThenArg<TType> =
+  TType extends PromiseLike<infer U> ? ThenArg<U> : TType;
 
 /**
  * @internal


### PR DESCRIPTION
## What changed

- Applied Prettier to code files only: `**/*.{js,jsx,ts,tsx,css,mjs,cjs}`.
- Excluded generated files from the formatting diff via the new config branch.
- Left JSON, Markdown, and MDX content unformatted.

## Why

This stacks on top of the lint/type fixes and configuration PR so functional changes, configuration, and mechanical code formatting can be reviewed separately.

## Validation

- `pnpm format --check`
- `pnpm lint`
- `pnpm exec tsc --noEmit -p packages/shared/tsconfig.json`
- `pnpm exec tsc --noEmit -p packages/react/tsconfig.json`
- `pnpm exec tsc --noEmit -p packages/server/tsconfig.json`
- `pnpm build`