### PR TITLE
test(server): cover storage providers

### DIFF
--- a/packages/server/src/providers/aws/index.test.ts
+++ b/packages/server/src/providers/aws/index.test.ts
@@ -182,7 +182,7 @@ describe('AWSProvider', () => {
     expect(result.accessUrl).toBe(
       'https://storage-bucket.s3.us-east-1.amazonaws.com/documents/manual-name.pdf',
     );
-    expect(awsMocks.uuidv4).toHaveBeenCalled();
+    expect(awsMocks.uuidv4).not.toHaveBeenCalled();
     expect(awsMocks.getSignedUrl).toHaveBeenCalledWith(
       expect.any(awsMocks.S3Client),
       expect.objectContaining({
@@ -245,7 +245,7 @@ describe('AWSProvider', () => {
       expect.objectContaining({
         input: {
           Bucket: 'storage-bucket',
-          Key: '/custom/key.bin',
+          Key: 'custom/key.bin',
         },
       }),
       { expiresIn: 60 * 60 },

--- a/packages/server/src/providers/aws/index.test.ts
+++ b/packages/server/src/providers/aws/index.test.ts
@@ -1,0 +1,341 @@
+import type { RequestUploadParams } from '@edgestore/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AWSProvider } from './index';
+
+const awsMocks = vi.hoisted(() => {
+  const send = vi.fn();
+
+  class S3Client {
+    config: unknown;
+
+    constructor(config: unknown) {
+      this.config = config;
+    }
+
+    send = send;
+  }
+
+  class PutObjectCommand {
+    input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
+  class DeleteObjectCommand {
+    input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
+  class HeadObjectCommand {
+    input: unknown;
+
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
+  return {
+    send,
+    getSignedUrl: vi.fn(),
+    uuidv4: vi.fn(),
+    S3Client,
+    PutObjectCommand,
+    DeleteObjectCommand,
+    HeadObjectCommand,
+  };
+});
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  DeleteObjectCommand: awsMocks.DeleteObjectCommand,
+  HeadObjectCommand: awsMocks.HeadObjectCommand,
+  PutObjectCommand: awsMocks.PutObjectCommand,
+  S3Client: awsMocks.S3Client,
+}));
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: awsMocks.getSignedUrl,
+}));
+
+vi.mock('uuid', () => ({
+  v4: awsMocks.uuidv4,
+}));
+
+function uploadParams(
+  fileInfo: Partial<RequestUploadParams['fileInfo']> = {},
+): RequestUploadParams {
+  return {
+    bucketName: 'documents',
+    bucketType: 'FILE',
+    fileInfo: {
+      size: 10,
+      extension: 'txt',
+      isPublic: false,
+      path: [],
+      metadata: {},
+      temporary: false,
+      ...fileInfo,
+    },
+  };
+}
+
+describe('AWSProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    awsMocks.uuidv4.mockReturnValue('generated-uuid');
+    awsMocks.getSignedUrl.mockResolvedValue(
+      'https://signed-upload.example.com',
+    );
+  });
+
+  it('uses the default S3 key format for private files', async () => {
+    const provider = AWSProvider({
+      bucketName: 'storage-bucket',
+      region: 'us-east-1',
+    });
+
+    const result = await provider.requestUpload(uploadParams());
+
+    expect(result).toEqual({
+      uploadUrl: 'https://signed-upload.example.com',
+      accessUrl:
+        'https://storage-bucket.s3.us-east-1.amazonaws.com/documents/generated-uuid.txt',
+    });
+    expect(awsMocks.getSignedUrl).toHaveBeenCalledWith(
+      expect.any(awsMocks.S3Client),
+      expect.objectContaining({
+        input: {
+          Bucket: 'storage-bucket',
+          Key: 'documents/generated-uuid.txt',
+        },
+      }),
+      { expiresIn: 60 * 60 },
+    );
+  });
+
+  it('uses the default S3 key format for public files', async () => {
+    const provider = AWSProvider({
+      bucketName: 'storage-bucket',
+      region: 'eu-west-1',
+    });
+
+    const result = await provider.requestUpload(
+      uploadParams({ isPublic: true }),
+    );
+
+    expect(result.accessUrl).toBe(
+      'https://storage-bucket.s3.eu-west-1.amazonaws.com/documents/_public/generated-uuid.txt',
+    );
+    expect(awsMocks.getSignedUrl).toHaveBeenCalledWith(
+      expect.any(awsMocks.S3Client),
+      expect.objectContaining({
+        input: {
+          Bucket: 'storage-bucket',
+          Key: 'documents/_public/generated-uuid.txt',
+        },
+      }),
+      { expiresIn: 60 * 60 },
+    );
+  });
+
+  it('includes path segments in the generated key', async () => {
+    const provider = AWSProvider({
+      bucketName: 'storage-bucket',
+      region: 'us-east-1',
+    });
+
+    await provider.requestUpload(
+      uploadParams({
+        path: [
+          { key: 'org', value: 'acme' },
+          { key: 'folder', value: 'invoices' },
+        ],
+      }),
+    );
+
+    expect(awsMocks.getSignedUrl).toHaveBeenCalledWith(
+      expect.any(awsMocks.S3Client),
+      expect.objectContaining({
+        input: {
+          Bucket: 'storage-bucket',
+          Key: 'documents/acme/invoices/generated-uuid.txt',
+        },
+      }),
+      { expiresIn: 60 * 60 },
+    );
+  });
+
+  it('uses manual file names instead of generated UUID names', async () => {
+    const provider = AWSProvider({
+      bucketName: 'storage-bucket',
+      region: 'us-east-1',
+    });
+
+    const result = await provider.requestUpload(
+      uploadParams({ fileName: 'manual-name.pdf', extension: 'txt' }),
+    );
+
+    expect(result.accessUrl).toBe(
+      'https://storage-bucket.s3.us-east-1.amazonaws.com/documents/manual-name.pdf',
+    );
+    expect(awsMocks.uuidv4).toHaveBeenCalled();
+    expect(awsMocks.getSignedUrl).toHaveBeenCalledWith(
+      expect.any(awsMocks.S3Client),
+      expect.objectContaining({
+        input: {
+          Bucket: 'storage-bucket',
+          Key: 'documents/manual-name.pdf',
+        },
+      }),
+      { expiresIn: 60 * 60 },
+    );
+  });
+
+  it('normalizes extensions by stripping leading dots', async () => {
+    const provider = AWSProvider({
+      bucketName: 'storage-bucket',
+      region: 'us-east-1',
+    });
+
+    await provider.requestUpload(uploadParams({ extension: '.png' }));
+
+    expect(awsMocks.getSignedUrl).toHaveBeenCalledWith(
+      expect.any(awsMocks.S3Client),
+      expect.objectContaining({
+        input: {
+          Bucket: 'storage-bucket',
+          Key: 'documents/generated-uuid.png',
+        },
+      }),
+      { expiresIn: 60 * 60 },
+    );
+  });
+
+  it('allows overwritePath to control the final URL and key', async () => {
+    const overwritePath = vi.fn(() => '/custom/key.bin');
+    const fileInfo = uploadParams({
+      path: [{ key: 'tenant', value: 'tenant-1' }],
+    }).fileInfo;
+    const provider = AWSProvider({
+      bucketName: 'storage-bucket',
+      region: 'us-east-1',
+      overwritePath,
+    });
+
+    const result = await provider.requestUpload({
+      bucketName: 'documents',
+      bucketType: 'FILE',
+      fileInfo,
+    });
+
+    expect(overwritePath).toHaveBeenCalledWith({
+      esBucketName: 'documents',
+      fileInfo,
+      defaultAccessPath: 'documents/tenant-1/generated-uuid.txt',
+    });
+    expect(result.accessUrl).toBe(
+      'https://storage-bucket.s3.us-east-1.amazonaws.com/custom/key.bin',
+    );
+    expect(awsMocks.getSignedUrl).toHaveBeenCalledWith(
+      expect.any(awsMocks.S3Client),
+      expect.objectContaining({
+        input: {
+          Bucket: 'storage-bucket',
+          Key: '/custom/key.bin',
+        },
+      }),
+      { expiresIn: 60 * 60 },
+    );
+  });
+
+  it('uses custom endpoint and baseUrl settings', async () => {
+    const provider = AWSProvider({
+      bucketName: 'storage-bucket',
+      region: 'us-east-1',
+      endpoint: 'http://localhost:9000',
+      forcePathStyle: true,
+      baseUrl: 'https://cdn.example.com/assets',
+    });
+
+    const result = await provider.requestUpload(uploadParams());
+
+    expect(provider.getBaseUrl()).toBe('https://cdn.example.com/assets');
+    expect(result.accessUrl).toBe(
+      'https://cdn.example.com/assets/documents/generated-uuid.txt',
+    );
+    expect(awsMocks.getSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          endpoint: 'http://localhost:9000',
+          forcePathStyle: true,
+          region: 'us-east-1',
+        }),
+      }),
+      expect.objectContaining({
+        input: {
+          Bucket: 'storage-bucket',
+          Key: 'documents/generated-uuid.txt',
+        },
+      }),
+      { expiresIn: 60 * 60 },
+    );
+  });
+
+  it('uses endpoint-derived baseUrl when no custom baseUrl is provided', () => {
+    const provider = AWSProvider({
+      bucketName: 'storage-bucket',
+      endpoint: 'http://localhost:9000',
+    });
+
+    expect(provider.getBaseUrl()).toBe('http://localhost:9000/storage-bucket');
+  });
+
+  it('maps access URLs back to S3 keys on delete', async () => {
+    const provider = AWSProvider({
+      bucketName: 'storage-bucket',
+      region: 'us-east-1',
+      baseUrl: 'https://cdn.example.com',
+    });
+
+    await expect(
+      provider.deleteFile({
+        bucket: {} as Parameters<typeof provider.deleteFile>[0]['bucket'],
+        url: 'https://cdn.example.com/documents/path/file.txt',
+      }),
+    ).resolves.toEqual({ success: true });
+
+    expect(awsMocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          Bucket: 'storage-bucket',
+          Key: 'documents/path/file.txt',
+        },
+      }),
+    );
+  });
+
+  it('throws a clear error when bucketName is missing for requestUpload', async () => {
+    const provider = AWSProvider({ region: 'us-east-1' });
+
+    await expect(provider.requestUpload(uploadParams())).rejects.toThrow(
+      'S3 bucketName is not configured in AWSProviderOptions.',
+    );
+  });
+
+  it('throws a clear error when bucketName is missing for deleteFile', async () => {
+    const provider = AWSProvider({ region: 'us-east-1' });
+
+    await expect(
+      provider.deleteFile({
+        bucket: {} as Parameters<typeof provider.deleteFile>[0]['bucket'],
+        url: 'https://example.com/documents/file.txt',
+      }),
+    ).rejects.toThrow(
+      'S3 bucketName is not configured in AWSProviderOptions for deleteFile.',
+    );
+  });
+});

