### PR TITLE
[Friendly Types 01] test: add public hover type contracts

### DIFF
--- a/packages/tests/fixtures/type-hovers.ts
+++ b/packages/tests/fixtures/type-hovers.ts
@@ -1,0 +1,107 @@
+import { createEdgeStoreProvider } from '@edgestore/react';
+import { createEdgeStoreFastifyHandler } from '@edgestore/server/adapters/fastify';
+import { createEdgeStoreHonoHandler } from '@edgestore/server/adapters/hono';
+import { initEdgeStoreClient } from '@edgestore/server/core';
+import { initEdgeStore } from '@edgestore/shared';
+import { z } from 'zod';
+
+type Context = {
+  userId: string;
+  role: 'admin' | 'visitor';
+};
+
+const es = initEdgeStore.context<Context>().create();
+
+const privateFiles = es
+  .fileBucket()
+  .input(
+    z.object({
+      category: z.enum(['invoice', 'contract']),
+    }),
+  )
+  .path((pathArgs) => [
+    { owner: pathArgs.ctx.userId },
+    { category: pathArgs.input.category },
+  ])
+  .metadata((metadataArgs) => ({
+    role: metadataArgs.ctx.role,
+    category: metadataArgs.input.category,
+  }))
+  .beforeUpload((beforeUploadArgs) => {
+    return beforeUploadArgs.fileInfo.size > 0;
+  })
+  .beforeDelete((beforeDeleteArgs) => {
+    return beforeDeleteArgs.fileInfo.metadata.role === 'admin';
+  })
+  .accessControl('private')
+  .autoSignedUrls();
+
+const router = es.router({
+  publicFiles: es.fileBucket(),
+  privateFiles,
+  privateImages: es
+    .imageBucket()
+    .accessControl('private')
+    .autoSignedUrls({ includeThumbnails: true }),
+});
+
+const backendClient = initEdgeStoreClient({ router });
+const { useEdgeStore } = createEdgeStoreProvider<typeof router>();
+const { edgestore, state: providerState } = useEdgeStore();
+
+const honoHandler = createEdgeStoreHonoHandler({
+  router,
+  createContext: () => ({ userId: 'user-1', role: 'admin' }),
+});
+
+const fastifyHandler = createEdgeStoreFastifyHandler({
+  router,
+  createContext: () => ({ userId: 'user-1', role: 'admin' }),
+});
+
+async function inspectOperationResults() {
+  const backendUnsignedUpload = await backendClient.publicFiles.upload({
+    content: 'hello',
+    ctx: { userId: 'user-1', role: 'admin' },
+  });
+  const backendSignedFileUpload = await backendClient.privateFiles.upload({
+    content: 'hello',
+    ctx: { userId: 'user-1', role: 'admin' },
+    input: { category: 'invoice' },
+  });
+  const backendGetFile = await backendClient.privateFiles.getFile({
+    url: 'https://example.com/file',
+  });
+  const backendListFiles = await backendClient.privateFiles.listFiles();
+  const backendGetSignedUrl = await backendClient.privateFiles.getSignedUrl({
+    url: 'https://example.com/file',
+  });
+  const backendGetSignedUrls = await backendClient.privateImages.getSignedUrls({
+    urls: ['https://example.com/image'],
+  });
+
+  const reactUnsignedUpload = await edgestore.publicFiles.upload({
+    file: null! as File,
+  });
+  const reactSignedFileUpload = await edgestore.privateFiles.upload({
+    file: null! as File,
+    input: { category: 'invoice' },
+  });
+  const reactSignedImageUpload = await edgestore.privateImages.upload({
+    file: null! as File,
+  });
+
+  return {
+    backendUnsignedUpload,
+    backendSignedFileUpload,
+    backendGetFile,
+    backendListFiles,
+    backendGetSignedUrl,
+    backendGetSignedUrls,
+    reactUnsignedUpload,
+    reactSignedFileUpload,
+    reactSignedImageUpload,
+  };
+}
+
+void inspectOperationResults;

