### PR TITLE
chore: require changesets for published changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,14 @@
 For focused work, prefer Turbo or pnpm filters, for example:
 `pnpm turbo run test --filter=@edgestore/server`.
 
+## Changesets
+
+- Any PR that changes published `@edgestore/*` behavior or public APIs must
+  include a changeset.
+- Use `patch` for fixes, `minor` for backward-compatible features, and `major`
+  for breaking changes.
+- Changes limited to tests, docs, examples, or internal tooling do not need one.
+
 ## Review guidelines
 
 - Prioritize structural issues over style nits.


### PR DESCRIPTION
## Summary

- require changesets for PRs that modify published `@edgestore/*` behavior or public APIs
- document patch, minor, and major version guidance
- exempt test-only, documentation, example, and internal tooling changes

## Why

Recent user-facing fixes were opened without changesets. This gives agents a concise repository-level rule to apply while making changes.

## Validation

- `prettier AGENTS.md --check`