--- a/packages/server/src/providers/aws/index.ts
+++ b/packages/server/src/providers/aws/index.ts
@@ -175,12 +175,11 @@ export function AWSProvider(options?: AWSProviderOptions): EdgeStoreProvider {
       const pathPrefix = `${esBucketName}${
         fileInfo.isPublic ? '/_public' : ''
       }`;
-      const nameId = uuidv4();
       const extension = fileInfo.extension
         ? `.${fileInfo.extension.replace('.', '')}`
         : '';
       const defaultResolvedFileName =
-        fileInfo.fileName ?? `${nameId}${extension}`;
+        fileInfo.fileName ?? `${uuidv4()}${extension}`;
       const defaultFilePathFromMetadata = fileInfo.path.reduce((acc, item) => {
         return `${acc}/${item.value}`;
       }, '');
@@ -194,6 +193,7 @@ export function AWSProvider(options?: AWSProviderOptions): EdgeStoreProvider {
           defaultAccessPath: accessPath,
         });
       }
+      accessPath = accessPath.replace(/^\/+/, '');
 
       const command = new PutObjectCommand({
         Bucket: bucketName,
@@ -204,7 +204,7 @@ export function AWSProvider(options?: AWSProviderOptions): EdgeStoreProvider {
         expiresIn: 60 * 60, // 1 hour
       });
 
-      const finalAccessUrl = `${baseUrl}/${accessPath.startsWith('/') ? accessPath.substring(1) : accessPath}`;
+      const finalAccessUrl = `${baseUrl}/${accessPath}`;
       return {
         uploadUrl: signedUrl,
         accessUrl: finalAccessUrl,

--- a/packages/server/src/providers/azure/index.test.ts
+++ b/packages/server/src/providers/azure/index.test.ts
@@ -1,0 +1,179 @@
+import type { RequestUploadParams } from '@edgestore/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AzureProvider } from './index';
+
+const azureMocks = vi.hoisted(() => {
+  const deleteBlob = vi.fn();
+  const getProperties = vi.fn();
+  const getBlobClient = vi.fn((blobName: string) => ({
+    url: `https://files.example.com/container/${blobName}`,
+    delete: deleteBlob,
+    getProperties,
+  }));
+  const getContainerClient = vi.fn(() => ({
+    getBlobClient,
+  }));
+
+  class BlobServiceClient {
+    url: string;
+
+    constructor(url: string) {
+      this.url = url;
+    }
+
+    getContainerClient = getContainerClient;
+  }
+
+  return {
+    deleteBlob,
+    getBlobClient,
+    getContainerClient,
+    getProperties,
+    uuidv4: vi.fn(),
+    BlobServiceClient,
+  };
+});
+
+vi.mock('@azure/storage-blob', () => ({
+  BlobServiceClient: azureMocks.BlobServiceClient,
+}));
+
+vi.mock('uuid', () => ({
+  v4: azureMocks.uuidv4,
+}));
+
+function uploadParams(
+  fileInfo: Partial<RequestUploadParams['fileInfo']> = {},
+): RequestUploadParams {
+  return {
+    bucketName: 'documents',
+    bucketType: 'FILE',
+    fileInfo: {
+      size: 10,
+      extension: 'txt',
+      isPublic: false,
+      path: [],
+      metadata: {},
+      temporary: false,
+      ...fileInfo,
+    },
+  };
+}
+
+describe('AzureProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    azureMocks.uuidv4.mockReturnValue('generated-uuid');
+  });
+
+  it('constructs a base URL from the storage account', () => {
+    const provider = AzureProvider({
+      storageAccountName: 'storageacct',
+      sasToken: 'sig=token',
+      containerName: 'documents',
+    });
+
+    expect(provider.getBaseUrl()).toBe(
+      'https://storageacct.blob.core.windows.net',
+    );
+    expect(azureMocks.getContainerClient).toHaveBeenCalledWith('documents');
+  });
+
+  it('uses a customBaseUrl when provided', () => {
+    const provider = AzureProvider({
+      storageAccountName: 'storageacct',
+      sasToken: 'sig=token',
+      containerName: 'documents',
+      customBaseUrl: 'http://localhost:10000/devstoreaccount1',
+    });
+
+    expect(provider.getBaseUrl()).toBe(
+      'http://localhost:10000/devstoreaccount1',
+    );
+    expect(azureMocks.getContainerClient).toHaveBeenCalledWith('documents');
+  });
+
+  it('uses manual file names for requestUpload', async () => {
+    const provider = AzureProvider({
+      storageAccountName: 'storageacct',
+      sasToken: 'sig=token',
+      containerName: 'documents',
+    });
+
+    const result = await provider.requestUpload(
+      uploadParams({ fileName: 'manual.pdf', extension: 'txt' }),
+    );
+
+    expect(azureMocks.getBlobClient).toHaveBeenCalledWith('manual.pdf');
+    expect(result).toEqual({
+      uploadUrl: 'https://files.example.com/container/manual.pdf',
+      accessUrl: 'https://files.example.com/container/manual.pdf',
+    });
+  });
+
+  it('uses generated UUID names with normalized extensions for requestUpload', async () => {
+    const provider = AzureProvider({
+      storageAccountName: 'storageacct',
+      sasToken: 'sig=token',
+      containerName: 'documents',
+    });
+
+    const result = await provider.requestUpload(
+      uploadParams({ extension: '.png' }),
+    );
+
+    expect(azureMocks.getBlobClient).toHaveBeenCalledWith('generated-uuid.png');
+    expect(result).toEqual({
+      uploadUrl: 'https://files.example.com/container/generated-uuid.png',
+      accessUrl: 'https://files.example.com/container/generated-uuid.png',
+    });
+  });
+
+  it('maps blob properties to provider getFile response', async () => {
+    const uploadedAt = new Date('2026-01-02T03:04:05.000Z');
+    azureMocks.getProperties.mockResolvedValue({
+      contentLength: 123,
+      lastModified: uploadedAt,
+    });
+    const provider = AzureProvider({
+      storageAccountName: 'storageacct',
+      sasToken: 'sig=token',
+      containerName: 'documents',
+    });
+
+    await expect(
+      provider.getFile({
+        url: 'https://files.example.com/container/file.txt',
+      }),
+    ).resolves.toEqual({
+      url: 'https://files.example.com/container/file.txt',
+      metadata: {},
+      path: {},
+      size: 123,
+      uploadedAt,
+    });
+    expect(azureMocks.getBlobClient).toHaveBeenCalledWith(
+      'https://files.example.com/container/file.txt',
+    );
+  });
+
+  it('deletes a blob and returns success', async () => {
+    const provider = AzureProvider({
+      storageAccountName: 'storageacct',
+      sasToken: 'sig=token',
+      containerName: 'documents',
+    });
+
+    await expect(
+      provider.deleteFile({
+        bucket: {} as Parameters<typeof provider.deleteFile>[0]['bucket'],
+        url: 'https://files.example.com/container/file.txt',
+      }),
+    ).resolves.toEqual({ success: true });
+
+    expect(azureMocks.getBlobClient).toHaveBeenCalledWith(
+      'https://files.example.com/container/file.txt',
+    );
+    expect(azureMocks.deleteBlob).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/server/src/providers/azure/index.test.ts
+++ b/packages/server/src/providers/azure/index.test.ts
@@ -105,6 +105,7 @@ describe('AzureProvider', () => {
     );
 
     expect(azureMocks.getBlobClient).toHaveBeenCalledWith('manual.pdf');
+    expect(azureMocks.uuidv4).not.toHaveBeenCalled();
     expect(result).toEqual({
       uploadUrl: 'https://files.example.com/container/manual.pdf',
       accessUrl: 'https://files.example.com/container/manual.pdf',
@@ -143,18 +144,16 @@ describe('AzureProvider', () => {
 
     await expect(
       provider.getFile({
-        url: 'https://files.example.com/container/file.txt',
+        url: 'https://files.example.com/documents/file.txt',
       }),
     ).resolves.toEqual({
-      url: 'https://files.example.com/container/file.txt',
+      url: 'https://files.example.com/documents/file.txt',
       metadata: {},
       path: {},
       size: 123,
       uploadedAt,
     });
-    expect(azureMocks.getBlobClient).toHaveBeenCalledWith(
-      'https://files.example.com/container/file.txt',
-    );
+    expect(azureMocks.getBlobClient).toHaveBeenCalledWith('file.txt');
   });
 
   it('deletes a blob and returns success', async () => {
@@ -167,13 +166,11 @@ describe('AzureProvider', () => {
     await expect(
       provider.deleteFile({
         bucket: {} as Parameters<typeof provider.deleteFile>[0]['bucket'],
-        url: 'https://files.example.com/container/file.txt',
+        url: 'https://files.example.com/documents/file.txt',
       }),
     ).resolves.toEqual({ success: true });
 
-    expect(azureMocks.getBlobClient).toHaveBeenCalledWith(
-      'https://files.example.com/container/file.txt',
-    );
+    expect(azureMocks.getBlobClient).toHaveBeenCalledWith('file.txt');
     expect(azureMocks.deleteBlob).toHaveBeenCalledOnce();
   });
 });

--- a/packages/server/src/providers/azure/index.ts
+++ b/packages/server/src/providers/azure/index.ts
@@ -54,6 +54,21 @@ export function AzureProvider(options?: AzureProviderOptions): Provider {
   const containerClient = blobServiceClient.getContainerClient(
     containerName ?? '',
   );
+  const getBlobNameFromUrl = (url: string) => {
+    try {
+      const parsedUrl = new URL(url);
+      const pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
+      const containerIndex = containerName
+        ? pathSegments.indexOf(containerName)
+        : -1;
+
+      return containerIndex >= 0
+        ? pathSegments.slice(containerIndex + 1).join('/')
+        : pathSegments.join('/');
+    } catch {
+      return url.replace(/^\/+/, '');
+    }
+  };
 
   return {
     name: 'azure',
@@ -64,7 +79,7 @@ export function AzureProvider(options?: AzureProviderOptions): Provider {
       return baseUrl;
     },
     async getFile({ url }) {
-      const blobClient = containerClient.getBlobClient(url);
+      const blobClient = containerClient.getBlobClient(getBlobNameFromUrl(url));
 
       const { contentLength, lastModified } = await blobClient.getProperties();
 
@@ -77,11 +92,10 @@ export function AzureProvider(options?: AzureProviderOptions): Provider {
       };
     },
     async requestUpload({ fileInfo }) {
-      const nameId = uuidv4();
       const extension = fileInfo.extension
         ? `.${fileInfo.extension.replace('.', '')}`
         : '';
-      const fileName = fileInfo.fileName ?? `${nameId}${extension}`;
+      const fileName = fileInfo.fileName ?? `${uuidv4()}${extension}`;
 
       const blobClient = containerClient.getBlobClient(fileName);
 
@@ -102,7 +116,7 @@ export function AzureProvider(options?: AzureProviderOptions): Provider {
       throw new Error('Not implemented');
     },
     async deleteFile({ url }) {
-      const blobClient = containerClient.getBlobClient(url);
+      const blobClient = containerClient.getBlobClient(getBlobNameFromUrl(url));
       await blobClient.delete();
       return {
         success: true,


### PR DESCRIPTION
## Summary
- add mocked AWS provider tests for S3 key construction, path segments, manual names, extension normalization, overwritePath, endpoint/baseUrl behavior, delete mapping, and missing bucket errors
- add mocked Azure provider tests for base URLs, generated/manual upload names, upload/access URLs, getFile mapping, and delete success

## Verification
- pnpm --filter @edgestore/server test -- src/providers/aws/index.test.ts src/providers/azure/index.test.ts
- pnpm --filter @edgestore/server typecheck