### PR TITLE
test: add smoke coverage for API error responses

### DIFF
--- a/packages/server/.env.smoke.example
+++ b/packages/server/.env.smoke.example
@@ -7,6 +7,8 @@ EDGESTORE_SMOKE_BUCKET_NAME=publicFiles
 # Optional. Defaults to https://api.edgestore.dev.
 # Set this for staging or local EdgeStore API smoke runs.
 # EDGE_STORE_API_ENDPOINT=https://api.edgestore.dev
+# Example for dev:
+# EDGE_STORE_API_ENDPOINT=https://api-dev.edgestore.dev
 
 # Required for live smoke tests.
 EDGE_STORE_ACCESS_KEY=

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,8 +34,11 @@
     "codegen:entrypoints": "tsx entrypoints.script.ts",
     "test": "vitest run --config vitest.config.ts",
     "test:smoke": "vitest run --config vitest.smoke.config.ts",
+    "test:smoke:dev": "TEST_ENV=dev vitest run --config vitest.smoke.config.ts",
+    "test:smoke:prod": "TEST_ENV=prod vitest run --config vitest.smoke.config.ts",
     "test:smoke:adapter": "vitest run --config vitest.smoke.config.ts src/adapters/edgestore.smoke.test.ts",
     "test:smoke:client": "vitest run --config vitest.smoke.config.ts src/core/client/edgestore.smoke.test.ts",
+    "test:smoke:errors": "vitest run --config vitest.smoke.config.ts src/core/sdk/edgestore.errors.smoke.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint --cache --ext \".js,.ts,.tsx\" --ignore-path ../../.gitignore --report-unused-disable-directives src"
   },

--- a/packages/server/src/adapters/edgestore.smoke.test.ts
+++ b/packages/server/src/adapters/edgestore.smoke.test.ts
@@ -12,6 +12,8 @@ import {
 import { createEdgeStoreExpressHandler } from './express';
 
 const smokeBucketName = getSmokeBucketName();
+const smokeMaxSizeBucketName = 'smokeMaxSizeFiles';
+const smokeImageBucketName = 'smokeImages';
 
 type HeadersWithSetCookie = Headers & {
   getSetCookie?: () => string[];
@@ -42,10 +44,26 @@ async function expectOk(res: Response) {
   }
 }
 
+async function expectEdgeStoreError(
+  res: Response,
+  params: {
+    code: string;
+    status: number;
+  },
+) {
+  expect(res.status).toBe(params.status);
+  await expect(res.json()).resolves.toMatchObject({
+    code: params.code,
+    message: expect.any(String),
+  });
+}
+
 async function createSmokeServer() {
   const es = initEdgeStore.create();
   const router = es.router({
     [smokeBucketName]: es.fileBucket().beforeDelete(() => true),
+    [smokeMaxSizeBucketName]: es.fileBucket({ maxSize: 5 }),
+    [smokeImageBucketName]: es.imageBucket(),
   });
   const handler = createEdgeStoreExpressHandler({
     router,
@@ -204,6 +222,50 @@ describe('EdgeStore adapter live smoke test', () => {
       expect(uploadRes).toMatchObject({
         size: fileBody.size,
         url: expect.any(String),
+      });
+
+      const tooLargeRes = await fetch(`${baseUrl}/request-upload`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: cookie,
+        },
+        body: JSON.stringify({
+          bucketName: smokeMaxSizeBucketName,
+          input: {},
+          fileInfo: {
+            extension: 'txt',
+            size: 6,
+            temporary: true,
+            type: 'text/plain',
+          },
+        }),
+      });
+      await expectEdgeStoreError(tooLargeRes, {
+        code: 'FILE_TOO_LARGE',
+        status: 400,
+      });
+
+      const wrongMimeRes = await fetch(`${baseUrl}/request-upload`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: cookie,
+        },
+        body: JSON.stringify({
+          bucketName: smokeImageBucketName,
+          input: {},
+          fileInfo: {
+            extension: 'txt',
+            size: 4,
+            temporary: true,
+            type: 'text/plain',
+          },
+        }),
+      });
+      await expectEdgeStoreError(wrongMimeRes, {
+        code: 'MIME_TYPE_NOT_ALLOWED',
+        status: 400,
       });
     } finally {
       await smokeServer.close();

--- a/packages/server/src/core/sdk/edgestore.errors.smoke.test.ts
+++ b/packages/server/src/core/sdk/edgestore.errors.smoke.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getSmokeApiEndpoint,
+  getSmokeBasicAuthHeader,
+  getSmokeBucketName,
+  requireSmokeCredentials,
+} from '../../test-utils/edgestoreSmoke';
+
+type EdgeStoreErrorJson = {
+  code?: string;
+  message?: string;
+  details?: unknown;
+};
+
+function smokeApiUrl(path: string) {
+  return new URL(path, getSmokeApiEndpoint()).toString();
+}
+
+async function postJson(
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+) {
+  return await fetch(smokeApiUrl(path), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function parseJsonBody(res: Response) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as EdgeStoreErrorJson;
+  } catch {
+    throw new Error(
+      `Expected JSON response, got ${res.status} ${res.statusText}: ${text}`,
+    );
+  }
+}
+
+const validRequestUploadBody = {
+  bucketType: 'FILE',
+  extension: 'txt',
+  isPublic: true,
+  isTemporary: true,
+  metadata: {},
+  mimeType: 'text/plain',
+  path: [],
+  size: 12,
+};
+
+describe('EdgeStore API deployed error contract smoke test', () => {
+  it('authenticates protected routes before body validation', async () => {
+    const res = await postJson('/request-upload', {
+      ...validRequestUploadBody,
+      bucketName: getSmokeBucketName(),
+    });
+
+    expect(res.status).toBe(401);
+    await expect(parseJsonBody(res)).resolves.toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: expect.any(String),
+    });
+  });
+
+  it('preserves authenticated input validation error shape', async () => {
+    requireSmokeCredentials();
+
+    const res = await postJson(
+      '/request-upload',
+      {
+        bucketName: '',
+        bucketType: 'IMAGE',
+        path: [],
+        size: 1234,
+      },
+      {
+        Authorization: getSmokeBasicAuthHeader(),
+      },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(parseJsonBody(res)).resolves.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Input validation error',
+      details: expect.any(Array),
+    });
+  });
+
+  it('preserves oversized JSON payload rejection shape', async () => {
+    const res = await postJson(
+      '/request-upload',
+      {
+        ...validRequestUploadBody,
+        bucketName: getSmokeBucketName(),
+        payload: 'x'.repeat(100 * 1024),
+      },
+      {
+        Authorization: getSmokeBasicAuthHeader(),
+      },
+    );
+
+    expect(res.status).toBe(413);
+    await expect(parseJsonBody(res)).resolves.toMatchObject({
+      code: 'PAYLOAD_TOO_LARGE',
+    });
+  });
+
+  it('returns a stable JSON shape for unknown routes', async () => {
+    const res = await postJson('/does-not-exist', {});
+
+    expect(res.status).toBe(404);
+    await expect(parseJsonBody(res)).resolves.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'Route not found',
+    });
+  });
+});

