### PR TITLE
[codex] tighten public type contracts

### DIFF
--- a/packages/react/src/createNextProxy.ts
+++ b/packages/react/src/createNextProxy.ts
@@ -1,6 +1,8 @@
 import {
+  type AnyBuilder,
   type AnyRouter,
   type InferBucketPathObject,
+  type InferBucketPathOrder,
   type InferMetadataObject,
   type SharedRequestUploadRes,
   type UploadOptions,
@@ -10,14 +12,25 @@ import EdgeStoreClientError from './libs/errors/EdgeStoreClientError';
 import { handleError } from './libs/errors/handleError';
 import { UploadAbortedError } from './libs/errors/uploadAbortedError';
 
-/**
- * @internal
- * @see https://www.totaltypescript.com/concepts/the-prettify-helper
- */
-export type Prettify<TType> = {
-  [K in keyof TType]: TType[K];
-  // eslint-disable-next-line @typescript-eslint/ban-types
-} & {};
+type UploadResponse<TBucket extends AnyBuilder> =
+  TBucket['_def']['type'] extends 'IMAGE'
+    ? {
+        url: string;
+        thumbnailUrl: string | null;
+        size: number;
+        uploadedAt: Date;
+        metadata: InferMetadataObject<TBucket>;
+        path: InferBucketPathObject<TBucket>;
+        pathOrder: InferBucketPathOrder<TBucket>;
+      }
+    : {
+        url: string;
+        size: number;
+        uploadedAt: Date;
+        metadata: InferMetadataObject<TBucket>;
+        path: InferBucketPathObject<TBucket>;
+        pathOrder: InferBucketPathOrder<TBucket>;
+      };
 
 export type BucketFunctions<TRouter extends AnyRouter> = {
   [K in keyof TRouter['buckets']]: {
@@ -52,30 +65,7 @@ export type BucketFunctions<TRouter extends AnyRouter> = {
             onProgressChange?: OnProgressChangeHandler;
             options?: UploadOptions;
           },
-    ) => Promise<
-      TRouter['buckets'][K]['_def']['type'] extends 'IMAGE'
-        ? {
-            url: string;
-            thumbnailUrl: string | null;
-            size: number;
-            uploadedAt: Date;
-            metadata: InferMetadataObject<TRouter['buckets'][K]>;
-            path: InferBucketPathObject<TRouter['buckets'][K]>;
-            pathOrder: Prettify<
-              keyof InferBucketPathObject<TRouter['buckets'][K]>
-            >[];
-          }
-        : {
-            url: string;
-            size: number;
-            uploadedAt: Date;
-            metadata: InferMetadataObject<TRouter['buckets'][K]>;
-            path: InferBucketPathObject<TRouter['buckets'][K]>;
-            pathOrder: Prettify<
-              keyof InferBucketPathObject<TRouter['buckets'][K]>
-            >[];
-          }
-    >;
+    ) => Promise<UploadResponse<TRouter['buckets'][K]>>;
     confirmUpload: (params: { url: string }) => Promise<void>;
     delete: (params: { url: string }) => Promise<void>;
   };

--- a/packages/server/src/core/client/index.ts
+++ b/packages/server/src/core/client/index.ts
@@ -137,14 +137,18 @@ export type UploadFileRes<TBucket extends AnyBuilder> =
         size: number;
         metadata: InferMetadataObject<TBucket>;
         path: InferBucketPathObject<TBucket>;
