### PR TITLE
fix(react): typecheck against shared source

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,12 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "baseUrl": "../..",
-    "paths": {
-      "@edgestore/react": ["packages/react/src"],
-      "@edgestore/react/*": ["packages/react/src/*"],
-      "@edgestore/shared": ["packages/shared/src"]
-    }
-  },
   "include": ["src"]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,4 +1,12 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "@edgestore/react": ["packages/react/src"],
+      "@edgestore/react/*": ["packages/react/src/*"],
+      "@edgestore/shared": ["packages/shared/src"]
+    }
+  },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "baseUrl": ".",
     "paths": {
       "@edgestore/react": ["packages/react/src"],
-      "@edgestore/react/*": ["packages/react/src/*"]
+      "@edgestore/react/*": ["packages/react/src/*"],
+      "@edgestore/shared": ["packages/shared/src"]
     },
     "types": ["node"]
   }


### PR DESCRIPTION
## Summary
- add React-local TypeScript path mapping for @edgestore/shared to packages/shared/src
- allow pnpm --filter @edgestore/react typecheck to pass without requiring packages/shared/dist first

## Verification
- rm -rf packages/shared/dist packages/react/dist
- pnpm --filter @edgestore/react typecheck
- pnpm --filter @edgestore/shared typecheck

## Notes
This intentionally does not change React build/declaration emit config. Direct React build may still warn about unresolved @edgestore/shared when shared/dist is absent, but direct React typecheck no longer depends on built shared output.