### PR TITLE
[codex] rename private tests package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "docs:dev": "pnpm --filter docs dev",
     "docs:build": "pnpm build && pnpm --filter docs run build",
     "test": "turbo run test --filter=@edgestore/*",
-    "test:types": "turbo run test:types --filter=@edgestore/tests",
+    "test:types": "turbo run test:types --filter=edgestore-tests",
     "lint": "turbo lint",
     "typecheck": "turbo run typecheck --filter=@edgestore/*",
     "lint-fix": "turbo lint -- --fix && manypkg fix && pnpm format:write",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@edgestore/tests",
+  "name": "edgestore-tests",
   "private": true,
   "scripts": {
     "test:types": "tsd --files \"test-d/**/*.test-d.ts\""


### PR DESCRIPTION
## Summary

Fix the Changesets release workflow after the failure in https://github.com/edgestorejs/edgestore/actions/runs/28247080154 while preserving the intentional canary prerelease flow and the original `@edgestore/*` fixed release group.

The failure was caused by the private type-test workspace package being named `@edgestore/tests`:

- `.changeset/config.json` intentionally uses `fixed: [["@edgestore/*"]]` for the published Edge Store packages.
- PR #113 added the private workspace package `@edgestore/tests` under that same scope.
- `@edgestore/tests` intentionally has no package version, so Changesets included it in fixed-release planning and crashed while reading/comparing package versions.

## Changes

- Rename the private test-only package from `@edgestore/tests` to `edgestore-tests`.
- Update the root `test:types` Turbo filter to target `edgestore-tests`.
- Leave `.changeset/pre.json` and `.changeset/config.json` unchanged in the final diff, so canary mode and the release grouping stay intact.

## Validation

- Reproduced the original `pnpm -s run version` failure locally.
- Verified in a disposable clean copy that `pnpm install --frozen-lockfile && pnpm -s run version` completes successfully with canary mode still active and `fixed: [["@edgestore/*"]]` preserved.
- Confirmed `turbo run test:types --filter=edgestore-tests` scopes the renamed package.
- Parsed the touched JSON files and ran `git diff --check`.

Note: a full local `pnpm test:types` run is currently blocked in this checkout by dependency codegen subcommands picking up the bundled pnpm 11 runtime and failing on lockfile override config mismatch. The package filter itself resolves correctly before that unrelated local install failure.