-        pathOrder: (keyof InferBucketPathObject<TBucket>)[];
+        pathOrder: InferBucketPathKeys<TBucket> extends never
+          ? []
+          : InferBucketPathKeys<TBucket>[];
       }
     : {
         url: string;
         size: number;
         metadata: InferMetadataObject<TBucket>;
         path: InferBucketPathObject<TBucket>;
-        pathOrder: (keyof InferBucketPathObject<TBucket>)[];
+        pathOrder: InferBucketPathKeys<TBucket> extends never
+          ? []
+          : InferBucketPathKeys<TBucket>[];
       };
 
 type Filter<TBucket extends AnyBuilder> = {

--- a/packages/server/src/core/client/index.ts
+++ b/packages/server/src/core/client/index.ts
@@ -4,6 +4,7 @@ import {
   type AnyRouter,
   type InferBucketPathKeys,
   type InferBucketPathObject,
+  type InferBucketPathOrder,
   type InferMetadataObject,
   type MaybePromise,
   type Prettify,
@@ -137,18 +138,14 @@ export type UploadFileRes<TBucket extends AnyBuilder> =
         size: number;
         metadata: InferMetadataObject<TBucket>;
         path: InferBucketPathObject<TBucket>;
-        pathOrder: InferBucketPathKeys<TBucket> extends never
-          ? []
-          : InferBucketPathKeys<TBucket>[];
+        pathOrder: InferBucketPathOrder<TBucket>;
       }
     : {
         url: string;
         size: number;
         metadata: InferMetadataObject<TBucket>;
         path: InferBucketPathObject<TBucket>;
-        pathOrder: InferBucketPathKeys<TBucket> extends never
-          ? []
-          : InferBucketPathKeys<TBucket>[];
+        pathOrder: InferBucketPathOrder<TBucket>;
       };
 
 type Filter<TBucket extends AnyBuilder> = {

--- a/packages/shared/src/internals/bucketBuilder.test.ts
+++ b/packages/shared/src/internals/bucketBuilder.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { EdgeStoreError } from '../errors';
+import { initEdgeStore } from './bucketBuilder';
+
+describe('bucketBuilder path validation', () => {
+  it('rejects path params with multiple keys', () => {
+    const es = initEdgeStore
+      .context<{ author: string; type: string; userId: string }>()
+      .create();
+
+    expect(() =>
+      es.fileBucket().path(({ ctx }) => [
+        {
+          author: ctx.author,
+          type: ctx.type,
+        },
+      ]),
+    ).toThrow(EdgeStoreError);
+  });
+
+  it('rejects duplicate path param keys', () => {
+    const es = initEdgeStore
+      .context<{ author: string; type: string; userId: string }>()
+      .create();
+
+    expect(() =>
+      es
+        .fileBucket()
+        .path(({ ctx }) => [{ author: ctx.author }, { author: ctx.userId }]),
+    ).toThrow(EdgeStoreError);
+  });
+});

--- a/packages/shared/src/internals/bucketBuilder.test.ts
+++ b/packages/shared/src/internals/bucketBuilder.test.ts
@@ -15,7 +15,7 @@ describe('bucketBuilder path validation', () => {
           type: ctx.type,
         },
       ]),
-    ).toThrow(EdgeStoreError);
+    ).toThrow(/Found keys: author, type/);
   });
 
   it('rejects duplicate path param keys', () => {

--- a/packages/shared/src/internals/bucketBuilder.ts
+++ b/packages/shared/src/internals/bucketBuilder.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { EdgeStoreError } from '../errors';
 import { type KeysOfUnion, type MaybePromise, type Simplify } from '../types';
 import { createPathParamProxy } from './createPathParamProxy';
 
@@ -53,7 +54,20 @@ type InferMetadataObjectFromDef<TDef extends AnyDef> =
     ? Awaited<ReturnType<TDef['metadata']>>
     : Record<string, never>;
 
-export type AnyContext = Record<string, string | undefined | null>;
+export type AnyContextValue =
+  | string
+  | number
+  | boolean
+  | undefined
+  | null
+  | AnyContext
+  | AnyContextValueArray;
+
+interface AnyContextValueArray extends Array<AnyContextValue> {}
+
+export interface AnyContext {
+  [key: string]: AnyContextValue;
+}
 
 export type AnyInput = z.AnyZodObject | z.ZodNever;
 
@@ -355,11 +369,30 @@ function createBuilder<
       }) as any;
     },
     path(pathResolver) {
-      // TODO: Should throw a runtime error in the following cases:
-      // 1. in case of multiple keys in one object
-      // 2. in case of duplicate keys
       const pathParamProxy = createPathParamProxy();
       const params = pathResolver(pathParamProxy);
+      const pathKeys = new Set<string>();
+      for (const param of params) {
+        const entries = Object.entries(param);
+        if (entries.length !== 1) {
+          throw new EdgeStoreError({
+            message: `Path params must have exactly one key. Found: ${JSON.stringify(
+              param,
+            )}`,
+            code: 'SERVER_ERROR',
+          });
+        }
+        const key = entries[0]?.[0];
+        if (key !== undefined && pathKeys.has(key)) {
+          throw new EdgeStoreError({
+            message: `Duplicate path param found: ${key}`,
+            code: 'SERVER_ERROR',
+          });
+        }
+        if (key !== undefined) {
+          pathKeys.add(key);
+        }
+      }
       return createNewBuilder(_def, {
         path: params,
       }) as any;
@@ -397,7 +430,13 @@ class EdgeStoreBuilder<TCtx = Record<string, never>> {
   }
 }
 
