### PR TITLE
test(server): cover EdgeStore SDK contracts

### DIFF
--- a/packages/server/src/core/sdk/index.test.ts
+++ b/packages/server/src/core/sdk/index.test.ts
@@ -1,0 +1,169 @@
+import { initEdgeStore } from '@edgestore/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { edgeStoreRawSdk, initEdgeStoreSdk } from '.';
+import EdgeStoreCredentialsError from '../../libs/errors/EdgeStoreCredentialsError';
+import {
+  EDGE_STORE_PACKAGE_NAME,
+  EDGE_STORE_PACKAGE_VERSION,
+} from '../../version';
+
+function mockFetchJson(body: unknown, init?: Partial<Response>) {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    ...init,
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function getFetchBody(fetchMock: ReturnType<typeof vi.fn>) {
+  const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+  return JSON.parse(init?.body as string);
+}
+
+const fileInfo = {
+  size: 123,
+  extension: 'txt',
+  type: 'text/plain',
+  isPublic: true,
+  path: [{ key: 'org', value: 'acme' }],
+  metadata: { owner: 'user-1' },
+  fileName: 'readme.txt',
+  replaceTargetUrl: 'https://files.example.com/old.txt',
+  temporary: false,
+};
+
+describe('initEdgeStoreSdk', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends basic auth, package headers, and a JSON body through public SDK APIs', async () => {
+    const fetchMock = mockFetchJson({
+      signedUrl: 'https://upload.example.com/file.txt',
+      url: 'https://files.example.com/file.txt',
+      path: 'bucket/file.txt',
+      thumbnailUrl: null,
+    });
+    const sdk = initEdgeStoreSdk({
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+    });
+
+    await sdk.requestUpload({
+      bucketName: 'documents',
+      bucketType: 'FILE',
+      fileInfo,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.edgestore.dev/request-upload',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${Buffer.from('access-key:secret-key').toString(
+            'base64',
+          )}`,
+          'x-edgestore-package-name': EDGE_STORE_PACKAGE_NAME,
+          'x-edgestore-package-version': EDGE_STORE_PACKAGE_VERSION,
+        },
+      }),
+    );
+    expect(getFetchBody(fetchMock)).toEqual({
+      bucketName: 'documents',
+      bucketType: 'FILE',
+      isPublic: true,
+      path: [{ key: 'org', value: 'acme' }],
+      extension: 'txt',
+      size: 123,
+      mimeType: 'text/plain',
+      metadata: { owner: 'user-1' },
+      fileName: 'readme.txt',
+      replaceTargetUrl: 'https://files.example.com/old.txt',
+      isTemporary: false,
+    });
+  });
+
+  it('includes response text when a request fails', async () => {
+    const fetchMock = mockFetchJson(undefined, {
+      ok: false,
+      text: async () => 'invalid project credentials',
+    });
+    const sdk = initEdgeStoreSdk({
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+    });
+
+    await expect(
+      sdk.confirmUpload({
+        url: 'https://files.example.com/file.txt',
+      }),
+    ).rejects.toThrow(
+      'Failed to make request to /confirm-upload: invalid project credentials',
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('throws EdgeStoreCredentialsError when credentials are missing', () => {
+    expect(() =>
+      initEdgeStoreSdk({
+        accessKey: '',
+        secretKey: 'secret-key',
+      }),
+    ).toThrow(EdgeStoreCredentialsError);
+  });
+});
+
+describe('edgeStoreRawSdk.getToken', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('serializes router bucket path and accessControl in the request body', async () => {
+    const fetchMock = mockFetchJson({ token: 'edge-token' });
+    const es = initEdgeStore
+      .context<{ userId: string; orgId: string }>()
+      .create();
+    const router = es.router({
+      documents: es
+        .fileBucket()
+        .path(({ ctx }) => [{ owner: ctx.userId }, { org: ctx.orgId }])
+        .accessControl({
+          userId: { eq: { path: 'owner' } },
+          orgId: { eq: { path: 'org' } },
+        }),
+    });
+
+    await expect(
+      edgeStoreRawSdk.getToken({
+        accessKey: 'access-key',
+        secretKey: 'secret-key',
+        ctx: { userId: 'user-1', orgId: 'org-1' },
+        router,
+      }),
+    ).resolves.toBe('edge-token');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.edgestore.dev/get-token',
+      expect.any(Object),
+    );
+    expect(getFetchBody(fetchMock)).toEqual({
+      ctx: { userId: 'user-1', orgId: 'org-1' },
+      buckets: {
+        documents: {
+          path: [
+            { key: 'owner', value: 'ctx.userId' },
+            { key: 'org', value: 'ctx.orgId' },
+          ],
+          accessControl: {
+            userId: { eq: { path: 'owner' } },
+            orgId: { eq: { path: 'org' } },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/server/src/core/sdk/index.test.ts
+++ b/packages/server/src/core/sdk/index.test.ts
@@ -1,11 +1,17 @@
 import { initEdgeStore } from '@edgestore/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { edgeStoreRawSdk, initEdgeStoreSdk } from '.';
-import EdgeStoreCredentialsError from '../../libs/errors/EdgeStoreCredentialsError';
 import {
   EDGE_STORE_PACKAGE_NAME,
   EDGE_STORE_PACKAGE_VERSION,
 } from '../../version';
+
+const DEFAULT_API_ENDPOINT = 'https://api.edgestore.dev';
+
+async function importSdk(params?: { apiEndpoint?: string }) {
+  vi.resetModules();
+  vi.stubEnv('EDGE_STORE_API_ENDPOINT', params?.apiEndpoint);
+  return await import('.');
+}
 
 function mockFetchJson(body: unknown, init?: Partial<Response>) {
   const fetchMock = vi.fn(async () => ({
@@ -38,9 +44,11 @@ const fileInfo = {
 describe('initEdgeStoreSdk', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it('sends basic auth, package headers, and a JSON body through public SDK APIs', async () => {
+    const { initEdgeStoreSdk } = await importSdk();
     const fetchMock = mockFetchJson({
       signedUrl: 'https://upload.example.com/file.txt',
       url: 'https://files.example.com/file.txt',
@@ -59,7 +67,7 @@ describe('initEdgeStoreSdk', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.edgestore.dev/request-upload',
+      `${DEFAULT_API_ENDPOINT}/request-upload`,
       expect.objectContaining({
         method: 'POST',
         headers: {
@@ -88,6 +96,7 @@ describe('initEdgeStoreSdk', () => {
   });
 
   it('includes response text when a request fails', async () => {
+    const { initEdgeStoreSdk } = await importSdk();
     const fetchMock = mockFetchJson(undefined, {
       ok: false,
       text: async () => 'invalid project credentials',
@@ -107,7 +116,12 @@ describe('initEdgeStoreSdk', () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
-  it('throws EdgeStoreCredentialsError when credentials are missing', () => {
+  it('throws EdgeStoreCredentialsError when credentials are missing', async () => {
+    const { initEdgeStoreSdk } = await importSdk();
+    const { default: EdgeStoreCredentialsError } = await import(
+      '../../libs/errors/EdgeStoreCredentialsError'
+    );
+
     expect(() =>
       initEdgeStoreSdk({
         accessKey: '',
@@ -115,14 +129,43 @@ describe('initEdgeStoreSdk', () => {
       }),
     ).toThrow(EdgeStoreCredentialsError);
   });
+
+  it('uses EDGE_STORE_API_ENDPOINT when provided', async () => {
+    const { initEdgeStoreSdk } = await importSdk({
+      apiEndpoint: 'https://api.test.invalid',
+    });
+    const fetchMock = mockFetchJson({
+      signedUrl: 'https://upload.example.com/file.txt',
+      url: 'https://files.example.com/file.txt',
+      path: 'bucket/file.txt',
+      thumbnailUrl: null,
+    });
+    const sdk = initEdgeStoreSdk({
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+    });
+
+    await sdk.requestUpload({
+      bucketName: 'documents',
+      bucketType: 'FILE',
+      fileInfo,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test.invalid/request-upload',
+      expect.any(Object),
+    );
+  });
 });
 
 describe('edgeStoreRawSdk.getToken', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it('serializes router bucket path and accessControl in the request body', async () => {
+    const { edgeStoreRawSdk } = await importSdk();
     const fetchMock = mockFetchJson({ token: 'edge-token' });
     const es = initEdgeStore
       .context<{ userId: string; orgId: string }>()
@@ -147,7 +190,7 @@ describe('edgeStoreRawSdk.getToken', () => {
     ).resolves.toBe('edge-token');
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.edgestore.dev/get-token',
+      `${DEFAULT_API_ENDPOINT}/get-token`,
       expect.any(Object),
     );
     expect(getFetchBody(fetchMock)).toEqual({

--- a/packages/server/src/providers/edgestore/index.test.ts
+++ b/packages/server/src/providers/edgestore/index.test.ts
@@ -1,0 +1,238 @@
+import { EdgeStoreError } from '@edgestore/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EdgeStoreProvider } from '.';
+import { initEdgeStoreSdk, type EdgeStoreSdk } from '../../core/sdk';
+
+vi.mock('../../core/sdk', () => ({
+  initEdgeStoreSdk: vi.fn(),
+}));
+
+type MockSdk = {
+  [K in keyof EdgeStoreSdk]: ReturnType<typeof vi.fn>;
+};
+
+const initEdgeStoreSdkMock = vi.mocked(initEdgeStoreSdk);
+
+const fileInfo = {
+  size: 1024,
+  extension: 'txt',
+  isPublic: true,
+  path: [{ key: 'org', value: 'acme' }],
+  metadata: { owner: 'user-1' },
+  temporary: false,
+};
+
+function createMockSdk(overrides: Partial<MockSdk> = {}) {
+  const sdk = {
+    getToken: vi.fn(),
+    getFile: vi.fn(),
+    requestUpload: vi.fn(),
+    requestUploadParts: vi.fn(),
+    completeMultipartUpload: vi.fn(),
+    confirmUpload: vi.fn(),
+    deleteFile: vi.fn(),
+    listFiles: vi.fn(),
+    ...overrides,
+  } satisfies MockSdk;
+  initEdgeStoreSdkMock.mockReturnValue(sdk as unknown as EdgeStoreSdk);
+  return sdk;
+}
+
+describe('EdgeStoreProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps signedUrl to uploadUrl below the multipart threshold', async () => {
+    const sdk = createMockSdk({
+      requestUpload: vi.fn(async () => ({
+        signedUrl: 'https://upload.example.com/file.txt',
+        accessUrl: 'https://files.example.com/file.txt',
+        path: 'documents/file.txt',
+        thumbnailUrl: 'https://files.example.com/thumb.jpg',
+      })),
+    });
+    const provider = EdgeStoreProvider({
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+    });
+
+    await expect(
+      provider.requestUpload({
+        bucketName: 'documents',
+        bucketType: 'FILE',
+        fileInfo,
+      }),
+    ).resolves.toEqual({
+      uploadUrl: 'https://upload.example.com/file.txt',
+      accessUrl: 'https://files.example.com/file.txt',
+      thumbnailUrl: 'https://files.example.com/thumb.jpg',
+    });
+    expect(sdk.requestUpload).toHaveBeenCalledWith({
+      bucketName: 'documents',
+      bucketType: 'FILE',
+      fileInfo,
+    });
+  });
+
+  it('requests multipart parts and maps signedUrl to uploadUrl above the threshold', async () => {
+    const size = 11 * 1024 * 1024;
+    const sdk = createMockSdk({
+      requestUpload: vi.fn(async () => ({
+        multipart: {
+          key: 'documents/file.bin',
+          uploadId: 'upload-id',
+          parts: [
+            { partNumber: 1, signedUrl: 'https://upload.example.com/part-1' },
+            { partNumber: 2, signedUrl: 'https://upload.example.com/part-2' },
+            { partNumber: 3, signedUrl: 'https://upload.example.com/part-3' },
+          ],
+        },
+        accessUrl: 'https://files.example.com/file.bin',
+        path: 'documents/file.bin',
+        thumbnailUrl: null,
+      })),
+    });
+    const provider = EdgeStoreProvider({
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+    });
+
+    await expect(
+      provider.requestUpload({
+        bucketName: 'documents',
+        bucketType: 'FILE',
+        fileInfo: {
+          ...fileInfo,
+          size,
+          extension: 'bin',
+        },
+      }),
+    ).resolves.toEqual({
+      accessUrl: 'https://files.example.com/file.bin',
+      thumbnailUrl: null,
+      multipart: {
+        key: 'documents/file.bin',
+        uploadId: 'upload-id',
+        partSize: 5 * 1024 * 1024,
+        totalParts: 3,
+        parts: [
+          { partNumber: 1, uploadUrl: 'https://upload.example.com/part-1' },
+          { partNumber: 2, uploadUrl: 'https://upload.example.com/part-2' },
+          { partNumber: 3, uploadUrl: 'https://upload.example.com/part-3' },
+        ],
+      },
+    });
+    expect(sdk.requestUpload).toHaveBeenCalledWith({
+      bucketName: 'documents',
+      bucketType: 'FILE',
+      fileInfo: {
+        ...fileInfo,
+        size,
+        extension: 'bin',
+      },
+      multipart: {
+        parts: [1, 2, 3],
+      },
+    });
+  });
+
+  it('caps multipart uploads at 1000 parts and increases partSize', async () => {
+    const size = 1001 * 5 * 1024 * 1024;
+    const sdk = createMockSdk({
+      requestUpload: vi.fn(async () => ({
+        multipart: {
+          key: 'documents/large.bin',
+          uploadId: 'upload-id',
+          parts: [{ partNumber: 1, signedUrl: 'https://upload.example.com/1' }],
+        },
+        accessUrl: 'https://files.example.com/large.bin',
+        path: 'documents/large.bin',
+        thumbnailUrl: null,
+      })),
+    });
+    const provider = EdgeStoreProvider({
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+    });
+
+    const res = await provider.requestUpload({
+      bucketName: 'documents',
+      bucketType: 'FILE',
+      fileInfo: {
+        ...fileInfo,
+        size,
+        extension: 'bin',
+      },
+    });
+
+    const request = sdk.requestUpload.mock.calls[0]?.[0];
+    expect(request.multipart.parts).toHaveLength(1000);
+    expect(request.multipart.parts[0]).toBe(1);
+    expect(request.multipart.parts[999]).toBe(1000);
+    expect(res).toMatchObject({
+      multipart: {
+        partSize: Math.ceil(size / 1000),
+        totalParts: 1000,
+      },
+    });
+  });
+
+  it('throws when the upload response has neither signedUrl nor multipart', async () => {
+    createMockSdk({
+      requestUpload: vi.fn(async () => ({
+        accessUrl: 'https://files.example.com/file.txt',
+        path: 'documents/file.txt',
+        thumbnailUrl: null,
+      })),
+    });
+    const provider = EdgeStoreProvider({
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+    });
+
+    await expect(
+      provider.requestUpload({
+        bucketName: 'documents',
+        bucketType: 'FILE',
+        fileInfo,
+      }),
+    ).rejects.toThrow(EdgeStoreError);
+  });
+
+  it('maps requestUploadParts signedUrl values to uploadUrl values', async () => {
+    createMockSdk({
+      requestUploadParts: vi.fn(async () => ({
+        multipart: {
+          uploadId: 'upload-id',
+          parts: [
+            { partNumber: 1, signedUrl: 'https://upload.example.com/part-1' },
+            { partNumber: 2, signedUrl: 'https://upload.example.com/part-2' },
+          ],
+        },
+      })),
+    });
+    const provider = EdgeStoreProvider({
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+    });
+
+    await expect(
+      provider.requestUploadParts({
+        path: 'documents/file.bin',
+        multipart: {
+          uploadId: 'upload-id',
+          parts: [1, 2],
+        },
+      }),
+    ).resolves.toEqual({
+      multipart: {
+        uploadId: 'upload-id',
+        parts: [
+          { partNumber: 1, uploadUrl: 'https://upload.example.com/part-1' },
+          { partNumber: 2, uploadUrl: 'https://upload.example.com/part-2' },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add mocked SDK contract coverage for auth headers, request bodies, error text, credentials, and getToken serialization
- add EdgeStore provider tests for signed upload mapping, multipart sizing/capping, missing upload URL errors, and requestUploadParts mapping

## Verification
- pnpm --filter @edgestore/server test -- src/core/sdk/index.test.ts src/providers/edgestore/index.test.ts
- pnpm --filter @edgestore/server typecheck