### PR TITLE
test(react): cover upload and provider runtime behavior

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config rollup.config.ts --configPlugin rollup-plugin-swc3",
     "dev": "pnpm build --watch",
     "codegen:entrypoints": "tsx entrypoints.script.ts",
+    "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },
@@ -91,6 +92,7 @@
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
     "@types/uuid": "^9.0.1",
+    "jsdom": "^29.1.1",
     "next": "16.1.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/packages/react/src/contextProvider.test.tsx
+++ b/packages/react/src/contextProvider.test.tsx
@@ -1,0 +1,232 @@
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createEdgeStoreProvider } from './contextProvider';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type FetchCall = {
+  url: string;
+  init: RequestInit | undefined;
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+function urlToString(url: string | URL | Request) {
+  return typeof url === 'string'
+    ? url
+    : url instanceof Request
+      ? url.url
+      : url.toString();
+}
+
+function createFetchMock(responses: Response[]) {
+  const calls: FetchCall[] = [];
+  const fetchMock = vi.fn(
+    async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({
+        url: urlToString(url),
+        init,
+      });
+      const response = responses.shift();
+      if (!response) {
+        throw new Error(`Unexpected fetch: ${urlToString(url)}`);
+      }
+      return response;
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  return { calls, fetchMock };
+}
+
+async function waitFor(assertion: () => void) {
+  let lastError: unknown;
+  for (let i = 0; i < 20; i++) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+  }
+  throw lastError;
+}
+
+describe('createEdgeStoreProvider initialization', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('skips _init for public EdgeStore responses', async () => {
+    const { calls } = createFetchMock([
+      jsonResponse({
+        providerName: 'edgestore',
+        requiresFileAccessCookie: false,
+      }),
+    ]);
+    const { EdgeStoreProvider, useEdgeStore } = createEdgeStoreProvider<any>();
+    const states: unknown[] = [];
+
+    function Consumer() {
+      states.push(useEdgeStore().state);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <EdgeStoreProvider>
+          <Consumer />
+        </EdgeStoreProvider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(states.at(-1)).toEqual({
+        loading: false,
+        initialized: true,
+        error: false,
+      });
+    });
+
+    expect(calls.map((call) => call.url)).toEqual(['/api/edgestore/init']);
+  });
+
+  it('calls _init for older or protected EdgeStore responses', async () => {
+    const { calls } = createFetchMock([
+      jsonResponse({
+        providerName: 'edgestore',
+        token: 'token_1',
+      }),
+      jsonResponse({ success: true }),
+    ]);
+    const { EdgeStoreProvider, useEdgeStore } = createEdgeStoreProvider<any>();
+
+    function Consumer() {
+      useEdgeStore();
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <EdgeStoreProvider>
+          <Consumer />
+        </EdgeStoreProvider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(calls).toHaveLength(2);
+    });
+
+    expect(calls[0]).toMatchObject({
+      url: '/api/edgestore/init',
+      init: {
+        method: 'POST',
+        credentials: 'include',
+      },
+    });
+    expect(calls[1]).toMatchObject({
+      url: 'https://files.edgestore.dev/_init',
+      init: {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'x-edgestore-token': 'token_1',
+        },
+      },
+    });
+  });
+
+  it('skips _init for non-EdgeStore providers', async () => {
+    const { calls } = createFetchMock([
+      jsonResponse({
+        providerName: 's3',
+      }),
+    ]);
+    const { EdgeStoreProvider, useEdgeStore } = createEdgeStoreProvider<any>();
+
+    function Consumer() {
+      useEdgeStore();
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <EdgeStoreProvider>
+          <Consumer />
+        </EdgeStoreProvider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(calls).toHaveLength(1);
+    });
+    expect(calls[0]?.url).toBe('/api/edgestore/init');
+  });
+
+  it('reset reruns initialization', async () => {
+    const { calls } = createFetchMock([
+      jsonResponse({
+        providerName: 'edgestore',
+        requiresFileAccessCookie: false,
+      }),
+      jsonResponse({
+        providerName: 'edgestore',
+        requiresFileAccessCookie: false,
+      }),
+    ]);
+    const { EdgeStoreProvider, useEdgeStore } = createEdgeStoreProvider<any>();
+    let reset: (() => Promise<void>) | undefined;
+
+    function Consumer() {
+      reset = useEdgeStore().reset;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <EdgeStoreProvider>
+          <Consumer />
+        </EdgeStoreProvider>,
+      );
+    });
+    await waitFor(() => {
+      expect(calls).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await reset?.();
+    });
+
+    expect(calls.map((call) => call.url)).toEqual([
+      '/api/edgestore/init',
+      '/api/edgestore/init',
+    ]);
+  });
+});

