### PR TITLE
fix(server): normalize Azure blob keys

### DIFF
--- a/.changeset/normalize-azure-blob-keys.md
+++ b/.changeset/normalize-azure-blob-keys.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/server": patch
+---
+
+Normalize Azure blob keys and access URLs while preserving support for existing flat URLs.

--- a/packages/server/src/providers/azure/index.test.ts
+++ b/packages/server/src/providers/azure/index.test.ts
@@ -1,0 +1,167 @@
+import { type RequestUploadParams } from '@edgestore/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AzureProvider } from './index';
+
+const mocks = vi.hoisted(() => ({
+  deleteBlob: vi.fn(),
+  getBlobClient: vi.fn(),
+  getContainerClient: vi.fn(),
+  getProperties: vi.fn(),
+  uuidv4: vi.fn(),
+}));
+
+vi.mock('@azure/storage-blob', () => ({
+  BlobServiceClient: vi.fn(
+    class {
+      getContainerClient = mocks.getContainerClient;
+    },
+  ),
+}));
+
+vi.mock('uuid', () => ({
+  v4: mocks.uuidv4,
+}));
+
+function encodeBlobName(blobName: string) {
+  return blobName.split('/').map(encodeURIComponent).join('/');
+}
+
+function createUploadParams(
+  overrides: Partial<RequestUploadParams['fileInfo']> = {},
+): RequestUploadParams {
+  return {
+    bucketName: 'documents',
+    bucketType: 'file',
+    fileInfo: {
+      extension: 'txt',
+      fileName: undefined,
+      isPublic: false,
+      metadata: {},
+      path: [],
+      size: 10,
+      temporary: false,
+      ...overrides,
+    },
+  };
+}
+
+describe('AzureProvider', () => {
+  const containerUrl = 'http://localhost:10000/devstoreaccount1/files';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.uuidv4.mockReturnValue('generated-id');
+    mocks.getProperties.mockResolvedValue({
+      contentLength: 123,
+      lastModified: new Date('2026-01-02T03:04:05.000Z'),
+    });
+    mocks.deleteBlob.mockResolvedValue(undefined);
+    mocks.getContainerClient.mockImplementation((containerName: string) => ({
+      getBlobClient: mocks.getBlobClient,
+      url: `http://localhost:10000/devstoreaccount1/${containerName}`,
+    }));
+    mocks.getBlobClient.mockImplementation((blobName: string) => ({
+      delete: mocks.deleteBlob,
+      getProperties: mocks.getProperties,
+      url: `${containerUrl}/${encodeBlobName(blobName)}`,
+    }));
+  });
+
+  it.each([
+    {
+      expectedUuidCalls: 0,
+      fileInfo: {
+        extension: 'png',
+        fileName: 'avatar.png',
+        isPublic: true,
+        path: [
+          { key: 'org', value: 'acme' },
+          { key: 'user', value: 'ravi' },
+        ],
+      },
+      expectedBlobName: 'documents/_public/acme/ravi/avatar.png',
+    },
+    {
+      expectedUuidCalls: 0,
+      fileInfo: {
+        extension: 'pdf',
+        fileName: 'report.pdf',
+        isPublic: false,
+        path: [],
+      },
+      expectedBlobName: 'documents/report.pdf',
+    },
+    {
+      expectedUuidCalls: 1,
+      fileInfo: {
+        extension: '.pdf',
+        fileName: undefined,
+        isPublic: false,
+        path: [{ key: 'year', value: '2026' }],
+      },
+      expectedBlobName: 'documents/2026/generated-id.pdf',
+    },
+  ])(
+    'uses the EdgeStore path shape as the Azure blob name',
+    async ({ fileInfo, expectedBlobName, expectedUuidCalls }) => {
+      const provider = AzureProvider({
+        containerName: 'files',
+        customBaseUrl: 'http://localhost:10000/devstoreaccount1',
+        sasToken: 'token',
+        storageAccountName: 'devstoreaccount1',
+      });
+
+      const res = await provider.requestUpload(createUploadParams(fileInfo));
+
+      expect(mocks.getBlobClient).toHaveBeenCalledWith(expectedBlobName);
+      expect(mocks.uuidv4).toHaveBeenCalledTimes(expectedUuidCalls);
+      expect(res).toEqual({
+        accessUrl: `${containerUrl}/${encodeBlobName(expectedBlobName)}`,
+        uploadUrl: `${containerUrl}/${encodeBlobName(expectedBlobName)}`,
+      });
+    },
+  );
+
+  it('normalizes an Azure access URL to a blob name for getFile', async () => {
+    const provider = AzureProvider({
+      containerName: 'files',
+      customBaseUrl: 'http://localhost:10000/devstoreaccount1',
+      sasToken: 'token',
+      storageAccountName: 'devstoreaccount1',
+    });
+
+    const res = await provider.getFile({
+      url: `${containerUrl}/documents/_public/a%20b/file.txt?sv=token`,
+    });
+
+    expect(mocks.getBlobClient).toHaveBeenCalledWith(
+      'documents/_public/a b/file.txt',
+    );
+    expect(res).toEqual({
+      metadata: {},
+      path: {},
+      size: 123,
+      uploadedAt: new Date('2026-01-02T03:04:05.000Z'),
+      url: `${containerUrl}/documents/_public/a%20b/file.txt?sv=token`,
+    });
+  });
+
+  it('normalizes an Azure access URL to a blob name for deleteFile', async () => {
+    const provider = AzureProvider({
+      containerName: 'files',
+      customBaseUrl: 'http://localhost:10000/devstoreaccount1',
+      sasToken: 'token',
+      storageAccountName: 'devstoreaccount1',
+    });
+
+    await expect(
+      provider.deleteFile({
+        bucket: {} as never,
+        url: `${containerUrl}/documents/report.pdf`,
+      }),
+    ).resolves.toEqual({ success: true });
+
+    expect(mocks.getBlobClient).toHaveBeenCalledWith('documents/report.pdf');
+    expect(mocks.deleteBlob).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/server/src/providers/azure/index.ts
+++ b/packages/server/src/providers/azure/index.ts
@@ -55,6 +55,43 @@ export function AzureProvider(options?: AzureProviderOptions): Provider {
     containerName ?? '',
   );
 
+  function getBlobNameFromUrl(url: string) {
+    try {
+      const blobUrl = new URL(url);
+      const containerUrl = new URL(containerClient.url);
+      const containerPath = containerUrl.pathname.replace(/\/$/, '');
+
+      if (blobUrl.origin !== containerUrl.origin) {
+        return url;
+      }
+
+      if (!blobUrl.pathname.startsWith(`${containerPath}/`)) {
+        return url;
+      }
+
+      return decodeURIComponent(
+        blobUrl.pathname.slice(containerPath.length + 1),
+      );
+    } catch {
+      return url;
+    }
+  }
+
+  function getBlobName(params: Parameters<Provider['requestUpload']>[0]) {
+    const { bucketName: esBucketName, fileInfo } = params;
+    const extension = fileInfo.extension
+      ? `.${fileInfo.extension.replace('.', '')}`
+      : '';
+    const fileName = fileInfo.fileName ?? `${uuidv4()}${extension}`;
+
+    return [
+      esBucketName,
+      ...(fileInfo.isPublic ? ['_public'] : []),
+      ...fileInfo.path.map((item) => item.value),
+      fileName,
+    ].join('/');
+  }
+
   return {
     name: 'azure',
     async init() {
@@ -64,7 +101,7 @@ export function AzureProvider(options?: AzureProviderOptions): Provider {
       return baseUrl;
     },
     async getFile({ url }) {
-      const blobClient = containerClient.getBlobClient(url);
+      const blobClient = containerClient.getBlobClient(getBlobNameFromUrl(url));
 
       const { contentLength, lastModified } = await blobClient.getProperties();
 
@@ -76,14 +113,8 @@ export function AzureProvider(options?: AzureProviderOptions): Provider {
         uploadedAt: lastModified ?? new Date(),
       };
     },
-    async requestUpload({ fileInfo }) {
-      const nameId = uuidv4();
-      const extension = fileInfo.extension
-        ? `.${fileInfo.extension.replace('.', '')}`
-        : '';
-      const fileName = fileInfo.fileName ?? `${nameId}${extension}`;
-
-      const blobClient = containerClient.getBlobClient(fileName);
+    async requestUpload(params) {
+      const blobClient = containerClient.getBlobClient(getBlobName(params));
 
       const url = blobClient.url;
 
@@ -102,7 +133,7 @@ export function AzureProvider(options?: AzureProviderOptions): Provider {
       throw new Error('Not implemented');
     },
     async deleteFile({ url }) {
-      const blobClient = containerClient.getBlobClient(url);
+      const blobClient = containerClient.getBlobClient(getBlobNameFromUrl(url));
       await blobClient.delete();
       return {
         success: true,


### PR DESCRIPTION
## Summary
- make Azure upload blob names use the EdgeStore key shape: bucket, optional _public marker, path values, and filename
- normalize Azure access URLs back to blob names for getFile and deleteFile
- avoid generating a UUID when Azure uploads use a manual filename
- add focused Azure provider tests for key generation and URL normalization

## Backcompat
New Azure uploads now use nested EdgeStore-style blob paths instead of the previous flat filename-only layout. Existing flat URLs still fall back conservatively when normalized, so old files remain addressable when callers pass old URLs.

## Verification
- pnpm --filter @edgestore/server test -- src/providers/azure/index.test.ts
- pnpm --filter @edgestore/server typecheck