--- a/packages/server/src/test-utils/edgestoreSmoke.ts
+++ b/packages/server/src/test-utils/edgestoreSmoke.ts
@@ -2,8 +2,19 @@ import { randomUUID } from 'node:crypto';
 
 export const SMOKE_CONTENT = 'edgestore smoke test';
 
+export function getSmokeApiEndpoint() {
+  return process.env.EDGE_STORE_API_ENDPOINT ?? 'https://api.edgestore.dev';
+}
+
 export function getSmokeBucketName() {
   return process.env.EDGESTORE_SMOKE_BUCKET_NAME ?? 'publicFiles';
+}
+
+export function getSmokeBasicAuthHeader() {
+  requireSmokeCredentials();
+  return `Basic ${Buffer.from(
+    `${process.env.EDGE_STORE_ACCESS_KEY}:${process.env.EDGE_STORE_SECRET_KEY}`,
+  ).toString('base64')}`;
 }
 
 export function createSmokeFileName(prefix: string) {


### PR DESCRIPTION
## What changed

Adds live smoke coverage for EdgeStore API error contracts and package adapter domain errors.

- Added a deployed API smoke test for protected-route auth, authenticated input validation, oversized JSON payloads, and unknown-route JSON responses.
- Added adapter smoke assertions for `FILE_TOO_LARGE` and `MIME_TYPE_NOT_ALLOWED`.
- Added smoke helpers for API endpoint/auth reuse and convenience scripts for dev/prod smoke runs.

## Why

The dev EdgeStore API has an oRPC migration deployed that changes the HTTP boundary for some error responses. These smoke tests make the expected deployed JSON contracts explicit before promoting that API change to production.

## Impact

Package lifecycle smoke still covers upload, confirm, get, and delete. The new tests add confidence that clients see stable structured error JSON for the API paths most likely to drift during deploys.

## Validation

- `pnpm --filter @edgestore/server typecheck`
- `TEST_ENV=dev pnpm --filter @edgestore/server test:smoke`
- `TEST_ENV=prod pnpm --filter @edgestore/server test:smoke:adapter`
- `TEST_ENV=prod pnpm --filter @edgestore/server test:smoke:client`

Also ran `TEST_ENV=prod pnpm --filter @edgestore/server test:smoke`; it failed only in the new deployed API error-contract smoke because production still returns the old Express/Vendia HTML bodies for oversized payloads and unknown routes. That mismatch is expected until the API migration is promoted to prod.