-export type EdgeStoreRouter<TCtx> = {
+export type EdgeStoreRouter<
+  TCtx,
+  TBuckets extends Record<string, Builder<TCtx, AnyDef>> = Record<
+    string,
+    Builder<TCtx, AnyDef>
+  >,
+> = {
   /**
    * Only used for types
    * @internal
@@ -405,10 +444,10 @@ export type EdgeStoreRouter<TCtx> = {
   $config: {
     ctx: TCtx;
   };
-  buckets: Record<string, Builder<TCtx, AnyDef>>;
+  buckets: TBuckets;
 };
 
-export type AnyRouter = EdgeStoreRouter<any>;
+export type AnyRouter = EdgeStoreRouter<any, Record<string, AnyBuilder>>;
 
 function createRouterFactory<TCtx>() {
   return function createRouterInner<
@@ -419,7 +458,7 @@ function createRouterFactory<TCtx>() {
         ctx: undefined as TCtx,
       },
       buckets,
-    } satisfies EdgeStoreRouter<TCtx>;
+    } satisfies EdgeStoreRouter<TCtx, TBuckets>;
   };
 }
 

--- a/packages/shared/src/internals/bucketBuilder.ts
+++ b/packages/shared/src/internals/bucketBuilder.ts
@@ -37,6 +37,11 @@ export type InferBucketPathObject<TBucket extends Builder<any, AnyDef>> =
         [TKey in InferBucketPathKeys<TBucket>]: string;
       };
 
+export type InferBucketPathOrder<TBucket extends Builder<any, AnyDef>> =
+  InferBucketPathKeys<TBucket> extends never
+    ? []
+    : InferBucketPathKeys<TBucket>[];
+
 export type InferBucketPathObjectFromDef<TDef extends AnyDef> =
   InferBucketPathKeysFromDef<TDef> extends never
     ? Record<string, never>
@@ -54,16 +59,7 @@ type InferMetadataObjectFromDef<TDef extends AnyDef> =
     ? Awaited<ReturnType<TDef['metadata']>>
     : Record<string, never>;
 
-export type AnyContextValue =
-  | string
-  | number
-  | boolean
-  | undefined
-  | null
-  | AnyContext
-  | AnyContextValueArray;
-
-interface AnyContextValueArray extends Array<AnyContextValue> {}
+export type AnyContextValue = string | undefined | null | AnyContext;
 
 export interface AnyContext {
   [key: string]: AnyContextValue;

--- a/packages/shared/src/internals/bucketBuilder.ts
+++ b/packages/shared/src/internals/bucketBuilder.ts
@@ -371,10 +371,11 @@ function createBuilder<
       for (const param of params) {
         const entries = Object.entries(param);
         if (entries.length !== 1) {
+          const foundKeys = entries.map(([key]) => key);
           throw new EdgeStoreError({
-            message: `Path params must have exactly one key. Found: ${JSON.stringify(
-              param,
-            )}`,
+            message: `Path params must have exactly one key. Found keys: ${
+              foundKeys.length > 0 ? foundKeys.join(', ') : '(none)'
+            }`,
             code: 'SERVER_ERROR',
           });
         }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -6,6 +6,7 @@
   },
   "types": "index.d.ts",
   "dependencies": {
+    "@edgestore/react": "workspace:*",
     "@edgestore/server": "workspace:*",
     "@edgestore/shared": "workspace:*",
     "zod": "3.25.42"

--- a/packages/tests/test-d/react.test-d.ts
+++ b/packages/tests/test-d/react.test-d.ts
@@ -1,0 +1,19 @@
+import { createEdgeStoreProvider } from '@edgestore/react';
+import { initEdgeStore } from '@edgestore/shared';
+import { expectType } from 'tsd';
+
+const es = initEdgeStore.create();
+
+const router = es.router({
+  files: es.fileBucket(),
+  images: es.imageBucket().path(() => [{ author: () => 'ctx.userId' }]),
+});
+
+const { useEdgeStore } = createEdgeStoreProvider<typeof router>();
+
+type Edgestore = ReturnType<typeof useEdgeStore>['edgestore'];
+type FileUploadResponse = Awaited<ReturnType<Edgestore['files']['upload']>>;
+type ImageUploadResponse = Awaited<ReturnType<Edgestore['images']['upload']>>;
+
+expectType<[]>({} as FileUploadResponse['pathOrder']);
+expectType<'author'[]>({} as ImageUploadResponse['pathOrder']);

--- a/packages/tests/test-d/server.test-d.ts
+++ b/packages/tests/test-d/server.test-d.ts
@@ -295,7 +295,7 @@ expectType<{
       size: number;
       metadata: Record<string, never>;
       path: Record<string, never>;
-      pathOrder: string[];
+      pathOrder: [];
     };
     getFile: {
       url: string;

--- a/packages/tests/test-d/shared.test-d.ts
+++ b/packages/tests/test-d/shared.test-d.ts
@@ -1,8 +1,10 @@
 import {
   initEdgeStore,
   type AccessControlSchema,
+  type AnyContext,
   type EdgeStoreRouter,
   type InferBucketPathObject,
+  type InferBucketPathOrder,
   type InferMetadataObject,
 } from '@edgestore/shared';
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
@@ -48,14 +50,19 @@ const imageBucket = es
   });
 
 const fileBucket = es.fileBucket().path(({ ctx }) => [{ author: ctx.userId }]);
+const emptyBucket = es.fileBucket();
 
 expectType<{ author: string; type: string }>(
   {} as InferBucketPathObject<typeof imageBucket>,
+);
+expectType<('author' | 'type')[]>(
+  {} as InferBucketPathOrder<typeof imageBucket>,
 );
 expectType<{ role: 'admin' | 'visitor'; extension: string | undefined }>(
   {} as InferMetadataObject<typeof imageBucket>,
 );
 expectType<{ author: string }>({} as InferBucketPathObject<typeof fileBucket>);
+expectType<[]>({} as InferBucketPathOrder<typeof emptyBucket>);
 
 expectAssignable<AccessControlSchema<Context, typeof imageBucket._def>>({
   userId: { path: 'author' },
@@ -103,3 +110,11 @@ const nestedBucket = nestedEs
 expectType<{ author: string; role: string }>(
   {} as InferBucketPathObject<typeof nestedBucket>,
 );
+
+expectNotAssignable<AnyContext>({
+  user: {
+    id: 123,
+  },
+});
+// @ts-expect-error context path leaves must be string-compatible.
+initEdgeStore.context<{ user: { id: number } }>().create();

--- a/packages/tests/test-d/shared.test-d.ts
+++ b/packages/tests/test-d/shared.test-d.ts
@@ -1,6 +1,7 @@
 import {
   initEdgeStore,
   type AccessControlSchema,
+  type EdgeStoreRouter,
   type InferBucketPathObject,
   type InferMetadataObject,
 } from '@edgestore/shared';
@@ -77,3 +78,28 @@ const router = es.router({
 
 expectType<typeof imageBucket>(router.buckets.imageBucket);
 expectType<typeof fileBucket>(router.buckets.fileBucket);
+
+type ExactRouter = EdgeStoreRouter<Context, typeof router.buckets>;
+expectType<typeof imageBucket>({} as ExactRouter['buckets']['imageBucket']);
+expectType<typeof fileBucket>({} as ExactRouter['buckets']['fileBucket']);
+
+type NestedContext = {
+  user: {
+    id: string;
+    profile: {
+      role: 'admin' | 'visitor';
+    };
+  };
+};
+
+const nestedEs = initEdgeStore.context<NestedContext>().create();
+const nestedBucket = nestedEs
+  .fileBucket()
+  .path(({ ctx }) => [
+    { author: ctx.user.id },
+    { role: ctx.user.profile.role },
+  ]);
+
+expectType<{ author: string; role: string }>(
+  {} as InferBucketPathObject<typeof nestedBucket>,
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1000,6 +1000,9 @@ importers:
 
   packages/tests:
     dependencies:
+      '@edgestore/react':
+        specifier: workspace:*
+        version: link:../react
       '@edgestore/server':
         specifier: workspace:*
         version: link:../server


### PR DESCRIPTION
## Summary

Keeps the API/runtime fixes separate from the test-harness PR. This PR uses the tests added in #113 to lock the fixes that were discovered while building the test suite, plus a follow-up cleanup for the public React upload response contract.

## Changes

- Add a shared `InferBucketPathOrder` helper so server and React upload responses agree on path-order inference.
- Tighten `UploadFileRes.pathOrder` and React upload `pathOrder` so pathless buckets type as `[]` and keyed buckets use inferred path keys.
- Support nested context objects while keeping context leaves string-compatible, avoiding implicit number/boolean/array path values.
- Preserve exact bucket maps through `EdgeStoreRouter<TCtx, TBuckets>`.
- Validate bucket path definitions at runtime for duplicate path keys and multi-key path segments.
- Add shared/server/react type assertions and runtime assertions for the fixed behavior.

## Validation

- `pnpm --filter @edgestore/shared test -- bucketBuilder`
- `pnpm --filter @edgestore/shared build`
- `pnpm --filter @edgestore/react build`
- `pnpm --filter @edgestore/server build`
- `pnpm --filter @edgestore/tests test:types`

Note: the full `pnpm test:types` Turbo path currently fails before `tsd` because package codegen invokes a bundled `pnpm@11.7.0` that reports a lockfile overrides mismatch. The direct `@edgestore/tests` tsd suite passes after building the packages.
