### PR TITLE
[Friendly Types 02] fix: simplify public type hovers

### DIFF
--- a/.changeset/friendly-public-types.md
+++ b/.changeset/friendly-public-types.md
@@ -1,0 +1,7 @@
+---
+"@edgestore/react": patch
+"@edgestore/server": patch
+"@edgestore/shared": patch
+---
+
+Present concise, user-friendly types for public EdgeStore APIs in editor hovers.

--- a/packages/react/src/contextProvider.tsx
+++ b/packages/react/src/contextProvider.tsx
@@ -25,7 +25,7 @@ type EdgeStoreContextValue<TRouter extends AnyRouter> = {
    * You can use this to wait for the provider to be initialized
    * before trying to show private images on your app.
    */
-  state: ProviderState;
+  state: EdgeStoreProviderState;
 };
 
 export function createEdgeStoreProvider<TRouter extends AnyRouter>(opts?: {
@@ -95,7 +95,7 @@ export function createEdgeStoreProvider<TRouter extends AnyRouter>(opts?: {
   };
 }
 
-type ProviderState =
+export type EdgeStoreProviderState =
   | {
       loading: true;
       initialized: false;
@@ -126,7 +126,7 @@ function EdgeStoreProviderInner<TRouter extends AnyRouter>({
   disableDevProxy?: boolean;
 }) {
   const apiPath = basePath ? `${basePath}` : '/api/edgestore';
-  const [state, setState] = React.useState<ProviderState>({
+  const [state, setState] = React.useState<EdgeStoreProviderState>({
     loading: true,
     initialized: false,
     error: false,

--- a/packages/react/src/createNextProxy.ts
+++ b/packages/react/src/createNextProxy.ts
@@ -4,6 +4,7 @@ import {
   type InferBucketPathObject,
   type InferBucketPathOrder,
   type InferMetadataObject,
+  type Prettify,
   type SharedRequestUploadRes,
   type UploadOptions,
 } from '@edgestore/shared';
@@ -31,14 +32,14 @@ type UploadResponse<TBucket extends AnyBuilder> =
         path: InferBucketPathObject<TBucket>;
         pathOrder: InferBucketPathOrder<TBucket>;
       }) &
-  (undefined extends TBucket['_def']['autoSignedUrls']
-    ? unknown
-    : {
-        signedUrl: string;
-        expiresAt: Date;
-        expiresIn: number;
-        signedThumbnailUrl?: string | null;
-      });
+    (undefined extends TBucket['_def']['autoSignedUrls']
+      ? unknown
+      : {
+          signedUrl: string;
+          expiresAt: Date;
+          expiresIn: number;
+          signedThumbnailUrl?: string | null;
+        });
 
 export type BucketFunctions<TRouter extends AnyRouter> = {
   [K in keyof TRouter['buckets']]: {
@@ -63,17 +64,17 @@ export type BucketFunctions<TRouter extends AnyRouter> = {
         ? {
             file: File;
             signal?: AbortSignal;
-            onProgressChange?: OnProgressChangeHandler;
+            onProgressChange?: (progress: number) => void;
             options?: UploadOptions;
           }
         : {
             file: File;
             signal?: AbortSignal;
             input: z.infer<TRouter['buckets'][K]['_def']['input']>;
-            onProgressChange?: OnProgressChangeHandler;
+            onProgressChange?: (progress: number) => void;
             options?: UploadOptions;
           },
-    ) => Promise<UploadResponse<TRouter['buckets'][K]>>;
+    ) => Promise<Prettify<UploadResponse<TRouter['buckets'][K]>>>;
     confirmUpload: (params: { url: string }) => Promise<void>;
     delete: (params: { url: string }) => Promise<void>;
   };

--- a/packages/server/src/adapters/fastify/index.ts
+++ b/packages/server/src/adapters/fastify/index.ts
@@ -80,7 +80,7 @@ export function createEdgeStoreFastifyHandler<TCtx>(config: Config<TCtx>) {
 
   const resolvedCookieConfig = getCookieConfig(cookieConfig);
 
-  return async (req: FastifyRequest, reply: FastifyReply) => {
+  return async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
     try {
       // Get the URL from the request - simplified approach
       const pathname = req.url;

--- a/packages/server/src/adapters/hono/index.ts
+++ b/packages/server/src/adapters/hono/index.ts
@@ -6,7 +6,7 @@ import {
   type MaybePromise,
   type Provider,
 } from '@edgestore/shared';
-import { type Context } from 'hono';
+import { type Context as HonoContext } from 'hono';
 import Logger, { type LogLevel } from '../../libs/logger';
 import { matchPath } from '../../libs/utils';
 import { EdgeStoreProvider } from '../../providers/edgestore';
@@ -27,7 +27,7 @@ import {
 } from '../shared';
 
 export type CreateContextOptions = {
-  c: Context;
+  c: HonoContext;
 };
 
 export type Config<TCtx> = {
@@ -49,7 +49,7 @@ declare const globalThis: {
 };
 
 // Helper to get a cookie value from Hono Context
-function getCookie(c: Context, name: string): string | undefined {
+function getCookie(c: HonoContext, name: string): string | undefined {
   const cookies = c.req.header('cookie');
   if (!cookies) return undefined;
 
@@ -65,7 +65,7 @@ export function createEdgeStoreHonoHandler<TCtx>(config: Config<TCtx>) {
 
   const resolvedCookieConfig = getCookieConfig(cookieConfig);
 
-  return async (c: Context) => {
+  return async (c: HonoContext): Promise<Response> => {
     try {
       const pathname = new URL(c.req.url).pathname;
 

--- a/packages/server/src/core/client/index.ts
+++ b/packages/server/src/core/client/index.ts
@@ -71,6 +71,8 @@ type UrlContent = {
   extension: string;
 };
 
+export type UploadContent = TextContent | BlobContent | UrlContent;
+
 export type ServerUploadTransform = (params: {
   blob: Blob;
   extension: string;
@@ -117,7 +119,7 @@ export type UploadFileRequest<TBucket extends AnyBuilder> = {
    *   extension: "csv",
    * }
    */
-  content: TextContent | BlobContent | UrlContent;
+  content: UploadContent;
   options?: UploadOptions;
 } & (TBucket['$config']['ctx'] extends Record<string, never>
   ? {}
@@ -216,7 +218,7 @@ type GetSignedUrlsRes<TBucket extends AnyBuilder> =
     : GetSignedUrlRes[];
 
 type BucketClient<TBucket extends AnyBuilder> = {
-  getFile: (params: { url: string }) => Promise<GetFileRes<TBucket>>;
+  getFile: (params: { url: string }) => Promise<Prettify<GetFileRes<TBucket>>>;
 
   /**
    * Use this function to upload a file to the bucket directly from your backend.
@@ -253,7 +255,7 @@ type BucketClient<TBucket extends AnyBuilder> = {
    * ```
    */
   upload: (
-    params: UploadFileRequest<TBucket>,
+    params: Prettify<UploadFileRequest<TBucket>>,
   ) => Promise<Prettify<UploadFileRes<TBucket>>>;
   /**
    * Confirm a temporary file upload directly from your backend.
@@ -280,12 +282,12 @@ type BucketClient<TBucket extends AnyBuilder> = {
       getSignedUrl: (params: {
         url: string;
         expiresIn?: number;
-      }) => Promise<GetSignedUrlRes>;
+      }) => Promise<Prettify<GetSignedUrlRes>>;
       getSignedUrls: (params: {
         urls: string[];
         expiresIn?: number;
         includeThumbnails?: boolean;
-      }) => Promise<GetSignedUrlsRes<TBucket>>;
+      }) => Promise<Prettify<GetSignedUrlsRes<TBucket>[number]>[]>;
     });
 
 type EdgeStoreClient<TRouter extends AnyRouter> = {
@@ -320,7 +322,7 @@ export function initEdgeStoreClient<TRouter extends AnyRouter>(config: {
         async upload(params) {
           const content = params.content;
           const ctx = 'ctx' in params ? params.ctx : {};
-          const input = 'input' in params ? params.input : {};
+          const input = 'input' in params ? (params.input as any) : {};
 
           let { blob, extension } = await (async () => {
             if (isTextContent(content)) {

--- a/packages/server/src/core/client/index.ts
+++ b/packages/server/src/core/client/index.ts
@@ -132,6 +132,12 @@ export type UploadFileRequest<TBucket extends AnyBuilder> = {
         input: z.infer<TBucket['_def']['input']>;
       });
 
+type UploadImplementationParams = {
+  content: UploadContent;
+  ctx?: Record<string, unknown>;
+  input?: Record<string, unknown>;
+};
+
 export type UploadFileRes<TBucket extends AnyBuilder> =
   (TBucket['_def']['type'] extends 'IMAGE'
     ? {
@@ -320,9 +326,11 @@ export function initEdgeStoreClient<TRouter extends AnyRouter>(config: {
       }
       const client: EdgeStoreClient<TRouter>[string] = {
         async upload(params) {
-          const content = params.content;
-          const ctx = 'ctx' in params ? params.ctx : {};
-          const input = 'input' in params ? (params.input as any) : {};
+          const {
+            content,
+            ctx = {},
+            input = {},
+          }: UploadImplementationParams = params;
 
           let { blob, extension } = await (async () => {
             if (isTextContent(content)) {

--- a/packages/shared/src/internals/bucketBuilder.ts
+++ b/packages/shared/src/internals/bucketBuilder.ts
@@ -126,19 +126,17 @@ type BucketConfig = {
   accept?: string[];
 };
 
-type FileInfo = {
-  size: number;
-  type: string;
-  extension: string;
-  fileName?: string;
-  replaceTargetUrl?: string;
-  temporary: boolean;
-};
-
 type BeforeUploadFn<TCtx, TDef extends AnyDef> = (params: {
   ctx: TCtx;
   input: z.infer<TDef['input']>;
-  fileInfo: FileInfo;
+  fileInfo: {
+    size: number;
+    type: string;
+    extension: string;
+    fileName?: string;
+    replaceTargetUrl?: string;
+    temporary: boolean;
+  };
 }) => MaybePromise<boolean>;
 
 type BeforeDeleteFn<TCtx, TDef extends AnyDef> = (params: {


### PR DESCRIPTION
## Summary

Makes the public editor hovers covered by #135 readable without adding runtime work.

The implementation applies compile-time-only `Prettify` boundaries to conditional/intersection-heavy operation types, inlines the small lifecycle file shape, exports a meaningful provider-state name, and explicitly annotates adapter handler returns. Runtime control flow and response mapping are unchanged.

## Before → after

### Lifecycle upload hook

```ts
// before
fileInfo: FileInfo

// after
fileInfo: {
  size: number;
  type: string;
  extension: string;
  fileName?: string;
  replaceTargetUrl?: string;
  temporary: boolean;
}
```

### React provider state

```ts
// before
const state: ProviderState

// after
const state: EdgeStoreProviderState
```

```ts
export type EdgeStoreProviderState =
  | { loading: true; initialized: false; error: false }
  | { loading: false; initialized: false; error: true }
  | { loading: false; initialized: true; error: false };
```

### Backend upload method

```ts
// before
const upload: (
  params: UploadFileRequest<Builder<Context, BucketDefinition>>
) => Promise<...>

// after
const upload: (params: {
  content: UploadContent;
  options?: UploadOptions | undefined;
  ctx: Context;
  input: {
    category: "invoice" | "contract";
  };
}) => Promise<{
  url: string;
  size: number;
  metadata: {
    role: "admin" | "visitor";
    category: "invoice" | "contract";
  };
  path: {
    category: string;
    owner: string;
  };
  pathOrder: ("category" | "owner")[];
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
  signedThumbnailUrl?: string | null | undefined;
}>
```

The newly exported content alias represents every accepted backend input:

```ts
type UploadContent =
  | string
  | { blob: Blob; extension: string }
  | { url: string; extension: string };
```

### React upload method

```ts
// before
const upload: (params: {
  file: File;
  signal?: AbortSignal;
  input: { category: "invoice" | "contract" };
  onProgressChange?: OnProgressChangeHandler;
  options?: UploadOptions;
}) => Promise<UploadResponse<Builder<Context, BucketDefinition>>>

// after
const upload: (params: {
  file: File;
  signal?: AbortSignal;
  input: { category: "invoice" | "contract" };
  onProgressChange?: (progress: number) => void;
  options?: UploadOptions;
}) => Promise<{
  url: string;
  size: number;
  uploadedAt: Date;
  metadata: {
    role: "admin" | "visitor";
    category: "invoice" | "contract";
  };
  path: {
    category: string;
    owner: string;
  };
  pathOrder: ("category" | "owner")[];
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
  signedThumbnailUrl?: string | null | undefined;
}>
```

### Adapter handlers

```ts
// Hono before
const handler: (c: Context) => Promise<
  | Response & TypedResponse<"OK", ...>
  | Response & TypedResponse<InitResponse, ...>
  | Response & TypedResponse<UploadResponse, ...>
  | ...
>

// Hono after
const handler: (c: Context) => Promise<Response>

// Fastify before
const handler: (
  req: FastifyRequest,
  reply: FastifyReply
) => Promise<never>

// Fastify after
const handler: (
  req: FastifyRequest,
  reply: FastifyReply
) => Promise<void>
```

### Backend getFile

```ts
// before
const file: GetFileRes<Builder<Context, BucketDefinition>>

// after
const file: {
  url: string;
  size: number;
  uploadedAt: Date;
  metadata: {
    role: "admin" | "visitor";
    category: "invoice" | "contract";
  };
  path: {
    category: string;
    owner: string;
  };
}
```

### Backend getSignedUrl

```ts
// before
const result: GetSignedUrlRes

// after
const result: {
  url: string;
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
}
```

### Backend image getSignedUrls

```ts
// before
const results: (GetSignedUrlRes & {
  thumbnailUrl?: string | null;
  signedThumbnailUrl?: string | null;
})[]

// after
const results: {
  url: string;
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
  thumbnailUrl?: string | null | undefined;
  signedThumbnailUrl?: string | null | undefined;
}[]
```

### React signed file upload result

```ts
// before
const result: UploadResponse<Builder<Context, BucketDefinition>>

// after
const result: {
  url: string;
  size: number;
  uploadedAt: Date;
  metadata: {
    role: "admin" | "visitor";
    category: "invoice" | "contract";
  };
  path: {
    category: string;
    owner: string;
  };
  pathOrder: ("category" | "owner")[];
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
  signedThumbnailUrl?: string | null | undefined;
}
```

### React signed image upload result

```ts
// before
const result: UploadResponse<Builder<Context, BucketDefinition>>

// after
const result: {
  url: string;
  thumbnailUrl: string | null;
  size: number;
  uploadedAt: Date;
  metadata: Record<string, never>;
  path: Record<string, never>;
  pathOrder: [];
  signedUrl: string;
  expiresAt: Date;
  expiresIn: number;
  signedThumbnailUrl?: string | null | undefined;
}
```

## Preserved readable types

The positive hover contracts remain unchanged for path and metadata callbacks, `beforeDelete`, unsigned React uploads, backend upload values, and backend list results.

## Stack

- Base: #135
- #135 is based on #118

## Validation

- `pnpm test:types` — passes, including 19/19 language-service hover contracts
- `pnpm typecheck` — passes
- `pnpm test` — passes: shared 5, server 91, React 16
- `pnpm lint` — passes
- targeted Prettier check for every changed file — passes
- repository-wide Prettier check still reports seven unrelated generated/example files
- `git diff --check` — passes
