### PR TITLE
[codex] Add format-after-edit hooks

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,17 @@
+[[hooks.PostToolUse]]
+matcher = "apply_patch|Edit|MultiEdit|Write"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = '''
+root="$(git rev-parse --show-toplevel)" || exit 0
+cd "$root" || exit 0
+{
+  git diff -z --name-only --diff-filter=ACMRTUXB HEAD -- "*.js" "*.jsx" "*.mjs" "*.cjs" "*.ts" "*.tsx" "*.mts" "*.cts" "*.css"
+  git ls-files -z --others --exclude-standard -- "*.js" "*.jsx" "*.mjs" "*.cjs" "*.ts" "*.tsx" "*.mts" "*.cts" "*.css"
+} |
+  sort -zu |
+  xargs -0 sh -c '[ "$#" -eq 0 ] || "$0/node_modules/.bin/prettier" --write --ignore-unknown "$@"' "$root"
+'''
+timeout = 120
+statusMessage = "Formatting edited files"


### PR DESCRIPTION
## Summary

Adds a repo-local Codex `PostToolUse` hook that formats changed source files after Codex file edits.

## Details

- Configures Codex to run after edit tools such as `apply_patch`, `Edit`, `MultiEdit`, and `Write`.
- Resolves the git root first so the hook works even if Codex is launched from a package subdirectory.
- Uses git to find changed JS/TS/CSS files, including both tracked changes and newly-created untracked files.
- Dedupes the file list and passes it to the local Prettier binary at `node_modules/.bin/prettier`.

## Validation

- Created a temporary unformatted untracked TypeScript file and ran the hook command from `packages/react`; Prettier formatted it successfully.
- Timed that formatting smoke test at about 0.9s wall time for one changed file.
- Ran `codex exec --strict-config --ephemeral --dangerously-bypass-hook-trust --output-last-message /tmp/codex-hook-check.out 'Reply with ok.'` to verify the project Codex config loads.