--- a/packages/tests/fixtures/type-hovers.ts
+++ b/packages/tests/fixtures/type-hovers.ts
@@ -48,6 +48,8 @@ const router = es.router({
 const backendClient = initEdgeStoreClient({ router });
 const { useEdgeStore } = createEdgeStoreProvider<typeof router>();
 const { edgestore, state: providerState } = useEdgeStore();
+const backendSignedUploadMethod = backendClient.privateFiles.upload;
+const reactSignedUploadMethod = edgestore.privateFiles.upload;
 
 const honoHandler = createEdgeStoreHonoHandler({
   router,

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -2,7 +2,9 @@
   "name": "edgestore-tests",
   "private": true,
   "scripts": {
-    "test:types": "tsd --files \"test-d/**/*.test-d.ts\""
+    "test:types": "pnpm test:types:structural && pnpm test:types:hover",
+    "test:types:structural": "tsd --files \"test-d/**/*.test-d.ts\"",
+    "test:types:hover": "node --test type-hovers.test.mjs"
   },
   "types": "index.d.ts",
   "dependencies": {

--- a/packages/tests/type-hovers.test.mjs
+++ b/packages/tests/type-hovers.test.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import ts from 'typescript';
+
+const workspaceRoot = path.resolve(import.meta.dirname, '../..');
+const fixturePath = path.join(import.meta.dirname, 'fixtures/type-hovers.ts');
+const fixture = fs.readFileSync(fixturePath, 'utf8');
+
+const compilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  strict: true,
+  jsx: ts.JsxEmit.ReactJSX,
+  lib: ['lib.es2022.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+  skipLibCheck: true,
+};
+
+const host = {
+  getCompilationSettings: () => compilerOptions,
+  getCurrentDirectory: () => workspaceRoot,
+  getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+  getDirectories: ts.sys.getDirectories,
+  getScriptFileNames: () => [fixturePath],
+  getScriptSnapshot(fileName) {
+    if (!fs.existsSync(fileName)) return undefined;
+    return ts.ScriptSnapshot.fromString(fs.readFileSync(fileName, 'utf8'));
+  },
+  getScriptVersion: () => '0',
+  readDirectory: ts.sys.readDirectory,
+  readFile: ts.sys.readFile,
+  fileExists: ts.sys.fileExists,
+  directoryExists: ts.sys.directoryExists,
+  realpath: ts.sys.realpath,
+};
+
+const languageService = ts.createLanguageService(
+  host,
+  ts.createDocumentRegistry(),
+);
+
+function getHover(identifier) {
+  const match = new RegExp(`\\b${identifier}\\b`).exec(fixture);
+  assert.ok(match, `Missing ${identifier} in hover fixture`);
+
+  const info = languageService.getQuickInfoAtPosition(
+    fixturePath,
+    match.index + 1,
+  );
+  assert.ok(info, `Missing quick info for ${identifier}`);
+  return ts.displayPartsToString(info.displayParts);
+}
+
+const expectedHovers = {
+  pathArgs: `(parameter) pathArgs: {
+    ctx: {
+        userId: () => string;
+        role: () => string;
+    };
+    input: {
+        category: () => string;
+    };
+}`,
+  metadataArgs: `(parameter) metadataArgs: {
+    ctx: Context;
+    input: {
+        category: "invoice" | "contract";
+    };
+}`,
+  beforeUploadArgs: `(parameter) beforeUploadArgs: {
+    ctx: Context;
+    input: {
+        category: "invoice" | "contract";
+    };
+    fileInfo: {
+        size: number;
+        type: string;
+        extension: string;
+        fileName?: string;
+        replaceTargetUrl?: string;
+        temporary: boolean;
+    };
+}`,
+  beforeDeleteArgs: `(parameter) beforeDeleteArgs: {
+    ctx: Context;
+    fileInfo: {
+        url: string;
+        size: number;
+        uploadedAt: Date;
+        path: {
+            category: string;
+            owner: string;
+        };
+        metadata: {
+            role: "admin" | "visitor";
+            category: "invoice" | "contract";
+        };
+    };
+}`,
+  providerState: 'const providerState: EdgeStoreProviderState',
+  honoHandler: 'const honoHandler: (c: HonoContext) => Promise<Response>',
+  fastifyHandler:
+    'const fastifyHandler: (req: FastifyRequest, reply: FastifyReply) => Promise<void>',
+  backendUnsignedUpload: `const backendUnsignedUpload: {
+    url: string;
+    size: number;
+    metadata: Record<string, never>;
+    path: Record<string, never>;
+    pathOrder: [];
+}`,
+  backendSignedFileUpload: `const backendSignedFileUpload: {
+    url: string;
+    size: number;
+    metadata: {
+        role: "admin" | "visitor";
+        category: "invoice" | "contract";
+    };
+    path: {
+        category: string;
+        owner: string;
+    };
+    pathOrder: ("category" | "owner")[];
+    signedUrl: string;
+    expiresAt: Date;
+    expiresIn: number;
+    signedThumbnailUrl?: string | null | undefined;
+}`,
+  backendGetFile: `const backendGetFile: {
+    url: string;
+    size: number;
+    uploadedAt: Date;
+    metadata: {
+        role: "admin" | "visitor";
+        category: "invoice" | "contract";
+    };
+    path: {
+        category: string;
+        owner: string;
+    };
+}`,
+  backendListFiles: `const backendListFiles: {
+    data: {
+        url: string;
+        size: number;
+        uploadedAt: Date;
+        metadata: {
+            role: "admin" | "visitor";
+            category: "invoice" | "contract";
+        };
+        path: {
+            category: string;
+            owner: string;
+        };
+    }[];
+    pagination: {
+        currentPage: number;
+        totalPages: number;
+        totalCount: number;
+    };
+}`,
+  backendGetSignedUrl: `const backendGetSignedUrl: {
+    url: string;
+    signedUrl: string;
+    expiresAt: Date;
+    expiresIn: number;
+}`,
+  backendGetSignedUrls: `const backendGetSignedUrls: {
+    url: string;
+    signedUrl: string;
+    expiresAt: Date;
+    expiresIn: number;
+    thumbnailUrl?: string | null | undefined;
+    signedThumbnailUrl?: string | null | undefined;
+}[]`,
+  reactUnsignedUpload: `const reactUnsignedUpload: {
+    url: string;
+    size: number;
+    uploadedAt: Date;
+    metadata: Record<string, never>;
+    path: Record<string, never>;
+    pathOrder: [];
+}`,
+  reactSignedFileUpload: `const reactSignedFileUpload: {
+    url: string;
+    size: number;
+    uploadedAt: Date;
+    metadata: {
+        role: "admin" | "visitor";
+        category: "invoice" | "contract";
+    };
+    path: {
+        category: string;
+        owner: string;
+    };
+    pathOrder: ("category" | "owner")[];
+    signedUrl: string;
+    expiresAt: Date;
+    expiresIn: number;
+    signedThumbnailUrl?: string | null | undefined;
+}`,
+  reactSignedImageUpload: `const reactSignedImageUpload: {
+    url: string;
+    thumbnailUrl: string | null;
+    size: number;
+    uploadedAt: Date;
+    metadata: Record<string, never>;
+    path: Record<string, never>;
+    pathOrder: [];
+    signedUrl: string;
+    expiresAt: Date;
+    expiresIn: number;
+    signedThumbnailUrl?: string | null | undefined;
+}`,
+};
+
+for (const [identifier, expected] of Object.entries(expectedHovers)) {
+  test(`${identifier} has a readable public hover type`, () => {
+    assert.equal(getHover(identifier), expected);
+  });
+}
+
+test('hover fixture has no TypeScript diagnostics', () => {
+  const diagnostics = [
+    ...languageService.getSyntacticDiagnostics(fixturePath),
+    ...languageService.getSemanticDiagnostics(fixturePath),
+  ];
+  assert.deepEqual(
+    diagnostics.map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+    ),
+    [],
+  );
+});

--- a/packages/tests/type-hovers.test.mjs
+++ b/packages/tests/type-hovers.test.mjs
@@ -100,6 +100,56 @@ const expectedHovers = {
     };
 }`,
   providerState: 'const providerState: EdgeStoreProviderState',
+  backendSignedUploadMethod: `const backendSignedUploadMethod: (params: {
+    content: UploadContent;
+    options?: UploadOptions;
+    ctx: Context;
+    input: {
+        category: "invoice" | "contract";
+    };
+}) => Promise<{
+    url: string;
+    size: number;
+    metadata: {
+        role: "admin" | "visitor";
+        category: "invoice" | "contract";
+    };
+    path: {
+        category: string;
+        owner: string;
+    };
+    pathOrder: ("category" | "owner")[];
+    signedUrl: string;
+    expiresAt: Date;
+    expiresIn: number;
+    signedThumbnailUrl?: string | null | undefined;
+}>`,
+  reactSignedUploadMethod: `const reactSignedUploadMethod: (params: {
+    file: File;
+    signal?: AbortSignal;
+    input: {
+        category: "invoice" | "contract";
+    };
+    onProgressChange?: ((progress: number) => void) | undefined;
+    options?: UploadOptions;
+}) => Promise<{
+    url: string;
+    size: number;
+    uploadedAt: Date;
+    metadata: {
+        role: "admin" | "visitor";
+        category: "invoice" | "contract";
+    };
+    path: {
+        category: string;
+        owner: string;
+    };
+    pathOrder: ("category" | "owner")[];
+    signedUrl: string;
+    expiresAt: Date;
+    expiresIn: number;
+    signedThumbnailUrl?: string | null | undefined;
+}>`,
   honoHandler: 'const honoHandler: (c: HonoContext) => Promise<Response>',
   fastifyHandler:
     'const fastifyHandler: (req: FastifyRequest, reply: FastifyReply) => Promise<void>',

--- a/packages/tests/type-hovers.test.mjs
+++ b/packages/tests/type-hovers.test.mjs
@@ -102,7 +102,7 @@ const expectedHovers = {
   providerState: 'const providerState: EdgeStoreProviderState',
   backendSignedUploadMethod: `const backendSignedUploadMethod: (params: {
     content: UploadContent;
-    options?: UploadOptions;
+    options?: UploadOptions | undefined;
     ctx: Context;
     input: {
         category: "invoice" | "contract";
@@ -130,7 +130,7 @@ const expectedHovers = {
     input: {
         category: "invoice" | "contract";
     };
-    onProgressChange?: ((progress: number) => void) | undefined;
+    onProgressChange?: (progress: number) => void;
     options?: UploadOptions;
 }) => Promise<{
     url: string;
@@ -150,7 +150,7 @@ const expectedHovers = {
     expiresIn: number;
     signedThumbnailUrl?: string | null | undefined;
 }>`,
-  honoHandler: 'const honoHandler: (c: HonoContext) => Promise<Response>',
+  honoHandler: 'const honoHandler: (c: Context) => Promise<Response>',
   fastifyHandler:
     'const fastifyHandler: (req: FastifyRequest, reply: FastifyReply) => Promise<void>',
   backendUnsignedUpload: `const backendUnsignedUpload: {


### PR DESCRIPTION
## Summary

Adds editor-hover contract tests for the public types developers encounter while configuring buckets and consuming React, backend-client, and adapter APIs.

The tests call TypeScript 5.9.3's language-service `getQuickInfoAtPosition` API against built package declarations, so they cover the same rendered types users see in editors. Structural `tsd` tests remain separate.

This PR intentionally leaves eleven hover assertions failing. The stacked follow-up fixes the public type presentation and makes the suite pass.

## Before → expected after

### Lifecycle hooks

```ts
// before
fileInfo: FileInfo

// after
fileInfo: {
  size: number;
  type: string;
  extension: string;
  fileName?: string;
  replaceTargetUrl?: string;
  temporary: boolean;
}
```

### React provider state

```ts
// before
const state: ProviderState

// after
const state: EdgeStoreProviderState
```

The exported state type remains the same discriminated union:

```ts
type EdgeStoreProviderState =
  | { loading: true; initialized: false; error: false }
  | { loading: false; initialized: false; error: true }
  | { loading: false; initialized: true; error: false };
```

### Adapter handlers

```ts
// Hono before
(c: Context) => Promise<Response & TypedResponse<...> | ...>

// Hono after
(c: Context) => Promise<Response>

// Fastify before
(req: FastifyRequest, reply: FastifyReply) => Promise<never>

// Fastify after
(req: FastifyRequest, reply: FastifyReply) => Promise<void>
```

### Upload method signatures

```ts
// backend before
(params: UploadFileRequest<Builder<Context, BucketDefinition>>) => Promise<...>

// backend after
(params: {
  content: UploadContent;
  options?: UploadOptions;
  ctx: Context;
  input: { category: "invoice" | "contract" };
}) => Promise<ExpandedSignedFileUpload>

// React before
(params: {
  file: File;
  signal?: AbortSignal;
  input: { category: "invoice" | "contract" };
  onProgressChange?: OnProgressChangeHandler;
  options?: UploadOptions;
}) => Promise<UploadResponse<Builder<Context, BucketDefinition>>>

// React after
(params: {
  file: File;
  signal?: AbortSignal;
  input: { category: "invoice" | "contract" };
  onProgressChange?: (progress: number) => void;
  options?: UploadOptions;
}) => Promise<ExpandedSignedFileUpload>
```

The expanded signed-file result is listed below in full.

### Backend getFile

```ts
// before
const file: GetFileRes<Builder<Context, BucketDefinition>>

// after
const file: {
  url: string;
  size: number;
  uploadedAt: Date;
  metadata: {
    role: "admin" | "visitor";
    category: "invoice" | "contract";
  };
  path: {
    category: string;
    owner: string;
  };
}
```

### Backend signed URLs

```ts
// before
const signedUrl: GetSignedUrlRes

// after
const signedUrl: {
  url: string;
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
}

// before
const signedUrls: (GetSignedUrlRes & {
  thumbnailUrl?: string | null;
  signedThumbnailUrl?: string | null;
})[]

// after
const signedUrls: {
  url: string;
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
  thumbnailUrl?: string | null | undefined;
  signedThumbnailUrl?: string | null | undefined;
}[]
```

### React signed file upload

```ts
// before
const upload: UploadResponse<Builder<Context, BucketDefinition>>

// after
const upload: {
  url: string;
  size: number;
  uploadedAt: Date;
  metadata: {
    role: "admin" | "visitor";
    category: "invoice" | "contract";
  };
  path: {
    category: string;
    owner: string;
  };
  pathOrder: ("category" | "owner")[];
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
  signedThumbnailUrl?: string | null | undefined;
}
```

### React signed image upload

```ts
// before
const upload: UploadResponse<Builder<Context, BucketDefinition>>

// after
const upload: {
  url: string;
  thumbnailUrl: string | null;
  size: number;
  uploadedAt: Date;
  metadata: Record<string, never>;
  path: Record<string, never>;
  pathOrder: [];
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
  signedThumbnailUrl?: string | null | undefined;
}
```

## Existing friendly types locked by the suite

The suite also protects the already-readable path, metadata, and before-delete callback arguments; unsigned React uploads; backend uploads; and backend list results.

## Stack

- Base: #118 (`codex/signed-urls-private-buckets`)
- Follow-up: #136

## Validation

- `pnpm --filter edgestore-tests test:types:structural` — passes
- `pnpm --filter edgestore-tests test:types:hover` — intentionally fails 11 readability assertions and passes 8 existing contracts
- `git diff --check` — passes
