### PR TITLE
fix(server): preserve proxy file response status

### DIFF
--- a/.changeset/preserve-proxy-response-status.md
+++ b/.changeset/preserve-proxy-response-status.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/server": patch
+---
+
+Preserve upstream response status codes when proxying files through server adapters.

--- a/packages/server/src/adapters/astro/index.ts
+++ b/packages/server/src/adapters/astro/index.ts
@@ -14,6 +14,7 @@ import {
   completeMultipartUpload,
   confirmUpload,
   deleteFile,
+  fetchProxyFile,
   getCookieConfig,
   init,
   requestUpload,
@@ -171,22 +172,18 @@ export function createEdgeStoreAstroHandler<TCtx>(config: Config<TCtx>) {
         const url = new URL(request.url).searchParams.get('url');
 
         if (typeof url === 'string') {
-          const cookieHeader = request.headers.get('cookie') ?? '';
-
-          const proxyRes = await fetch(url, {
-            headers: {
-              cookie: cookieHeader,
-            },
+          const proxyRes = await fetchProxyFile({
+            cookieHeader: request.headers.get('cookie') ?? undefined,
+            url,
           });
 
-          const data = await proxyRes.arrayBuffer();
           const headers = new Headers();
-          headers.set(
-            'Content-Type',
-            proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
-          );
+          headers.set('Content-Type', proxyRes.contentType);
 
-          return new Response(data, { headers });
+          return new Response(proxyRes.body, {
+            headers,
+            status: proxyRes.status,
+          });
         } else {
           return new Response(null, { status: 400 });
         }

--- a/packages/server/src/adapters/express/index.test.ts
+++ b/packages/server/src/adapters/express/index.test.ts
@@ -200,7 +200,7 @@ describe('Express adapter conformance', () => {
         cookie: 'session=abc; theme=dark',
       },
     });
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(202);
     expect(res.headers['Content-Type']).toBe('text/custom');
     expect(Buffer.isBuffer(res.body)).toBe(true);
     expect((res.body as Buffer).toString()).toBe('proxied body');

--- a/packages/server/src/adapters/express/index.ts
+++ b/packages/server/src/adapters/express/index.ts
@@ -14,6 +14,7 @@ import {
   completeMultipartUpload,
   confirmUpload,
   deleteFile,
+  fetchProxyFile,
   getCookieConfig,
   init,
   requestUpload,
@@ -131,20 +132,14 @@ export function createEdgeStoreExpressHandler<TCtx>(config: Config<TCtx>) {
       } else if (matchPath(pathname, '/proxy-file')) {
         const { url } = req.query;
         if (typeof url === 'string') {
-          const proxyRes = await fetch(url, {
-            headers: {
-              cookie: req.headers.cookie ?? '',
-            },
+          const proxyRes = await fetchProxyFile({
+            cookieHeader: req.headers.cookie,
+            url,
           });
 
-          const data = await proxyRes.arrayBuffer();
-          res.setHeader(
-            'Content-Type',
-            proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
-          );
-
+          res.setHeader('Content-Type', proxyRes.contentType);
           res.status(proxyRes.status);
-          res.end(Buffer.from(data));
+          res.end(Buffer.from(proxyRes.body));
         } else {
           res.status(400).end();
         }

--- a/packages/server/src/adapters/express/index.ts
+++ b/packages/server/src/adapters/express/index.ts
@@ -143,6 +143,7 @@ export function createEdgeStoreExpressHandler<TCtx>(config: Config<TCtx>) {
             proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
           );
 
+          res.status(proxyRes.status);
           res.end(Buffer.from(data));
         } else {
           res.status(400).end();

--- a/packages/server/src/adapters/express/index.ts
+++ b/packages/server/src/adapters/express/index.ts
@@ -139,7 +139,9 @@ export function createEdgeStoreExpressHandler<TCtx>(config: Config<TCtx>) {
 
           res.setHeader('Content-Type', proxyRes.contentType);
           res.status(proxyRes.status);
-          res.end(Buffer.from(proxyRes.body));
+          res.end(
+            proxyRes.body === null ? undefined : Buffer.from(proxyRes.body),
+          );
         } else {
           res.status(400).end();
         }

--- a/packages/server/src/adapters/fastify/index.ts
+++ b/packages/server/src/adapters/fastify/index.ts
@@ -14,6 +14,7 @@ import {
   completeMultipartUpload,
   confirmUpload,
   deleteFile,
+  fetchProxyFile,
   getCookieConfig,
   init,
   requestUpload,
@@ -171,21 +172,14 @@ export function createEdgeStoreFastifyHandler<TCtx>(config: Config<TCtx>) {
           : undefined;
 
         if (typeof url === 'string') {
-          const cookieHeader = req.headers.cookie ?? '';
-
-          const proxyRes = await fetch(url, {
-            headers: {
-              cookie: cookieHeader,
-            },
+          const proxyRes = await fetchProxyFile({
+            cookieHeader: req.headers.cookie,
+            url,
           });
 
-          const data = await proxyRes.arrayBuffer();
-          void reply.header(
-            'Content-Type',
-            proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
-          );
+          void reply.header('Content-Type', proxyRes.contentType);
 
-          return reply.send(Buffer.from(data));
+          return reply.status(proxyRes.status).send(Buffer.from(proxyRes.body));
         } else {
           return reply.status(400).send();
         }

--- a/packages/server/src/adapters/fastify/index.ts
+++ b/packages/server/src/adapters/fastify/index.ts
@@ -179,7 +179,11 @@ export function createEdgeStoreFastifyHandler<TCtx>(config: Config<TCtx>) {
 
           void reply.header('Content-Type', proxyRes.contentType);
 
-          return reply.status(proxyRes.status).send(Buffer.from(proxyRes.body));
+          return reply
+            .status(proxyRes.status)
+            .send(
+              proxyRes.body === null ? undefined : Buffer.from(proxyRes.body),
+            );
         } else {
           return reply.status(400).send();
         }

--- a/packages/server/src/adapters/hono/index.test.ts
+++ b/packages/server/src/adapters/hono/index.test.ts
@@ -133,7 +133,7 @@ describe('Hono adapter conformance', () => {
         cookie: 'session=abc; theme=dark',
       },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(202);
     expect(res.headers.get('content-type')).toBe('text/custom');
     await expect(res.text()).resolves.toBe('proxied body');
   });

--- a/packages/server/src/adapters/hono/index.ts
+++ b/packages/server/src/adapters/hono/index.ts
@@ -14,6 +14,7 @@ import {
   completeMultipartUpload,
   confirmUpload,
   deleteFile,
+  fetchProxyFile,
   getCookieConfig,
   init,
   requestUpload,
@@ -155,21 +156,15 @@ export function createEdgeStoreHonoHandler<TCtx>(config: Config<TCtx>) {
         const url = c.req.query('url');
 
         if (typeof url === 'string') {
-          const cookieHeader = c.req.header('cookie') ?? '';
-
-          const proxyRes = await fetch(url, {
-            headers: {
-              cookie: cookieHeader,
-            },
+          const proxyRes = await fetchProxyFile({
+            cookieHeader: c.req.header('cookie'),
+            url,
           });
 
-          const data = await proxyRes.arrayBuffer();
-          return new Response(Buffer.from(data), {
+          return new Response(Buffer.from(proxyRes.body), {
             status: proxyRes.status,
             headers: {
-              'Content-Type':
-                proxyRes.headers.get('Content-Type') ??
-                'application/octet-stream',
+              'Content-Type': proxyRes.contentType,
             },
           });
         } else {

--- a/packages/server/src/adapters/hono/index.ts
+++ b/packages/server/src/adapters/hono/index.ts
@@ -161,12 +161,15 @@ export function createEdgeStoreHonoHandler<TCtx>(config: Config<TCtx>) {
             url,
           });
 
-          return new Response(Buffer.from(proxyRes.body), {
-            status: proxyRes.status,
-            headers: {
-              'Content-Type': proxyRes.contentType,
+          return new Response(
+            proxyRes.body === null ? null : Buffer.from(proxyRes.body),
+            {
+              status: proxyRes.status,
+              headers: {
+                'Content-Type': proxyRes.contentType,
+              },
             },
-          });
+          );
         } else {
           return c.body(null, 400);
         }

--- a/packages/server/src/adapters/hono/index.ts
+++ b/packages/server/src/adapters/hono/index.ts
@@ -164,12 +164,14 @@ export function createEdgeStoreHonoHandler<TCtx>(config: Config<TCtx>) {
           });
 
           const data = await proxyRes.arrayBuffer();
-          c.header(
-            'Content-Type',
-            proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
-          );
-
-          return c.body(Buffer.from(data));
+          return new Response(Buffer.from(data), {
+            status: proxyRes.status,
+            headers: {
+              'Content-Type':
+                proxyRes.headers.get('Content-Type') ??
+                'application/octet-stream',
+            },
+          });
         } else {
           return c.body(null, 400);
         }

--- a/packages/server/src/adapters/next/app/index.ts
+++ b/packages/server/src/adapters/next/app/index.ts
@@ -14,6 +14,7 @@ import {
   completeMultipartUpload,
   confirmUpload,
   deleteFile,
+  fetchProxyFile,
   getCookieConfig,
   init,
   requestUpload,
@@ -166,19 +167,15 @@ export function createEdgeStoreNextHandler<TCtx>(config: Config<TCtx>) {
       } else if (matchPath(pathname, '/proxy-file')) {
         const url = req.nextUrl.searchParams.get('url');
         if (typeof url === 'string') {
-          const proxyRes = await fetch(url, {
-            headers: {
-              cookie: req.cookies.toString() ?? '',
-            },
+          const proxyRes = await fetchProxyFile({
+            cookieHeader: req.cookies.toString(),
+            url,
           });
 
-          const data = await proxyRes.arrayBuffer();
-          return new Response(data, {
+          return new Response(proxyRes.body, {
             status: proxyRes.status,
             headers: {
-              'Content-Type':
-                proxyRes.headers.get('Content-Type') ??
-                'application/octet-stream',
+              'Content-Type': proxyRes.contentType,
             },
           });
         } else {

--- a/packages/server/src/adapters/next/pages/index.ts
+++ b/packages/server/src/adapters/next/pages/index.ts
@@ -146,7 +146,9 @@ export function createEdgeStoreNextHandler<TCtx>(config: Config<TCtx>) {
           res.setHeader('Content-Type', proxyRes.contentType);
 
           res.status(proxyRes.status);
-          res.end(Buffer.from(proxyRes.body));
+          res.end(
+            proxyRes.body === null ? undefined : Buffer.from(proxyRes.body),
+          );
         } else {
           res.status(400).end();
         }

--- a/packages/server/src/adapters/next/pages/index.ts
+++ b/packages/server/src/adapters/next/pages/index.ts
@@ -14,6 +14,7 @@ import {
   completeMultipartUpload,
   confirmUpload,
   deleteFile,
+  fetchProxyFile,
   getCookieConfig,
   init,
   requestUpload,
@@ -137,19 +138,15 @@ export function createEdgeStoreNextHandler<TCtx>(config: Config<TCtx>) {
       } else if (matchPath(pathname, '/proxy-file')) {
         const { url } = req.query;
         if (typeof url === 'string') {
-          const proxyRes = await fetch(url, {
-            headers: {
-              cookie: req.headers.cookie ?? '',
-            },
+          const proxyRes = await fetchProxyFile({
+            cookieHeader: req.headers.cookie,
+            url,
           });
 
-          const data = await proxyRes.arrayBuffer();
-          res.setHeader(
-            'Content-Type',
-            proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
-          );
+          res.setHeader('Content-Type', proxyRes.contentType);
 
-          res.end(Buffer.from(data));
+          res.status(proxyRes.status);
+          res.end(Buffer.from(proxyRes.body));
         } else {
           res.status(400).end();
         }

--- a/packages/server/src/adapters/proxy-file-status.test.ts
+++ b/packages/server/src/adapters/proxy-file-status.test.ts
@@ -1,10 +1,18 @@
 import { createServer, request as httpRequest, type Server } from 'node:http';
 import { type EdgeStoreRouter, type Provider } from '@edgestore/shared';
 import express from 'express';
+import fastify from 'fastify';
 import { Hono } from 'hono';
+import { type NextApiRequest, type NextApiResponse } from 'next/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createEdgeStoreAstroHandler } from './astro';
 import { createEdgeStoreExpressHandler } from './express';
+import { createEdgeStoreFastifyHandler } from './fastify';
 import { createEdgeStoreHonoHandler } from './hono';
+import { createEdgeStoreNextHandler as createEdgeStoreNextAppHandler } from './next/app';
+import { createEdgeStoreNextHandler as createEdgeStoreNextPagesHandler } from './next/pages';
+import { createEdgeStoreRemixHandler } from './remix';
+import { createEdgeStoreStartHandler } from './start';
 
 function createProvider(): Provider {
   return {
@@ -67,6 +75,26 @@ async function createExpressServer() {
   };
 }
 
+async function createFastifyServer() {
+  const handler = createEdgeStoreFastifyHandler({
+    provider: createProvider(),
+    router: createRouter(),
+  });
+  const app = fastify();
+  app.all('/edgestore/*', handler);
+  await app.listen({ host: '127.0.0.1', port: 0 });
+
+  const address = app.server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Could not determine test server address');
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/edgestore`,
+    close: () => app.close(),
+  };
+}
+
 function closeServer(server: Server) {
   return new Promise<void>((resolve, reject) => {
     server.close((err) => {
@@ -77,6 +105,38 @@ function closeServer(server: Server) {
       }
     });
   });
+}
+
+function createNextPagesResponse() {
+  const headers = new Map<string, string | number | readonly string[]>();
+  let body: Buffer | undefined;
+  let statusCode: number | undefined;
+
+  const res = {
+    end: vi.fn((data?: Buffer) => {
+      body = data;
+      return res;
+    }),
+    json: vi.fn(),
+    send: vi.fn(),
+    setHeader: vi.fn(
+      (name: string, value: string | number | readonly string[]) => {
+        headers.set(name.toLowerCase(), value);
+        return res;
+      },
+    ),
+    status: vi.fn((status: number) => {
+      statusCode = status;
+      return res;
+    }),
+  } as unknown as NextApiResponse;
+
+  return {
+    getBody: () => body?.toString('utf8'),
+    getHeader: (name: string) => headers.get(name.toLowerCase()),
+    getStatus: () => statusCode,
+    res,
+  };
 }
 
 function request({ cookie, url }: { cookie: string; url: string }) {
@@ -152,6 +212,40 @@ describe('Express proxy-file', () => {
   });
 });
 
+describe('Fastify proxy-file', () => {
+  it('returns the upstream status while preserving body and Content-Type', async () => {
+    const fetchMock = mockProxyFetch({
+      body: 'missing file',
+      contentType: 'text/plain',
+      status: 404,
+    });
+    const server = await createFastifyServer();
+
+    try {
+      const res = await request({
+        cookie: 'session=abc',
+        url: `${server.baseUrl}/proxy-file?url=${encodeURIComponent(
+          'https://files.example.com/missing.txt',
+        )}`,
+      });
+
+      expect(res.status).toBe(404);
+      expect(res.contentType).toBe('text/plain');
+      expect(res.body).toBe('missing file');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://files.example.com/missing.txt',
+        {
+          headers: {
+            cookie: 'session=abc',
+          },
+        },
+      );
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('Hono proxy-file', () => {
   it('returns the upstream status while preserving body and Content-Type', async () => {
     const fetchMock = mockProxyFetch({
@@ -180,6 +274,194 @@ describe('Hono proxy-file', () => {
     expect(await res.text()).toBe('rate limited');
     expect(fetchMock).toHaveBeenCalledWith(
       'https://files.example.com/blocked.json',
+      {
+        headers: {
+          cookie: 'session=abc',
+        },
+      },
+    );
+  });
+});
+
+describe('Remix proxy-file', () => {
+  it('returns the upstream status while preserving body and Content-Type', async () => {
+    const fetchMock = mockProxyFetch({
+      body: 'remix denied',
+      contentType: 'application/json',
+      status: 401,
+    });
+    const handler = createEdgeStoreRemixHandler({
+      provider: createProvider(),
+      router: createRouter(),
+    });
+
+    const res = await handler({
+      request: new Request(
+        'https://app.example.com/edgestore/proxy-file?url=https%3A%2F%2Ffiles.example.com%2Fremix.json',
+        {
+          headers: {
+            Cookie: 'session=abc',
+          },
+        },
+      ),
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(await res.text()).toBe('remix denied');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://files.example.com/remix.json',
+      {
+        headers: {
+          cookie: 'session=abc',
+        },
+      },
+    );
+  });
+});
+
+describe('Astro proxy-file', () => {
+  it('returns the upstream status while preserving body and Content-Type', async () => {
+    const fetchMock = mockProxyFetch({
+      body: 'astro throttled',
+      contentType: 'text/html',
+      status: 503,
+    });
+    const handler = createEdgeStoreAstroHandler({
+      provider: createProvider(),
+      router: createRouter(),
+    });
+
+    const res = await handler({
+      request: new Request(
+        'https://app.example.com/edgestore/proxy-file?url=https%3A%2F%2Ffiles.example.com%2Fastro.html',
+        {
+          headers: {
+            Cookie: 'session=abc',
+          },
+        },
+      ),
+    } as Parameters<typeof handler>[0]);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get('Content-Type')).toBe('text/html');
+    expect(await res.text()).toBe('astro throttled');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://files.example.com/astro.html',
+      {
+        headers: {
+          cookie: 'session=abc',
+        },
+      },
+    );
+  });
+});
+
+describe('Next Pages proxy-file', () => {
+  it('returns the upstream status while preserving body and Content-Type', async () => {
+    const fetchMock = mockProxyFetch({
+      body: 'next pages denied',
+      contentType: 'application/octet-stream',
+      status: 410,
+    });
+    const handler = createEdgeStoreNextPagesHandler({
+      provider: createProvider(),
+      router: createRouter(),
+    });
+    const response = createNextPagesResponse();
+
+    await handler(
+      {
+        cookies: {},
+        headers: {
+          cookie: 'session=abc',
+        },
+        query: {
+          url: 'https://files.example.com/next-pages.bin',
+        },
+        url: '/edgestore/proxy-file?url=https%3A%2F%2Ffiles.example.com%2Fnext-pages.bin',
+      } as unknown as NextApiRequest,
+      response.res,
+    );
+
+    expect(response.getStatus()).toBe(410);
+    expect(response.getHeader('Content-Type')).toBe('application/octet-stream');
+    expect(response.getBody()).toBe('next pages denied');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://files.example.com/next-pages.bin',
+      {
+        headers: {
+          cookie: 'session=abc',
+        },
+      },
+    );
+  });
+});
+
+describe('Next App proxy-file', () => {
+  it('returns the upstream status while preserving body and Content-Type', async () => {
+    const fetchMock = mockProxyFetch({
+      body: 'next app denied',
+      contentType: 'text/plain',
+      status: 451,
+    });
+    const handler = createEdgeStoreNextAppHandler({
+      provider: createProvider(),
+      router: createRouter(),
+    });
+    const nextUrl = new URL(
+      'https://app.example.com/edgestore/proxy-file?url=https%3A%2F%2Ffiles.example.com%2Fnext-app.txt',
+    );
+
+    const res = await handler({
+      cookies: {
+        toString: () => 'session=abc',
+      },
+      nextUrl,
+    } as Parameters<typeof handler>[0]);
+
+    expect(res.status).toBe(451);
+    expect(res.headers.get('Content-Type')).toBe('text/plain');
+    expect(await res.text()).toBe('next app denied');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://files.example.com/next-app.txt',
+      {
+        headers: {
+          cookie: 'session=abc',
+        },
+      },
+    );
+  });
+});
+
+describe('Start proxy-file', () => {
+  it('returns the upstream status while preserving body and Content-Type', async () => {
+    const fetchMock = mockProxyFetch({
+      body: 'start unavailable',
+      contentType: 'application/json',
+      status: 502,
+    });
+    const handler = createEdgeStoreStartHandler({
+      provider: createProvider(),
+      router: createRouter(),
+    });
+
+    const res = await handler({
+      request: new Request(
+        'https://app.example.com/edgestore/proxy-file?url=https%3A%2F%2Ffiles.example.com%2Fstart.json',
+        {
+          headers: {
+            Cookie: 'session=abc',
+          },
+        },
+      ),
+    });
+
+    expect(res.status).toBe(502);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(await res.text()).toBe('start unavailable');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://files.example.com/start.json',
       {
         headers: {
           cookie: 'session=abc',

--- a/packages/server/src/adapters/proxy-file-status.test.ts
+++ b/packages/server/src/adapters/proxy-file-status.test.ts
@@ -1,0 +1,190 @@
+import { createServer, request as httpRequest, type Server } from 'node:http';
+import { type EdgeStoreRouter, type Provider } from '@edgestore/shared';
+import express from 'express';
+import { Hono } from 'hono';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createEdgeStoreExpressHandler } from './express';
+import { createEdgeStoreHonoHandler } from './hono';
+
+function createProvider(): Provider {
+  return {
+    name: 'test-provider',
+    init: vi.fn(() => ({ token: 'provider-token' })),
+    getBaseUrl: vi.fn(() => 'https://files.example.com'),
+    getFile: vi.fn(),
+    requestUpload: vi.fn(),
+    requestUploadParts: vi.fn(),
+    completeMultipartUpload: vi.fn(),
+    confirmUpload: vi.fn(),
+    deleteFile: vi.fn(),
+  };
+}
+
+function createRouter() {
+  return {} as EdgeStoreRouter<Record<string, never>>;
+}
+
+function mockProxyFetch({
+  body,
+  contentType,
+  status,
+}: {
+  body: string;
+  contentType: string;
+  status: number;
+}) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(body, {
+      status,
+      headers: {
+        'Content-Type': contentType,
+      },
+    }),
+  );
+}
+
+async function createExpressServer() {
+  const handler = createEdgeStoreExpressHandler({
+    provider: createProvider(),
+    router: createRouter(),
+  });
+  const app = express();
+  app.use('/edgestore', handler);
+
+  const server = createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Could not determine test server address');
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/edgestore`,
+    close: () => closeServer(server),
+  };
+}
+
+function closeServer(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function request({ cookie, url }: { cookie: string; url: string }) {
+  return new Promise<{
+    body: string;
+    contentType: string | undefined;
+    status: number | undefined;
+  }>((resolve, reject) => {
+    const req = createServerRequest(url, {
+      Cookie: cookie,
+    });
+
+    req.on('response', (res) => {
+      const chunks: Buffer[] = [];
+
+      res.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+      res.on('end', () => {
+        resolve({
+          body: Buffer.concat(chunks).toString('utf8'),
+          contentType: res.headers['content-type'],
+          status: res.statusCode,
+        });
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function createServerRequest(url: string, headers: Record<string, string>) {
+  return httpRequest(url, {
+    headers,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Express proxy-file', () => {
+  it('returns the upstream status while preserving body and Content-Type', async () => {
+    const fetchMock = mockProxyFetch({
+      body: 'upstream denied',
+      contentType: 'text/plain',
+      status: 403,
+    });
+    const server = await createExpressServer();
+
+    try {
+      const res = await request({
+        cookie: 'session=abc',
+        url: `${server.baseUrl}/proxy-file?url=${encodeURIComponent(
+          'https://files.example.com/private.txt',
+        )}`,
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.contentType).toBe('text/plain');
+      expect(res.body).toBe('upstream denied');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://files.example.com/private.txt',
+        {
+          headers: {
+            cookie: 'session=abc',
+          },
+        },
+      );
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('Hono proxy-file', () => {
+  it('returns the upstream status while preserving body and Content-Type', async () => {
+    const fetchMock = mockProxyFetch({
+      body: 'rate limited',
+      contentType: 'application/json',
+      status: 429,
+    });
+    const handler = createEdgeStoreHonoHandler({
+      provider: createProvider(),
+      router: createRouter(),
+    });
+    const app = new Hono();
+    app.all('/edgestore/*', handler);
+
+    const res = await app.request(
+      '/edgestore/proxy-file?url=https%3A%2F%2Ffiles.example.com%2Fblocked.json',
+      {
+        headers: {
+          Cookie: 'session=abc',
+        },
+      },
+    );
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(await res.text()).toBe('rate limited');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://files.example.com/blocked.json',
+      {
+        headers: {
+          cookie: 'session=abc',
+        },
+      },
+    );
+  });
+});

--- a/packages/server/src/adapters/proxy-file-status.test.ts
+++ b/packages/server/src/adapters/proxy-file-status.test.ts
@@ -37,16 +37,16 @@ function mockProxyFetch({
   contentType,
   status,
 }: {
-  body: string;
-  contentType: string;
+  body: string | null;
+  contentType?: string;
   status: number;
 }) {
+  const headers = contentType ? { 'Content-Type': contentType } : undefined;
+
   return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
     new Response(body, {
       status,
-      headers: {
-        'Content-Type': contentType,
-      },
+      headers,
     }),
   );
 }
@@ -200,6 +200,36 @@ describe('Express proxy-file', () => {
       expect(res.body).toBe('upstream denied');
       expect(fetchMock).toHaveBeenCalledWith(
         'https://files.example.com/private.txt',
+        {
+          headers: {
+            cookie: 'session=abc',
+          },
+        },
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns no body for upstream no-body statuses', async () => {
+    const fetchMock = mockProxyFetch({
+      body: null,
+      status: 204,
+    });
+    const server = await createExpressServer();
+
+    try {
+      const res = await request({
+        cookie: 'session=abc',
+        url: `${server.baseUrl}/proxy-file?url=${encodeURIComponent(
+          'https://files.example.com/no-content.txt',
+        )}`,
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.body).toBe('');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://files.example.com/no-content.txt',
         {
           headers: {
             cookie: 'session=abc',
@@ -425,6 +455,38 @@ describe('Next App proxy-file', () => {
     expect(await res.text()).toBe('next app denied');
     expect(fetchMock).toHaveBeenCalledWith(
       'https://files.example.com/next-app.txt',
+      {
+        headers: {
+          cookie: 'session=abc',
+        },
+      },
+    );
+  });
+
+  it('returns no body for upstream no-body statuses', async () => {
+    const fetchMock = mockProxyFetch({
+      body: null,
+      status: 204,
+    });
+    const handler = createEdgeStoreNextAppHandler({
+      provider: createProvider(),
+      router: createRouter(),
+    });
+    const nextUrl = new URL(
+      'https://app.example.com/edgestore/proxy-file?url=https%3A%2F%2Ffiles.example.com%2Fnext-app-empty.txt',
+    );
+
+    const res = await handler({
+      cookies: {
+        toString: () => 'session=abc',
+      },
+      nextUrl,
+    } as Parameters<typeof handler>[0]);
+
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe('');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://files.example.com/next-app-empty.txt',
       {
         headers: {
           cookie: 'session=abc',

--- a/packages/server/src/adapters/remix/index.ts
+++ b/packages/server/src/adapters/remix/index.ts
@@ -13,6 +13,7 @@ import {
   completeMultipartUpload,
   confirmUpload,
   deleteFile,
+  fetchProxyFile,
   getCookieConfig,
   init,
   requestUpload,
@@ -166,20 +167,18 @@ export function createEdgeStoreRemixHandler<TCtx>(config: Config<TCtx>) {
       } else if (matchPath(pathname, '/proxy-file')) {
         const url = new URL(req.url).searchParams.get('url');
         if (typeof url === 'string') {
-          const proxyRes = await fetch(url, {
-            headers: {
-              cookie: req.headers.get('cookie') ?? '',
-            },
+          const proxyRes = await fetchProxyFile({
+            cookieHeader: req.headers.get('cookie') ?? undefined,
+            url,
           });
 
-          const data = await proxyRes.arrayBuffer();
           const headers = new Headers();
-          headers.set(
-            'Content-Type',
-            proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
-          );
+          headers.set('Content-Type', proxyRes.contentType);
 
-          return new Response(data, { headers });
+          return new Response(proxyRes.body, {
+            headers,
+            status: proxyRes.status,
+          });
         } else {
           return new Response(null, { status: 400 });
         }

--- a/packages/server/src/adapters/shared.ts
+++ b/packages/server/src/adapters/shared.ts
@@ -22,6 +22,27 @@ declare const globalThis: {
   _EDGE_STORE_LOGGER: Logger;
 };
 
+export async function fetchProxyFile({
+  cookieHeader,
+  url,
+}: {
+  cookieHeader?: string;
+  url: string;
+}) {
+  const proxyRes = await fetch(url, {
+    headers: {
+      cookie: cookieHeader ?? '',
+    },
+  });
+
+  return {
+    body: await proxyRes.arrayBuffer(),
+    contentType:
+      proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
+    status: proxyRes.status,
+  };
+}
+
 export type CookieOptions = {
   /**
    * Cookie path

--- a/packages/server/src/adapters/shared.ts
+++ b/packages/server/src/adapters/shared.ts
@@ -22,6 +22,8 @@ declare const globalThis: {
   _EDGE_STORE_LOGGER: Logger;
 };
 
+const NO_BODY_STATUSES = new Set([204, 205, 304]);
+
 export async function fetchProxyFile({
   cookieHeader,
   url,
@@ -35,8 +37,12 @@ export async function fetchProxyFile({
     },
   });
 
+  const body = NO_BODY_STATUSES.has(proxyRes.status)
+    ? null
+    : await proxyRes.arrayBuffer();
+
   return {
-    body: await proxyRes.arrayBuffer(),
+    body,
     contentType:
       proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
     status: proxyRes.status,

--- a/packages/server/src/adapters/start/index.ts
+++ b/packages/server/src/adapters/start/index.ts
@@ -13,6 +13,7 @@ import {
   completeMultipartUpload,
   confirmUpload,
   deleteFile,
+  fetchProxyFile,
   getCookieConfig,
   init,
   requestUpload,
@@ -170,18 +171,16 @@ export function createEdgeStoreStartHandler<TCtx>(config: Config<TCtx>) {
       } else if (matchPath(pathname, '/proxy-file')) {
         const urlParam = new URL(request.url).searchParams.get('url');
         if (typeof urlParam === 'string') {
-          const proxyRes = await fetch(urlParam, {
-            headers: {
-              cookie: request.headers.get('cookie') ?? '',
-            },
+          const proxyRes = await fetchProxyFile({
+            cookieHeader: request.headers.get('cookie') ?? undefined,
+            url: urlParam,
           });
-          const data = await proxyRes.arrayBuffer();
           const headers = new Headers();
-          headers.set(
-            'Content-Type',
-            proxyRes.headers.get('Content-Type') ?? 'application/octet-stream',
-          );
-          return new Response(data, { status: proxyRes.status, headers });
+          headers.set('Content-Type', proxyRes.contentType);
+          return new Response(proxyRes.body, {
+            headers,
+            status: proxyRes.status,
+          });
         } else {
           return new Response(null, { status: 400 });
         }


### PR DESCRIPTION
## Summary
- preserve upstream response status from /proxy-file in the Express adapter
- preserve upstream response status from /proxy-file in the Hono adapter
- add focused tests for Express and Hono proxy body, content type, cookie forwarding, and status forwarding

## Verification
- pnpm --filter @edgestore/server test -- src/adapters/proxy-file-status.test.ts
- pnpm --filter @edgestore/server typecheck