### PR TITLE
[codex] send package version with api requests

### DIFF
--- a/packages/server/src/core/sdk/index.ts
+++ b/packages/server/src/core/sdk/index.ts
@@ -6,6 +6,10 @@ import {
 } from '@edgestore/shared';
 import { getEnv } from '../../adapters/shared';
 import EdgeStoreCredentialsError from '../../libs/errors/EdgeStoreCredentialsError';
+import {
+  EDGE_STORE_PACKAGE_NAME,
+  EDGE_STORE_PACKAGE_VERSION,
+} from '../../version';
 
 const API_ENDPOINT =
   getEnv('EDGE_STORE_API_ENDPOINT') ?? 'https://api.edgestore.dev';
@@ -77,6 +81,8 @@ async function makeRequest<TOutput>(params: {
       Authorization: `Basic ${Buffer.from(`${accessKey}:${secretKey}`).toString(
         'base64',
       )}`,
+      'x-edgestore-package-name': EDGE_STORE_PACKAGE_NAME,
+      'x-edgestore-package-version': EDGE_STORE_PACKAGE_VERSION,
     },
   });
   if (!res.ok) {

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -1,0 +1,2 @@
+export const EDGE_STORE_PACKAGE_NAME = '@edgestore/server';
+export const EDGE_STORE_PACKAGE_VERSION = '0.7.0';

--- a/scripts/syncVersions.ts
+++ b/scripts/syncVersions.ts
@@ -66,6 +66,38 @@ async function getStandaloneTargetManifests(): Promise<string[]> {
   return targets;
 }
 
+async function syncPackageVersionConstants(
+  localVersions: Record<string, string>,
+): Promise<string[]> {
+  const changedFiles: string[] = [];
+  const serverVersion = localVersions['@edgestore/server'];
+
+  if (serverVersion) {
+    const versionFilePath = path.join(
+      repoRoot,
+      'packages',
+      'server',
+      'src',
+      'version.ts',
+    );
+    const nextText = [
+      "export const EDGE_STORE_PACKAGE_NAME = '@edgestore/server';",
+      `export const EDGE_STORE_PACKAGE_VERSION = '${serverVersion}';`,
+      '',
+    ].join('\n');
+    const prevText = await readFile(versionFilePath, 'utf8');
+
+    if (prevText !== nextText) {
+      if (!CHECK_MODE) {
+        await writeFile(versionFilePath, nextText, 'utf8');
+      }
+      changedFiles.push(path.relative(repoRoot, versionFilePath));
+    }
+  }
+
+  return changedFiles;
+}
+
 function updateDepsObject({
   deps,
   localVersions,
@@ -99,7 +131,10 @@ async function main() {
   const targets = await getStandaloneTargetManifests();
 
   let anyChanges = false;
-  const changedFiles: string[] = [];
+  const changedFiles = await syncPackageVersionConstants(localVersions);
+  if (changedFiles.length > 0) {
+    anyChanges = true;
+  }
 
   for (const manifestPath of targets) {
     let pkg: PackageJson;


### PR DESCRIPTION
## Summary

- Add package name/version constants for `@edgestore/server`.
- Send those values on every EdgeStore API request via `x-edgestore-package-name` and `x-edgestore-package-version` headers.
- Keep the generated version constant synchronized from `packages/server/package.json` during `pnpm sync-versions`.

## Stack

Followed by https://github.com/edgestorejs/edge-store-app/pull/96, which logs these package headers server-side.

## Validation

- `pnpm -s sync-versions --check`
- `pnpm --filter @edgestore/server lint`