### PR TITLE
[codex] add PR CI workflow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 /** @type {import("eslint").Linter.Config} */
 const config = {
   root: true,
-  ignorePatterns: ['**/*.gen.ts', '**/*.gen.tsx'],
+  ignorePatterns: ['docs/.source/**', '**/*.gen.ts', '**/*.gen.tsx'],
   parser: '@typescript-eslint/parser',
   plugins: ['no-only-tests', 'unicorn', 'turbo'],
   extends: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CI: true
+  NEXT_TELEMETRY_DISABLED: 1
+  SKIP_ENV_VALIDATION: true
+  TURBO_TELEMETRY_DISABLED: 1
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting
+        run: pnpm format --check
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck shared package
+        run: pnpm exec tsc --noEmit -p packages/shared/tsconfig.json
+
+      - name: Typecheck react package
+        run: pnpm exec tsc --noEmit -p packages/react/tsconfig.json
+
+      - name: Typecheck server package
+        run: pnpm exec tsc --noEmit -p packages/server/tsconfig.json
+
+      - name: Build packages
+        run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -49,14 +49,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Typecheck shared package
-        run: pnpm exec tsc --noEmit -p packages/shared/tsconfig.json
-
-      - name: Typecheck react package
-        run: pnpm exec tsc --noEmit -p packages/react/tsconfig.json
-
-      - name: Typecheck server package
-        run: pnpm exec tsc --noEmit -p packages/server/tsconfig.json
+      - name: Typecheck packages
+        run: pnpm typecheck
 
       - name: Build packages
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.26.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ yarn-error.log*
 # turbo
 .turbo
 
+# generated docs
+docs/.source/
+
 # build
 dist
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 __generated__/
+docs/.source/
 **/*.gen.ts
 **/*.gen.tsx
 .docusaurus/

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "docs:dev": "pnpm --filter docs dev",
     "docs:build": "pnpm build && pnpm --filter docs run build",
     "lint": "turbo lint",
+    "typecheck": "turbo run typecheck --filter=@edgestore/*",
     "lint-fix": "turbo lint -- --fix && manypkg fix && pnpm format:write",
     "format": "prettier \"**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts,css}\"",
     "format:write": "pnpm format --write --list-different",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config rollup.config.ts --configPlugin rollup-plugin-swc3",
     "dev": "pnpm build --watch",
     "codegen:entrypoints": "tsx entrypoints.script.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
   "exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config rollup.config.ts --configPlugin rollup-plugin-swc3",
     "dev": "pnpm build --watch",
     "codegen:entrypoints": "tsx entrypoints.script.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config rollup.config.ts --configPlugin rollup-plugin-swc3",
     "dev": "pnpm build --watch",
     "codegen:entrypoints": "tsx entrypoints.script.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
   "exports": {

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,11 @@
       "outputs": [],
       "cache": true
     },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "cache": true
+    },
     "watch": {},
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary
- Adds a PR CI workflow for the lint/type/config/formatting stack.
- Runs on pull requests, pushes to main, and manual dispatch.
- Uses Node.js 24, pnpm from packageManager, pnpm lockfile caching, and frozen installs.
- Checks code formatting, lint, package type checks, and package builds.
- Ignores generated Fumadocs output under docs/.source for Git, Prettier, and ESLint so CI does not fail on postinstall artifacts.

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"\n- pnpm --filter docs postinstall && pnpm format --check\n- pnpm lint\n