--- a/packages/react/src/createNextProxy.test.ts
+++ b/packages/react/src/createNextProxy.test.ts
@@ -152,12 +152,13 @@ async function waitForXhrs(count: number) {
 beforeEach(() => {
   MockXMLHttpRequest.instances = [];
   vi.stubGlobal('XMLHttpRequest', MockXMLHttpRequest);
-  process.env.NODE_ENV = 'test';
+  vi.stubEnv('NODE_ENV', 'test');
 });
 
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
 });
 
 describe('createNextProxy upload', () => {
@@ -413,7 +414,7 @@ describe('createNextProxy upload', () => {
   });
 
   it('rewrites protected URLs in development, but not public URLs or disabled proxies', async () => {
-    process.env.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
     const cases = [
       {
         response: uploadResponse({

--- a/packages/react/src/createNextProxy.test.ts
+++ b/packages/react/src/createNextProxy.test.ts
@@ -1,0 +1,481 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createNextProxy } from './createNextProxy';
+import EdgeStoreClientError from './libs/errors/EdgeStoreClientError';
+import { UploadAbortedError } from './libs/errors/uploadAbortedError';
+
+type FetchCall = {
+  url: string;
+  init: RequestInit | undefined;
+};
+
+class MockXMLHttpRequest extends EventTarget {
+  static instances: MockXMLHttpRequest[] = [];
+
+  method?: string;
+  url?: string;
+  body?: BodyInit | null;
+  status = 200;
+  upload = new EventTarget();
+  headers = new Map<string, string>();
+  responseHeaders = new Map<string, string>();
+
+  constructor() {
+    super();
+    MockXMLHttpRequest.instances.push(this);
+  }
+
+  open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+
+  setRequestHeader(name: string, value: string) {
+    this.headers.set(name, value);
+  }
+
+  getResponseHeader(name: string) {
+    return this.responseHeaders.get(name) ?? null;
+  }
+
+  send(body?: BodyInit | null) {
+    this.body = body;
+    this.dispatchEvent(new Event('loadstart'));
+  }
+
+  abort() {
+    this.dispatchEvent(new Event('abort'));
+  }
+
+  progress(loaded: number, total: number) {
+    this.upload.dispatchEvent(
+      new ProgressEvent('progress', {
+        lengthComputable: true,
+        loaded,
+        total,
+      }),
+    );
+  }
+
+  load(status = 200, eTag?: string) {
+    this.status = status;
+    if (eTag) {
+      this.responseHeaders.set('ETag', eTag);
+    }
+    this.dispatchEvent(new Event('load'));
+  }
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+function urlToString(url: string | URL | Request) {
+  return typeof url === 'string'
+    ? url
+    : url instanceof Request
+      ? url.url
+      : url.toString();
+}
+
+function createFetchMock(responses: Response[]) {
+  const calls: FetchCall[] = [];
+  const fetchMock = vi.fn(
+    async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({
+        url: urlToString(url),
+        init,
+      });
+      const response = responses.shift();
+      if (!response) {
+        throw new Error(`Unexpected fetch: ${urlToString(url)}`);
+      }
+      return response;
+    },
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  return { calls, fetchMock };
+}
+
+function uploadResponse(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    uploadUrl: 'https://uploads.example/file',
+    accessUrl: 'https://files.example/protected/file.txt',
+    thumbnailUrl: null,
+    size: 12,
+    uploadedAt: '2024-01-02T03:04:05.000Z',
+    path: {},
+    pathOrder: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function createProxy(opts?: {
+  uploadingCount?: number;
+  maxConcurrentUploads?: number;
+  disableDevProxy?: boolean;
+}) {
+  const uploadingCountRef = { current: opts?.uploadingCount ?? 0 };
+  const edgestore = createNextProxy<any>({
+    apiPath: '/api/edgestore',
+    uploadingCountRef,
+    maxConcurrentUploads: opts?.maxConcurrentUploads,
+    disableDevProxy: opts?.disableDevProxy,
+  });
+  return { assets: edgestore.assets!, edgestore, uploadingCountRef };
+}
+
+function getBody(call: FetchCall) {
+  return JSON.parse(call.init?.body as string);
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function waitForXhrs(count: number) {
+  for (let i = 0; i < 20; i++) {
+    if (MockXMLHttpRequest.instances.length >= count) {
+      return;
+    }
+    await flushMicrotasks();
+  }
+  expect(MockXMLHttpRequest.instances).toHaveLength(count);
+}
+
+beforeEach(() => {
+  MockXMLHttpRequest.instances = [];
+  vi.stubGlobal('XMLHttpRequest', MockXMLHttpRequest);
+  process.env.NODE_ENV = 'test';
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('createNextProxy upload', () => {
+  it('requests an upload with the expected body and uploads to the signed URL', async () => {
+    const { calls } = createFetchMock([jsonResponse(uploadResponse())]);
+    const { assets } = createProxy();
+    const file = new File(['hello'], 'avatar.png', { type: 'image/png' });
+    const progress = vi.fn();
+
+    const upload = assets.upload({
+      file,
+      input: { userId: 'user_1' },
+      options: {
+        manualFileName: 'profile.jpg',
+        replaceTargetUrl: 'https://files.example/old.png',
+        temporary: true,
+      },
+      onProgressChange: progress,
+    });
+
+    await waitForXhrs(1);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('/api/edgestore/request-upload');
+    expect(calls[0]?.init).toMatchObject({
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(getBody(calls[0]!)).toEqual({
+      bucketName: 'assets',
+      input: { userId: 'user_1' },
+      fileInfo: {
+        extension: 'jpg',
+        type: 'image/png',
+        size: file.size,
+        fileName: 'profile.jpg',
+        replaceTargetUrl: 'https://files.example/old.png',
+        temporary: true,
+      },
+    });
+
+    const xhr = MockXMLHttpRequest.instances[0]!;
+    expect(xhr.method).toBe('PUT');
+    expect(xhr.url).toBe('https://uploads.example/file');
+    expect(xhr.headers.get('x-ms-blob-type')).toBe('BlockBlob');
+    expect(xhr.body).toBe(file);
+
+    xhr.progress(3, 12);
+    xhr.load();
+
+    await expect(upload).resolves.toMatchObject({
+      url: 'https://files.example/protected/file.txt',
+      size: 12,
+      path: {},
+      pathOrder: [],
+      metadata: {},
+    });
+    expect((await upload).uploadedAt).toEqual(
+      new Date('2024-01-02T03:04:05.000Z'),
+    );
+    expect(progress).toHaveBeenCalledWith(25);
+  });
+
+  it.each([
+    {
+      name: 'File return uses returned file name extension',
+      transform: () =>
+        new File(['file'], 'converted.webp', { type: 'image/webp' }),
+      expected: {
+        extension: 'webp',
+        type: 'image/webp',
+        size: 4,
+      },
+    },
+    {
+      name: 'Blob return keeps original extension',
+      transform: () => new Blob(['blob'], { type: 'text/plain' }),
+      expected: {
+        extension: 'txt',
+        type: 'text/plain',
+        size: 4,
+      },
+    },
+    {
+      name: 'object return uses explicit extension',
+      transform: () => ({
+        file: new Blob(['data'], { type: 'application/json' }),
+        extension: 'json',
+      }),
+      expected: {
+        extension: 'json',
+        type: 'application/json',
+        size: 4,
+      },
+    },
+  ])('supports transform form: $name', async ({ transform, expected }) => {
+    const { calls } = createFetchMock([jsonResponse(uploadResponse())]);
+    const { assets } = createProxy();
+    const upload = assets.upload({
+      file: new File(['original'], 'original.txt', { type: 'text/plain' }),
+      options: { transform },
+    });
+
+    await waitForXhrs(1);
+    MockXMLHttpRequest.instances[0]!.load();
+    await upload;
+
+    expect(getBody(calls[0]!).fileInfo).toMatchObject(expected);
+  });
+
+  it('lets manualFileName extension override transform extension', async () => {
+    const { calls } = createFetchMock([jsonResponse(uploadResponse())]);
+    const { assets } = createProxy();
+    const upload = assets.upload({
+      file: new File(['original'], 'original.txt', { type: 'text/plain' }),
+      options: {
+        manualFileName: 'manual.csv',
+        transform: () =>
+          new File(['converted'], 'converted.webp', { type: 'image/webp' }),
+      },
+    });
+
+    await waitForXhrs(1);
+    MockXMLHttpRequest.instances[0]!.load();
+    await upload;
+
+    expect(getBody(calls[0]!).fileInfo).toMatchObject({
+      extension: 'csv',
+      fileName: 'manual.csv',
+      type: 'image/webp',
+    });
+  });
+
+  it('reports progress and aborts during upload', async () => {
+    createFetchMock([jsonResponse(uploadResponse())]);
+    const { assets } = createProxy();
+    const controller = new AbortController();
+    const progress = vi.fn();
+    const upload = assets.upload({
+      file: new File(['hello'], 'hello.txt'),
+      signal: controller.signal,
+      onProgressChange: progress,
+    });
+
+    await waitForXhrs(1);
+    const xhr = MockXMLHttpRequest.instances[0]!;
+    xhr.progress(1, 4);
+    controller.abort();
+
+    await expect(upload).rejects.toBeInstanceOf(UploadAbortedError);
+    expect(progress).toHaveBeenCalledWith(25);
+    expect(progress).toHaveBeenLastCalledWith(0);
+  });
+
+  it('rejects when aborted before the upload starts', async () => {
+    createFetchMock([jsonResponse(uploadResponse())]);
+    const { assets } = createProxy();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      assets.upload({
+        file: new File(['hello'], 'hello.txt'),
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(UploadAbortedError);
+  });
+
+  it('queues uploads above maxConcurrentUploads', async () => {
+    vi.useFakeTimers();
+    createFetchMock([
+      jsonResponse(
+        uploadResponse({ uploadUrl: 'https://uploads.example/one' }),
+      ),
+      jsonResponse(
+        uploadResponse({ uploadUrl: 'https://uploads.example/two' }),
+      ),
+    ]);
+    const { assets } = createProxy({ maxConcurrentUploads: 1 });
+
+    const first = assets.upload({
+      file: new File(['one'], 'one.txt'),
+    });
+    await waitForXhrs(1);
+
+    const second = assets.upload({
+      file: new File(['two'], 'two.txt'),
+    });
+    await waitForXhrs(1);
+
+    expect(MockXMLHttpRequest.instances).toHaveLength(1);
+    MockXMLHttpRequest.instances[0]!.load();
+    await first;
+
+    await vi.advanceTimersByTimeAsync(300);
+    await flushMicrotasks();
+
+    expect(MockXMLHttpRequest.instances).toHaveLength(2);
+    expect(MockXMLHttpRequest.instances[1]!.url).toBe(
+      'https://uploads.example/two',
+    );
+    MockXMLHttpRequest.instances[1]!.load();
+    await second;
+  });
+
+  it('uploads multipart parts and completes the multipart upload', async () => {
+    const { calls } = createFetchMock([
+      jsonResponse({
+        ...uploadResponse({ uploadUrl: undefined }),
+        multipart: {
+          uploadId: 'upload_1',
+          key: 'bucket/key',
+          partSize: 2,
+          totalParts: 2,
+          parts: [
+            { partNumber: 1, uploadUrl: 'https://uploads.example/part-1' },
+            { partNumber: 2, uploadUrl: 'https://uploads.example/part-2' },
+          ],
+        },
+      }),
+      jsonResponse({ success: true }),
+    ]);
+    const { assets } = createProxy();
+    const progress = vi.fn();
+    const upload = assets.upload({
+      file: new File(['abcd'], 'data.bin'),
+      onProgressChange: progress,
+    });
+
+    await waitForXhrs(2);
+    MockXMLHttpRequest.instances[0]!.progress(2, 2);
+    MockXMLHttpRequest.instances[0]!.load(200, 'etag-1');
+    MockXMLHttpRequest.instances[1]!.progress(2, 2);
+    MockXMLHttpRequest.instances[1]!.load(200, 'etag-2');
+
+    await upload;
+
+    expect(calls[1]?.url).toBe('/api/edgestore/complete-multipart-upload');
+    expect(getBody(calls[1]!)).toEqual({
+      bucketName: 'assets',
+      uploadId: 'upload_1',
+      key: 'bucket/key',
+      parts: [
+        { partNumber: 1, eTag: 'etag-1' },
+        { partNumber: 2, eTag: 'etag-2' },
+      ],
+    });
+    expect(progress).toHaveBeenCalledWith(50);
+    expect(progress).toHaveBeenCalledWith(100);
+  });
+
+  it('rewrites protected URLs in development, but not public URLs or disabled proxies', async () => {
+    process.env.NODE_ENV = 'development';
+    const cases = [
+      {
+        response: uploadResponse({
+          accessUrl: 'https://files.example/protected/file.txt',
+        }),
+        disableDevProxy: false,
+        expected:
+          'http://localhost/api/edgestore/proxy-file?url=https%3A%2F%2Ffiles.example%2Fprotected%2Ffile.txt',
+      },
+      {
+        response: uploadResponse({
+          accessUrl: 'https://files.example/_public/file.txt',
+        }),
+        disableDevProxy: false,
+        expected: 'https://files.example/_public/file.txt',
+      },
+      {
+        response: uploadResponse({
+          accessUrl: 'https://files.example/protected/file.txt',
+        }),
+        disableDevProxy: true,
+        expected: 'https://files.example/protected/file.txt',
+      },
+    ];
+
+    for (const testCase of cases) {
+      createFetchMock([jsonResponse(testCase.response)]);
+      const { assets } = createProxy({
+        disableDevProxy: testCase.disableDevProxy,
+      });
+      const upload = assets.upload({
+        file: new File(['hello'], 'hello.txt'),
+      });
+
+      await waitForXhrs(MockXMLHttpRequest.instances.length + 1);
+      MockXMLHttpRequest.instances.at(-1)!.load();
+
+      await expect(upload).resolves.toMatchObject({
+        url: testCase.expected,
+      });
+      vi.unstubAllGlobals();
+      vi.stubGlobal('XMLHttpRequest', MockXMLHttpRequest);
+    }
+  });
+});
+
+describe('createNextProxy confirmUpload/delete', () => {
+  it('throws when confirmUpload returns success false', async () => {
+    createFetchMock([jsonResponse({ success: false })]);
+    const { assets } = createProxy();
+
+    await expect(
+      assets.confirmUpload({ url: 'https://files.example/file.txt' }),
+    ).rejects.toBeInstanceOf(EdgeStoreClientError);
+  });
+
+  it('throws when delete returns success false', async () => {
+    createFetchMock([jsonResponse({ success: false })]);
+    const { assets } = createProxy();
+
+    await expect(
+      assets.delete({ url: 'https://files.example/file.txt' }),
+    ).rejects.toBeInstanceOf(EdgeStoreClientError);
+  });
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@edgestore/shared': path.resolve(__dirname, '../shared/src/index.ts'),
+      zod: path.resolve(__dirname, 'node_modules/zod'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost/',
+      },
+    },
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    restoreMocks: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 0.33.0
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jsdom@29.1.1)(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
 
   docs:
     dependencies:
@@ -894,6 +894,9 @@ importers:
       '@types/uuid':
         specifier: ^9.0.1
         version: 9.0.1
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       next:
         specifier: 16.1.1
         version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1062,6 +1065,21 @@ packages:
   '@antfu/ni@23.3.1':
     resolution: {integrity: sha512-C90iyzm/jLV7Lomv2UzwWUzRv9WZr1oRsFRKsX5HjQL4EXrbi9H/RtBkjCP+NF+ABZXUKpAa4F1dkoTaea4zHg==}
     hasBin: true
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@astrojs/compiler@2.12.0':
     resolution: {integrity: sha512-7bCjW6tVDpUurQLeKBUN9tZ5kSv5qYrGmcn0sG0IwacL7isR2ZbyyA3AdZ4uxsuUFOS2SlgReTH7wkxO6zpqWA==}
@@ -1963,6 +1981,10 @@ packages:
     resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@bundled-es-modules/cookie@2.0.1':
     resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
 
@@ -2039,6 +2061,42 @@ packages:
   '@cloudflare/kv-asset-handler@0.3.4':
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
     engines: {node: '>=16.13'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@deno/shim-deno-test@0.5.0':
     resolution: {integrity: sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==}
@@ -2810,6 +2868,15 @@ packages:
   '@eslint/js@8.55.0':
     resolution: {integrity: sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
@@ -5810,9 +5877,11 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/nft@0.27.10':
     resolution: {integrity: sha512-zbaF9Wp/NsZtKLE4uVmL3FyfFwlpDyuymQM1kPbeT0mVOHKDQQNjnnfslB3REg3oZprmNFJuh3pkHBk2qAaizg==}
@@ -6208,6 +6277,9 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -6668,6 +6740,10 @@ packages:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -6680,11 +6756,16 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
   dax-sh@0.39.2:
     resolution: {integrity: sha512-gpuGEkBQM+5y6p4cWaw9+ePy5TNon+fdwFVtTI8leU3UhwhsBfPewRxMXGuQNC+M2b/MDGMlfgpqynkcd0C3FQ==}
+    deprecated: This package has moved to simply be 'dax' instead of 'dax-sh'
 
   db0@0.2.4:
     resolution: {integrity: sha512-hIzftLH1nMsF95zSLjDLYLbE9huOXnLYUTAQ5yKF5amp0FpeD+B15XJa8BvGYSOeSCH4gl2WahB/y1FcUByQSg==}
@@ -6751,6 +6832,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -6984,6 +7068,10 @@ packages:
   entities@6.0.0:
     resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -7657,11 +7745,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -7823,6 +7912,10 @@ packages:
   hosted-git-info@6.1.1:
     resolution: {integrity: sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -8079,6 +8172,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
@@ -8211,6 +8307,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
@@ -8505,6 +8610,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -8619,6 +8728,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -9322,6 +9434,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -9667,6 +9782,10 @@ packages:
 
   punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
+    engines: {node: '>=6'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   qs@6.11.0:
@@ -10142,6 +10261,10 @@ packages:
   sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -10517,6 +10640,9 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
@@ -10561,10 +10687,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -10647,6 +10775,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.4:
+    resolution: {integrity: sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==}
+
+  tldts@7.4.4:
+    resolution: {integrity: sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==}
+    hasBin: true
+
   to-readable-stream@1.0.0:
     resolution: {integrity: sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==}
     engines: {node: '>=6'}
@@ -10667,8 +10802,16 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -10852,6 +10995,10 @@ packages:
   undici@6.21.2:
     resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
     engines: {node: '>=18.17'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unenv@1.10.0:
     resolution: {integrity: sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==}
@@ -11133,10 +11280,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@0.41.0:
@@ -11304,6 +11453,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.5.0:
     resolution: {integrity: sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==}
     engines: {node: '>=10.13.0'}
@@ -11324,6 +11477,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
@@ -11340,6 +11497,14 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -11406,6 +11571,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
     engines: {node: '>=4.0.0'}
@@ -11413,6 +11582,9 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -11553,6 +11725,26 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@antfu/ni@23.3.1': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@astrojs/compiler@2.12.0': {}
 
@@ -13312,6 +13504,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@bundled-es-modules/cookie@2.0.1':
     dependencies:
       cookie: 0.7.2
@@ -13495,6 +13691,30 @@ snapshots:
   '@cloudflare/kv-asset-handler@0.3.4':
     dependencies:
       mime: 3.0.0
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@deno/shim-deno-test@0.5.0': {}
 
@@ -13923,6 +14143,8 @@ snapshots:
   '@eslint/js@8.40.0': {}
 
   '@eslint/js@8.55.0': {}
+
+  '@exodus/bytes@1.15.1': {}
 
   '@fastify/ajv-compiler@4.0.2':
     dependencies:
@@ -18066,6 +18288,10 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   binary-extensions@2.2.0: {}
 
   bindings@1.5.0:
@@ -18582,11 +18808,23 @@ snapshots:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   dataloader@1.4.0: {}
 
@@ -18621,6 +18859,8 @@ snapshots:
       map-obj: 1.0.1
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -18809,6 +19049,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@6.0.0: {}
+
+  entities@8.0.0: {}
 
   err-code@2.0.3: {}
 
@@ -20145,6 +20387,12 @@ snapshots:
     dependencies:
       lru-cache: 7.18.3
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
@@ -20368,6 +20616,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -20487,6 +20737,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@0.5.0: {}
 
@@ -20734,6 +21010,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -20959,6 +21237,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.12.2: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
 
@@ -21913,6 +22193,10 @@ snapshots:
     dependencies:
       entities: 6.0.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -22165,6 +22449,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.0: {}
+
+  punycode@2.3.1: {}
 
   qs@6.11.0:
     dependencies:
@@ -22773,6 +23059,10 @@ snapshots:
 
   sax@1.2.4: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   schema-utils@4.3.3:
@@ -23279,6 +23569,8 @@ snapshots:
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
 
+  symbol-tree@3.2.4: {}
+
   system-architecture@0.1.0: {}
 
   tailwind-merge@1.13.2: {}
@@ -23424,6 +23716,12 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.4: {}
+
+  tldts@7.4.4:
+    dependencies:
+      tldts-core: 7.4.4
+
   to-readable-stream@1.0.0: {}
 
   to-regex-range@5.0.1:
@@ -23441,7 +23739,15 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.4
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -23602,6 +23908,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici@6.21.2: {}
+
+  undici@7.28.0: {}
 
   unenv@1.10.0:
     dependencies:
@@ -24025,7 +24333,7 @@ snapshots:
     optionalDependencies:
       vite: 6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jsdom@29.1.1)(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
@@ -24050,8 +24358,13 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.0.3
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   watchpack@2.5.0:
     dependencies:
@@ -24070,6 +24383,8 @@ snapshots:
   web-vitals@4.2.4: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-sources@3.3.3:
     optional: true
@@ -24106,6 +24421,16 @@ snapshots:
       - esbuild
       - uglify-js
     optional: true
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -24186,12 +24511,16 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  xml-name-validator@5.0.0: {}
+
   xml2js@0.5.0:
     dependencies:
       sax: 1.2.4
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- add Vitest/jsdom runtime test setup for @edgestore/react
- cover createNextProxy upload bodies, transforms, progress/abort, queueing, multipart completion, dev proxy behavior, and confirm/delete failures
- cover provider initialization paths for public/protected/older EdgeStore responses, non-EdgeStore providers, and reset

## Verification
- pnpm --filter @edgestore/react test
- pnpm --filter @edgestore/shared build && pnpm --filter @edgestore/react typecheck

Note: shared build emits the existing Rollup TypeScript warning about optional zod resolution but exits successfully.