### PR TITLE
[SDK 05] feat: add management resource client

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,6 +9,7 @@ export {
   EdgeStoreError,
   EdgeStoreNetworkError,
 } from './errors';
+export type { ManagementClient } from './management';
 export {
   createEdgeStoreSdk,
   type EdgeStoreSdkOptions,

--- a/packages/sdk/src/internal/operationTypes.ts
+++ b/packages/sdk/src/internal/operationTypes.ts
@@ -14,6 +14,13 @@ export type OperationBody<TOperation extends OperationId> =
     ? TBody
     : never;
 
+export type OperationQuery<TOperation extends OperationId> =
+  operations[TOperation] extends {
+    parameters: { query?: infer TQuery };
+  }
+    ? NonNullable<TQuery>
+    : never;
+
 export type SuccessBody<TResponses extends Record<string | number, unknown>> =
   SuccessResponse<TResponses, 'application/json'>;
 

--- a/packages/sdk/src/internal/projectOperation.ts
+++ b/packages/sdk/src/internal/projectOperation.ts
@@ -1,18 +1,15 @@
-const projectOperationMarker = Symbol('EdgeStoreProjectOperation');
-
 type AnyFunction = (...args: never[]) => unknown;
-
-export type ProjectOperation<TFunction extends AnyFunction = AnyFunction> =
-  TFunction & {
-    readonly [projectOperationMarker]: true;
-  };
 
 export type ProjectOperationTree<TClient> = {
   [TResource in keyof TClient]: {
     [
       TOperation in keyof TClient[TResource]
     ]: TClient[TResource][TOperation] extends AnyFunction
-      ? ProjectOperation<TClient[TResource][TOperation]>
+      ? Parameters<TClient[TResource][TOperation]>[0] extends {
+          project: string;
+        }
+        ? TClient[TResource][TOperation]
+        : never
       : never;
   };
 };
@@ -21,12 +18,13 @@ type CurrentProjectInput<TInput> = TInput extends object
   ? Omit<TInput, 'project'> & { project?: never }
   : never;
 
-type ScopedProjectOperation<TOperation> =
-  TOperation extends ProjectOperation<(input: infer TInput) => infer TResult>
-    ? Record<string, never> extends CurrentProjectInput<TInput>
-      ? (input?: CurrentProjectInput<TInput>) => TResult
-      : (input: CurrentProjectInput<TInput>) => TResult
-    : never;
+type ScopedProjectOperation<TOperation> = TOperation extends (
+  input: infer TInput,
+) => infer TResult
+  ? Record<string, never> extends CurrentProjectInput<TInput>
+    ? (input?: CurrentProjectInput<TInput>) => TResult
+    : (input: CurrentProjectInput<TInput>) => TResult
+  : never;
 
 export type ScopedProjectOperationTree<TOperations> = {
   [TResource in keyof TOperations]: {
@@ -36,20 +34,8 @@ export type ScopedProjectOperationTree<TOperations> = {
   };
 };
 
-export function projectOperation<TInput extends { project: string }, TResult>(
-  operation: (input: TInput) => TResult,
-): ProjectOperation<(input: TInput) => TResult> {
-  Object.defineProperty(operation, projectOperationMarker, {
-    value: true,
-  });
-  return operation as ProjectOperation<(input: TInput) => TResult>;
-}
-
 export function scopeProjectOperations<
-  TOperations extends Record<
-    string,
-    Record<string, ProjectOperation<AnyFunction>>
-  >,
+  TOperations extends Record<string, Record<string, AnyFunction>>,
 >(
   operations: TOperations,
   project: string,
@@ -57,21 +43,11 @@ export function scopeProjectOperations<
   const entries = Object.entries(operations).map(([resourceName, resource]) => [
     resourceName,
     Object.fromEntries(
-      Object.entries(resource).map(([operationName, operation]) => {
-        if (
-          typeof operation !== 'function' ||
-          !(projectOperationMarker in operation)
-        ) {
-          throw new TypeError(
-            `Runtime operation ${resourceName}.${operationName} is not project-scoped.`,
-          );
-        }
-        return [
-          operationName,
-          (input: object | undefined) =>
-            operation({ ...input, project } as never),
-        ];
-      }),
+      Object.entries(resource).map(([operationName, operation]) => [
+        operationName,
+        (input: object | undefined) =>
+          operation({ ...input, project } as never),
+      ]),
     ),
   ]);
 

--- a/packages/sdk/src/internal/projectOperation.ts
+++ b/packages/sdk/src/internal/projectOperation.ts
@@ -1,0 +1,79 @@
+const projectOperationMarker = Symbol('EdgeStoreProjectOperation');
+
+type AnyFunction = (...args: never[]) => unknown;
+
+export type ProjectOperation<TFunction extends AnyFunction = AnyFunction> =
+  TFunction & {
+    readonly [projectOperationMarker]: true;
+  };
+
+export type ProjectOperationTree<TClient> = {
+  [TResource in keyof TClient]: {
+    [
+      TOperation in keyof TClient[TResource]
+    ]: TClient[TResource][TOperation] extends AnyFunction
+      ? ProjectOperation<TClient[TResource][TOperation]>
+      : never;
+  };
+};
+
+type CurrentProjectInput<TInput> = TInput extends object
+  ? Omit<TInput, 'project'> & { project?: never }
+  : never;
+
+type ScopedProjectOperation<TOperation> =
+  TOperation extends ProjectOperation<(input: infer TInput) => infer TResult>
+    ? Record<string, never> extends CurrentProjectInput<TInput>
+      ? (input?: CurrentProjectInput<TInput>) => TResult
+      : (input: CurrentProjectInput<TInput>) => TResult
+    : never;
+
+export type ScopedProjectOperationTree<TOperations> = {
+  [TResource in keyof TOperations]: {
+    [TOperation in keyof TOperations[TResource]]: ScopedProjectOperation<
+      TOperations[TResource][TOperation]
+    >;
+  };
+};
+
+export function projectOperation<TInput extends { project: string }, TResult>(
+  operation: (input: TInput) => TResult,
+): ProjectOperation<(input: TInput) => TResult> {
+  Object.defineProperty(operation, projectOperationMarker, {
+    value: true,
+  });
+  return operation as ProjectOperation<(input: TInput) => TResult>;
+}
+
+export function scopeProjectOperations<
+  TOperations extends Record<
+    string,
+    Record<string, ProjectOperation<AnyFunction>>
+  >,
+>(
+  operations: TOperations,
+  project: string,
+): ScopedProjectOperationTree<TOperations> {
+  const entries = Object.entries(operations).map(([resourceName, resource]) => [
+    resourceName,
+    Object.fromEntries(
+      Object.entries(resource).map(([operationName, operation]) => {
+        if (
+          typeof operation !== 'function' ||
+          !(projectOperationMarker in operation)
+        ) {
+          throw new TypeError(
+            `Runtime operation ${resourceName}.${operationName} is not project-scoped.`,
+          );
+        }
+        return [
+          operationName,
+          (input: object | undefined) =>
+            operation({ ...input, project } as never),
+        ];
+      }),
+    ),
+  ]);
+
+  return Object.fromEntries(entries) as ScopedProjectOperationTree<TOperations>;
+}

--- a/packages/sdk/src/internal/runtimeOperations.ts
+++ b/packages/sdk/src/internal/runtimeOperations.ts
@@ -4,18 +4,23 @@ import type {
   RuntimeFileDeleteInput,
   RuntimeFileRestoreInput,
 } from '../runtime';
+import {
+  projectOperation,
+  type ProjectOperationTree,
+} from './projectOperation';
 import type { Transport } from './transport';
 
 type Explicit<TInput> = TInput & { project: string };
 
-export type RuntimeOperations = ExplicitProjectRuntimeClient;
+export type RuntimeOperations =
+  ProjectOperationTree<ExplicitProjectRuntimeClient>;
 
 export function createRuntimeOperations(
   transport: Transport,
 ): RuntimeOperations {
   return {
     accessTokens: {
-      create: ({ project, signal, ...body }) =>
+      create: projectOperation(({ project, signal, ...body }) =>
         transport.execute((client) =>
           client.POST('/runtime/projects/{projectRef}/access-token', {
             params: { path: { projectRef: project } },
@@ -23,25 +28,28 @@ export function createRuntimeOperations(
             signal,
           }),
         ),
+      ),
     },
     projects: {
-      get: ({ project, signal }) =>
+      get: projectOperation(({ project, signal }) =>
         transport.execute((client) =>
           client.GET('/runtime/projects/{projectRef}', {
             params: { path: { projectRef: project } },
             signal,
           }),
         ),
+      ),
     },
     buckets: {
-      list: ({ project, signal }) =>
+      list: projectOperation(({ project, signal }) =>
         transport.execute((client) =>
           client.GET('/runtime/projects/{projectRef}/buckets', {
             params: { path: { projectRef: project } },
             signal,
           }),
         ),
-      get: ({ project, bucket, signal }) =>
+      ),
+      get: projectOperation(({ project, bucket, signal }) =>
         transport.execute((client) =>
           client.GET('/runtime/projects/{projectRef}/buckets/{bucketName}', {
             params: {
@@ -50,9 +58,10 @@ export function createRuntimeOperations(
             signal,
           }),
         ),
+      ),
     },
     files: {
-      search: ({ project, bucket, signal, ...body }) =>
+      search: projectOperation(({ project, bucket, signal, ...body }) =>
         transport.execute((client) =>
           client.POST(
             '/runtime/projects/{projectRef}/buckets/{bucketName}/files/search',
@@ -65,7 +74,8 @@ export function createRuntimeOperations(
             },
           ),
         ),
-      lookup: ({ project, signal, ...body }) =>
+      ),
+      lookup: projectOperation(({ project, signal, ...body }) =>
         transport.execute((client) =>
           client.POST('/runtime/projects/{projectRef}/files/lookup', {
             params: { path: { projectRef: project } },
@@ -73,28 +83,46 @@ export function createRuntimeOperations(
             signal,
           }),
         ),
-      generateSignedReadUrls: ({ project, bucket, signal, ...body }) =>
-        transport.execute((client) =>
-          client.POST(
-            '/runtime/projects/{projectRef}/buckets/{bucketName}/files/signed-urls',
-            {
-              params: {
-                path: { projectRef: project, bucketName: bucket },
+      ),
+      generateSignedReadUrls: projectOperation(
+        ({ project, bucket, signal, ...body }) =>
+          transport.execute((client) =>
+            client.POST(
+              '/runtime/projects/{projectRef}/buckets/{bucketName}/files/signed-urls',
+              {
+                params: {
+                  path: { projectRef: project, bucketName: bucket },
+                },
+                body,
+                signal,
               },
-              body,
-              signal,
-            },
+            ),
           ),
-        ),
-      confirm: ({ project, signal, ...body }) =>
-        executeFileMutation(transport, 'confirm', { project, signal, ...body }),
-      delete: ({ project, signal, ...body }) =>
-        executeFileMutation(transport, 'delete', { project, signal, ...body }),
-      restore: ({ project, signal, ...body }) =>
-        executeFileMutation(transport, 'restore', { project, signal, ...body }),
+      ),
+      confirm: projectOperation(({ project, signal, ...body }) =>
+        executeFileMutation(transport, 'confirm', {
+          project,
+          signal,
+          ...body,
+        }),
+      ),
+      delete: projectOperation(({ project, signal, ...body }) =>
+        executeFileMutation(transport, 'delete', {
+          project,
+          signal,
+          ...body,
+        }),
+      ),
+      restore: projectOperation(({ project, signal, ...body }) =>
+        executeFileMutation(transport, 'restore', {
+          project,
+          signal,
+          ...body,
+        }),
+      ),
     },
     uploads: {
-      request: ({ project, bucket, signal, ...body }) =>
+      request: projectOperation(({ project, bucket, signal, ...body }) =>
         transport.execute((client) =>
           client.POST(
             '/runtime/projects/{projectRef}/buckets/{bucketName}/uploads',
@@ -107,21 +135,24 @@ export function createRuntimeOperations(
             },
           ),
         ),
-      get: ({ project, uploadId, signal }) =>
+      ),
+      get: projectOperation(({ project, uploadId, signal }) =>
         transport.execute((client) =>
           client.GET('/runtime/projects/{projectRef}/uploads/{uploadId}', {
             params: { path: { projectRef: project, uploadId } },
             signal,
           }),
         ),
-      cancel: ({ project, uploadId, signal }) =>
+      ),
+      cancel: projectOperation(({ project, uploadId, signal }) =>
         transport.execute((client) =>
           client.DELETE('/runtime/projects/{projectRef}/uploads/{uploadId}', {
             params: { path: { projectRef: project, uploadId } },
             signal,
           }),
         ),
-      createParts: ({ project, uploadId, signal, ...body }) =>
+      ),
+      createParts: projectOperation(({ project, uploadId, signal, ...body }) =>
         transport.execute((client) =>
           client.POST(
             '/runtime/projects/{projectRef}/uploads/{uploadId}/parts',
@@ -132,17 +163,20 @@ export function createRuntimeOperations(
             },
           ),
         ),
-      completeMultipart: ({ project, uploadId, signal, ...body }) =>
-        transport.execute((client) =>
-          client.POST(
-            '/runtime/projects/{projectRef}/uploads/{uploadId}/complete',
-            {
-              params: { path: { projectRef: project, uploadId } },
-              body,
-              signal,
-            },
+      ),
+      completeMultipart: projectOperation(
+        ({ project, uploadId, signal, ...body }) =>
+          transport.execute((client) =>
+            client.POST(
+              '/runtime/projects/{projectRef}/uploads/{uploadId}/complete',
+              {
+                params: { path: { projectRef: project, uploadId } },
+                body,
+                signal,
+              },
+            ),
           ),
-        ),
+      ),
     },
   };
 }

--- a/packages/sdk/src/internal/runtimeOperations.ts
+++ b/packages/sdk/src/internal/runtimeOperations.ts
@@ -4,10 +4,7 @@ import type {
   RuntimeFileDeleteInput,
   RuntimeFileRestoreInput,
 } from '../runtime';
-import {
-  projectOperation,
-  type ProjectOperationTree,
-} from './projectOperation';
+import type { ProjectOperationTree } from './projectOperation';
 import type { Transport } from './transport';
 
 type Explicit<TInput> = TInput & { project: string };
@@ -20,7 +17,7 @@ export function createRuntimeOperations(
 ): RuntimeOperations {
   return {
     accessTokens: {
-      create: projectOperation(({ project, signal, ...body }) =>
+      create: ({ project, signal, ...body }) =>
         transport.execute((client) =>
           client.POST('/runtime/projects/{projectRef}/access-token', {
             params: { path: { projectRef: project } },
@@ -28,28 +25,25 @@ export function createRuntimeOperations(
             signal,
           }),
         ),
-      ),
     },
     projects: {
-      get: projectOperation(({ project, signal }) =>
+      get: ({ project, signal }) =>
         transport.execute((client) =>
           client.GET('/runtime/projects/{projectRef}', {
             params: { path: { projectRef: project } },
             signal,
           }),
         ),
-      ),
     },
     buckets: {
-      list: projectOperation(({ project, signal }) =>
+      list: ({ project, signal }) =>
         transport.execute((client) =>
           client.GET('/runtime/projects/{projectRef}/buckets', {
             params: { path: { projectRef: project } },
             signal,
           }),
         ),
-      ),
-      get: projectOperation(({ project, bucket, signal }) =>
+      get: ({ project, bucket, signal }) =>
         transport.execute((client) =>
           client.GET('/runtime/projects/{projectRef}/buckets/{bucketName}', {
             params: {
@@ -58,10 +52,9 @@ export function createRuntimeOperations(
             signal,
           }),
         ),
-      ),
     },
     files: {
-      search: projectOperation(({ project, bucket, signal, ...body }) =>
+      search: ({ project, bucket, signal, ...body }) =>
         transport.execute((client) =>
           client.POST(
             '/runtime/projects/{projectRef}/buckets/{bucketName}/files/search',
@@ -74,8 +67,7 @@ export function createRuntimeOperations(
             },
           ),
         ),
-      ),
-      lookup: projectOperation(({ project, signal, ...body }) =>
+      lookup: ({ project, signal, ...body }) =>
         transport.execute((client) =>
           client.POST('/runtime/projects/{projectRef}/files/lookup', {
             params: { path: { projectRef: project } },
@@ -83,46 +75,40 @@ export function createRuntimeOperations(
             signal,
           }),
         ),
-      ),
-      generateSignedReadUrls: projectOperation(
-        ({ project, bucket, signal, ...body }) =>
-          transport.execute((client) =>
-            client.POST(
-              '/runtime/projects/{projectRef}/buckets/{bucketName}/files/signed-urls',
-              {
-                params: {
-                  path: { projectRef: project, bucketName: bucket },
-                },
-                body,
-                signal,
+      generateSignedReadUrls: ({ project, bucket, signal, ...body }) =>
+        transport.execute((client) =>
+          client.POST(
+            '/runtime/projects/{projectRef}/buckets/{bucketName}/files/signed-urls',
+            {
+              params: {
+                path: { projectRef: project, bucketName: bucket },
               },
-            ),
+              body,
+              signal,
+            },
           ),
-      ),
-      confirm: projectOperation(({ project, signal, ...body }) =>
+        ),
+      confirm: ({ project, signal, ...body }) =>
         executeFileMutation(transport, 'confirm', {
           project,
           signal,
           ...body,
         }),
-      ),
-      delete: projectOperation(({ project, signal, ...body }) =>
+      delete: ({ project, signal, ...body }) =>
         executeFileMutation(transport, 'delete', {
           project,
           signal,
           ...body,
         }),
-      ),
-      restore: projectOperation(({ project, signal, ...body }) =>
+      restore: ({ project, signal, ...body }) =>
         executeFileMutation(transport, 'restore', {
           project,
           signal,
           ...body,
         }),
-      ),
     },
     uploads: {
-      request: projectOperation(({ project, bucket, signal, ...body }) =>
+      request: ({ project, bucket, signal, ...body }) =>
         transport.execute((client) =>
           client.POST(
             '/runtime/projects/{projectRef}/buckets/{bucketName}/uploads',
@@ -135,24 +121,21 @@ export function createRuntimeOperations(
             },
           ),
         ),
-      ),
-      get: projectOperation(({ project, uploadId, signal }) =>
+      get: ({ project, uploadId, signal }) =>
         transport.execute((client) =>
           client.GET('/runtime/projects/{projectRef}/uploads/{uploadId}', {
             params: { path: { projectRef: project, uploadId } },
             signal,
           }),
         ),
-      ),
-      cancel: projectOperation(({ project, uploadId, signal }) =>
+      cancel: ({ project, uploadId, signal }) =>
         transport.execute((client) =>
           client.DELETE('/runtime/projects/{projectRef}/uploads/{uploadId}', {
             params: { path: { projectRef: project, uploadId } },
             signal,
           }),
         ),
-      ),
-      createParts: projectOperation(({ project, uploadId, signal, ...body }) =>
+      createParts: ({ project, uploadId, signal, ...body }) =>
         transport.execute((client) =>
           client.POST(
             '/runtime/projects/{projectRef}/uploads/{uploadId}/parts',
@@ -163,20 +146,17 @@ export function createRuntimeOperations(
             },
           ),
         ),
-      ),
-      completeMultipart: projectOperation(
-        ({ project, uploadId, signal, ...body }) =>
-          transport.execute((client) =>
-            client.POST(
-              '/runtime/projects/{projectRef}/uploads/{uploadId}/complete',
-              {
-                params: { path: { projectRef: project, uploadId } },
-                body,
-                signal,
-              },
-            ),
+      completeMultipart: ({ project, uploadId, signal, ...body }) =>
+        transport.execute((client) =>
+          client.POST(
+            '/runtime/projects/{projectRef}/uploads/{uploadId}/complete',
+            {
+              params: { path: { projectRef: project, uploadId } },
+              body,
+              signal,
+            },
           ),
-      ),
+        ),
     },
   };
 }

--- a/packages/sdk/src/management.test.ts
+++ b/packages/sdk/src/management.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import type { ManagementClient } from './management';
+import { createEdgeStoreSdk } from './sdk';
+
+function createManagementSdk(fetch: typeof globalThis.fetch) {
+  return createEdgeStoreSdk({
+    credentials: { token: 'management-token' },
+    baseUrl: 'https://example.com/v2',
+    fetch,
+  });
+}
+
+describe('management resources', () => {
+  it('maps project creation and idempotency to the API contract', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      expect(request.method).toBe('POST');
+      expect(request.url).toBe(
+        'https://example.com/v2/management/accounts/account-id/projects',
+      );
+      expect(request.headers.get('idempotency-key')).toBe('project-request');
+      await expect(request.json()).resolves.toEqual({
+        name: 'Customer portal',
+        createKey: true,
+      });
+      return Response.json({ data: { project: { id: 'project-id' } } });
+    });
+    const sdk = createManagementSdk(fetch);
+
+    const result = await sdk.management.projects.create({
+      account: 'account-id',
+      name: 'Customer portal',
+      createKey: true,
+      idempotencyKey: 'project-request',
+    });
+
+    expect(result.project.id).toBe('project-id');
+    expectTypeOf(sdk.management).toEqualTypeOf<ManagementClient>();
+  });
+
+  it('serializes file pagination as query parameters', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      expect(request.url).toBe(
+        'https://example.com/v2/management/projects/project-id/buckets/documents/files?cursor=next-page&limit=50',
+      );
+      return Response.json({ data: { files: [], pagination: {} } });
+    });
+    const sdk = createManagementSdk(fetch);
+
+    await sdk.management.files.list({
+      project: 'project-id',
+      bucket: 'documents',
+      cursor: 'next-page',
+      limit: 50,
+    });
+
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('returns undefined for successful empty responses', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(
+      async () => new Response(null, { status: 204 }),
+    );
+    const sdk = createManagementSdk(fetch);
+
+    await expect(
+      sdk.management.projects.delete({ project: 'project-id' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/sdk/src/management.test.ts
+++ b/packages/sdk/src/management.test.ts
@@ -57,14 +57,14 @@ describe('management resources', () => {
     expect(fetch).toHaveBeenCalledOnce();
   });
 
-  it('returns undefined for successful empty responses', async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(
-      async () => new Response(null, { status: 204 }),
+  it('returns the API response for project deletion', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+      Response.json({ data: {} }),
     );
     const sdk = createManagementSdk(fetch);
 
     await expect(
       sdk.management.projects.delete({ project: 'project-id' }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({});
   });
 });

--- a/packages/sdk/src/management.test.ts
+++ b/packages/sdk/src/management.test.ts
@@ -11,14 +11,14 @@ function createManagementSdk(fetch: typeof globalThis.fetch) {
 }
 
 describe('management resources', () => {
-  it('maps project creation and idempotency to the API contract', async () => {
+  it('maps project creation to the API contract', async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
       const request = input instanceof Request ? input : new Request(input);
       expect(request.method).toBe('POST');
       expect(request.url).toBe(
         'https://example.com/v2/management/accounts/account-id/projects',
       );
-      expect(request.headers.get('idempotency-key')).toBe('project-request');
+      expect(request.headers.has('idempotency-key')).toBe(false);
       await expect(request.json()).resolves.toEqual({
         name: 'Customer portal',
         createKey: true,
@@ -31,7 +31,6 @@ describe('management resources', () => {
       account: 'account-id',
       name: 'Customer portal',
       createKey: true,
-      idempotencyKey: 'project-request',
     });
 
     expect(result.project.id).toBe('project-id');

--- a/packages/sdk/src/management.ts
+++ b/packages/sdk/src/management.ts
@@ -1,0 +1,363 @@
+import type {
+  OperationBody,
+  OperationId,
+  OperationQuery,
+  OperationResult,
+} from './internal/operationTypes';
+import type { Transport } from './internal/transport';
+
+type CallOptions = { signal?: AbortSignal };
+type AccountInput = { account: string };
+type ProjectInput = { project: string };
+type BucketInput = ProjectInput & { bucket: string };
+type UploadInput = ProjectInput & { uploadId: string };
+type EmptyJobInput = BucketInput & { jobId: string };
+type Idempotent = { idempotencyKey?: string };
+
+type Result<TOperation extends OperationId> = OperationResult<TOperation>;
+
+export type ManagementClient = {
+  projects: {
+    list(
+      input: AccountInput & CallOptions,
+    ): Promise<Result<'v2.management.projects.list'>>;
+    create(
+      input: AccountInput &
+        OperationBody<'v2.management.projects.create'> &
+        Idempotent &
+        CallOptions,
+    ): Promise<Result<'v2.management.projects.create'>>;
+    get(
+      input: ProjectInput & CallOptions,
+    ): Promise<Result<'v2.management.projects.get'>>;
+    delete(
+      input: ProjectInput & CallOptions,
+    ): Promise<Result<'v2.management.projects.delete'>>;
+  };
+  buckets: {
+    list(
+      input: ProjectInput & CallOptions,
+    ): Promise<Result<'v2.management.buckets.list'>>;
+    create(
+      input: ProjectInput &
+        OperationBody<'v2.management.buckets.create'> &
+        Idempotent &
+        CallOptions,
+    ): Promise<Result<'v2.management.buckets.create'>>;
+    get(
+      input: BucketInput & CallOptions,
+    ): Promise<Result<'v2.management.buckets.get'>>;
+    update(
+      input: BucketInput &
+        OperationBody<'v2.management.buckets.update'> &
+        CallOptions,
+    ): Promise<Result<'v2.management.buckets.update'>>;
+    delete(
+      input: BucketInput & CallOptions,
+    ): Promise<Result<'v2.management.buckets.delete'>>;
+    empty(
+      input: BucketInput & CallOptions,
+    ): Promise<Result<'v2.management.buckets.empty'>>;
+    emptyJobs: {
+      latest(
+        input: BucketInput & CallOptions,
+      ): Promise<Result<'v2.management.buckets.emptyJobs.latest'>>;
+      get(
+        input: EmptyJobInput & CallOptions,
+      ): Promise<Result<'v2.management.buckets.emptyJobs.get'>>;
+      retry(
+        input: EmptyJobInput & CallOptions,
+      ): Promise<Result<'v2.management.buckets.emptyJobs.retry'>>;
+    };
+  };
+  files: {
+    list(
+      input: BucketInput &
+        OperationQuery<'v2.management.files.list'> &
+        CallOptions,
+    ): Promise<Result<'v2.management.files.list'>>;
+    lookup(
+      input: ProjectInput &
+        OperationBody<'v2.management.files.lookup'> &
+        CallOptions,
+    ): Promise<Result<'v2.management.files.lookup'>>;
+    createDownloadUrls(
+      input: ProjectInput &
+        OperationBody<'v2.management.files.downloadUrls.create'> &
+        CallOptions,
+    ): Promise<Result<'v2.management.files.downloadUrls.create'>>;
+    delete(
+      input: ProjectInput &
+        OperationBody<'v2.management.files.delete'> &
+        CallOptions,
+    ): Promise<Result<'v2.management.files.delete'>>;
+  };
+  uploads: {
+    request(
+      input: BucketInput &
+        OperationBody<'v2.management.uploads.request'> &
+        Idempotent &
+        CallOptions,
+    ): Promise<Result<'v2.management.uploads.request'>>;
+    get(
+      input: UploadInput & CallOptions,
+    ): Promise<Result<'v2.management.uploads.get'>>;
+    cancel(
+      input: UploadInput & CallOptions,
+    ): Promise<Result<'v2.management.uploads.cancel'>>;
+    createParts(
+      input: UploadInput &
+        OperationBody<'v2.management.uploads.parts.create'> &
+        CallOptions,
+    ): Promise<Result<'v2.management.uploads.parts.create'>>;
+    completeMultipart(
+      input: UploadInput &
+        OperationBody<'v2.management.uploads.multipart.complete'> &
+        CallOptions,
+    ): Promise<Result<'v2.management.uploads.multipart.complete'>>;
+  };
+};
+
+export function createManagementClient(transport: Transport): ManagementClient {
+  return {
+    projects: {
+      list: ({ account, signal }) =>
+        transport.execute(() =>
+          transport.client.GET('/management/accounts/{accountId}/projects', {
+            params: { path: { accountId: account } },
+            signal,
+          }),
+        ),
+      create: ({ account, idempotencyKey, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST('/management/accounts/{accountId}/projects', {
+            params: {
+              path: { accountId: account },
+              header: { 'idempotency-key': idempotencyKey },
+            },
+            body,
+            signal,
+          }),
+        ),
+      get: ({ project, signal }) =>
+        transport.execute(() =>
+          transport.client.GET('/management/projects/{projectRef}', {
+            params: { path: { projectRef: project } },
+            signal,
+          }),
+        ),
+      delete: ({ project, signal }) =>
+        transport.execute(() =>
+          transport.client.DELETE('/management/projects/{projectRef}', {
+            params: { path: { projectRef: project } },
+            signal,
+          }),
+        ),
+    },
+    buckets: {
+      list: ({ project, signal }) =>
+        transport.execute(() =>
+          transport.client.GET('/management/projects/{projectRef}/buckets', {
+            params: { path: { projectRef: project } },
+            signal,
+          }),
+        ),
+      create: ({ project, idempotencyKey, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST('/management/projects/{projectRef}/buckets', {
+            params: {
+              path: { projectRef: project },
+              header: { 'idempotency-key': idempotencyKey },
+            },
+            body,
+            signal,
+          }),
+        ),
+      get: ({ project, bucket, signal }) =>
+        transport.execute(() =>
+          transport.client.GET(
+            '/management/projects/{projectRef}/buckets/{bucketName}',
+            {
+              params: { path: { projectRef: project, bucketName: bucket } },
+              signal,
+            },
+          ),
+        ),
+      update: ({ project, bucket, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.PATCH(
+            '/management/projects/{projectRef}/buckets/{bucketName}',
+            {
+              params: { path: { projectRef: project, bucketName: bucket } },
+              body,
+              signal,
+            },
+          ),
+        ),
+      delete: ({ project, bucket, signal }) =>
+        transport.execute(() =>
+          transport.client.DELETE(
+            '/management/projects/{projectRef}/buckets/{bucketName}',
+            {
+              params: { path: { projectRef: project, bucketName: bucket } },
+              signal,
+            },
+          ),
+        ),
+      empty: ({ project, bucket, signal }) =>
+        transport.execute(() =>
+          transport.client.POST(
+            '/management/projects/{projectRef}/buckets/{bucketName}/empty',
+            {
+              params: { path: { projectRef: project, bucketName: bucket } },
+              body: {},
+              signal,
+            },
+          ),
+        ),
+      emptyJobs: {
+        latest: ({ project, bucket, signal }) =>
+          transport.execute(() =>
+            transport.client.GET(
+              '/management/projects/{projectRef}/buckets/{bucketName}/empty-job',
+              {
+                params: { path: { projectRef: project, bucketName: bucket } },
+                signal,
+              },
+            ),
+          ),
+        get: ({ project, bucket, jobId, signal }) =>
+          transport.execute(() =>
+            transport.client.GET(
+              '/management/projects/{projectRef}/buckets/{bucketName}/empty-jobs/{jobId}',
+              {
+                params: {
+                  path: { projectRef: project, bucketName: bucket, jobId },
+                },
+                signal,
+              },
+            ),
+          ),
+        retry: ({ project, bucket, jobId, signal }) =>
+          transport.execute(() =>
+            transport.client.POST(
+              '/management/projects/{projectRef}/buckets/{bucketName}/empty-jobs/{jobId}/retry',
+              {
+                params: {
+                  path: { projectRef: project, bucketName: bucket, jobId },
+                },
+                body: {},
+                signal,
+              },
+            ),
+          ),
+      },
+    },
+    files: {
+      list: ({ project, bucket, cursor, limit, signal }) =>
+        transport.execute(() =>
+          transport.client.GET(
+            '/management/projects/{projectRef}/buckets/{bucketName}/files',
+            {
+              params: {
+                path: { projectRef: project, bucketName: bucket },
+                query: { cursor, limit },
+              },
+              signal,
+            },
+          ),
+        ),
+      lookup: ({ project, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST(
+            '/management/projects/{projectRef}/files/lookup',
+            {
+              params: { path: { projectRef: project } },
+              body,
+              signal,
+            },
+          ),
+        ),
+      createDownloadUrls: ({ project, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST(
+            '/management/projects/{projectRef}/files/download-urls',
+            {
+              params: { path: { projectRef: project } },
+              body,
+              signal,
+            },
+          ),
+        ),
+      delete: ({ project, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST(
+            '/management/projects/{projectRef}/files/delete',
+            {
+              params: { path: { projectRef: project } },
+              body,
+              signal,
+            },
+          ),
+        ),
+    },
+    uploads: {
+      request: ({ project, bucket, idempotencyKey, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST(
+            '/management/projects/{projectRef}/buckets/{bucketName}/uploads',
+            {
+              params: {
+                path: { projectRef: project, bucketName: bucket },
+                header: { 'idempotency-key': idempotencyKey },
+              },
+              body,
+              signal,
+            },
+          ),
+        ),
+      get: ({ project, uploadId, signal }) =>
+        transport.execute(() =>
+          transport.client.GET(
+            '/management/projects/{projectRef}/uploads/{uploadId}',
+            {
+              params: { path: { projectRef: project, uploadId } },
+              signal,
+            },
+          ),
+        ),
+      cancel: ({ project, uploadId, signal }) =>
+        transport.execute(() =>
+          transport.client.DELETE(
+            '/management/projects/{projectRef}/uploads/{uploadId}',
+            {
+              params: { path: { projectRef: project, uploadId } },
+              signal,
+            },
+          ),
+        ),
+      createParts: ({ project, uploadId, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST(
+            '/management/projects/{projectRef}/uploads/{uploadId}/parts',
+            {
+              params: { path: { projectRef: project, uploadId } },
+              body,
+              signal,
+            },
+          ),
+        ),
+      completeMultipart: ({ project, uploadId, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST(
+            '/management/projects/{projectRef}/uploads/{uploadId}/complete',
+            {
+              params: { path: { projectRef: project, uploadId } },
+              body,
+              signal,
+            },
+          ),
+        ),
+    },
+  };
+}

--- a/packages/sdk/src/management.ts
+++ b/packages/sdk/src/management.ts
@@ -12,7 +12,6 @@ type ProjectInput = { project: string };
 type BucketInput = ProjectInput & { bucket: string };
 type UploadInput = ProjectInput & { uploadId: string };
 type EmptyJobInput = BucketInput & { jobId: string };
-type Idempotent = { idempotencyKey?: string };
 
 type Result<TOperation extends OperationId> = OperationResult<TOperation>;
 
@@ -24,7 +23,6 @@ export type ManagementClient = {
     create(
       input: AccountInput &
         OperationBody<'v2.management.projects.create'> &
-        Idempotent &
         CallOptions,
     ): Promise<Result<'v2.management.projects.create'>>;
     get(
@@ -41,7 +39,6 @@ export type ManagementClient = {
     create(
       input: ProjectInput &
         OperationBody<'v2.management.buckets.create'> &
-        Idempotent &
         CallOptions,
     ): Promise<Result<'v2.management.buckets.create'>>;
     get(
@@ -96,7 +93,6 @@ export type ManagementClient = {
     request(
       input: BucketInput &
         OperationBody<'v2.management.uploads.request'> &
-        Idempotent &
         CallOptions,
     ): Promise<Result<'v2.management.uploads.request'>>;
     get(
@@ -128,13 +124,10 @@ export function createManagementClient(transport: Transport): ManagementClient {
             signal,
           }),
         ),
-      create: ({ account, idempotencyKey, signal, ...body }) =>
+      create: ({ account, signal, ...body }) =>
         transport.execute(() =>
           transport.client.POST('/management/accounts/{accountId}/projects', {
-            params: {
-              path: { accountId: account },
-              header: { 'idempotency-key': idempotencyKey },
-            },
+            params: { path: { accountId: account } },
             body,
             signal,
           }),
@@ -162,13 +155,10 @@ export function createManagementClient(transport: Transport): ManagementClient {
             signal,
           }),
         ),
-      create: ({ project, idempotencyKey, signal, ...body }) =>
+      create: ({ project, signal, ...body }) =>
         transport.execute(() =>
           transport.client.POST('/management/projects/{projectRef}/buckets', {
-            params: {
-              path: { projectRef: project },
-              header: { 'idempotency-key': idempotencyKey },
-            },
+            params: { path: { projectRef: project } },
             body,
             signal,
           }),
@@ -254,14 +244,14 @@ export function createManagementClient(transport: Transport): ManagementClient {
       },
     },
     files: {
-      list: ({ project, bucket, cursor, limit, signal }) =>
+      list: ({ project, bucket, signal, ...query }) =>
         transport.execute(() =>
           transport.client.GET(
             '/management/projects/{projectRef}/buckets/{bucketName}/files',
             {
               params: {
                 path: { projectRef: project, bucketName: bucket },
-                query: { cursor, limit },
+                query,
               },
               signal,
             },
@@ -302,14 +292,13 @@ export function createManagementClient(transport: Transport): ManagementClient {
         ),
     },
     uploads: {
-      request: ({ project, bucket, idempotencyKey, signal, ...body }) =>
+      request: ({ project, bucket, signal, ...body }) =>
         transport.execute(() =>
           transport.client.POST(
             '/management/projects/{projectRef}/buckets/{bucketName}/uploads',
             {
               params: {
                 path: { projectRef: project, bucketName: bucket },
-                header: { 'idempotency-key': idempotencyKey },
               },
               body,
               signal,

--- a/packages/sdk/src/management.ts
+++ b/packages/sdk/src/management.ts
@@ -78,11 +78,11 @@ export type ManagementClient = {
         OperationBody<'v2.management.files.lookup'> &
         CallOptions,
     ): Promise<Result<'v2.management.files.lookup'>>;
-    createDownloadUrls(
+    generateAccessUrls(
       input: ProjectInput &
-        OperationBody<'v2.management.files.downloadUrls.create'> &
+        OperationBody<'v2.management.files.generateAccessUrls'> &
         CallOptions,
-    ): Promise<Result<'v2.management.files.downloadUrls.create'>>;
+    ): Promise<Result<'v2.management.files.generateAccessUrls'>>;
     delete(
       input: ProjectInput &
         OperationBody<'v2.management.files.delete'> &
@@ -262,9 +262,9 @@ export function createManagementClient(transport: Transport): ManagementClient {
             signal,
           }),
         ),
-      createDownloadUrls: ({ project, signal, ...body }) =>
+      generateAccessUrls: ({ project, signal, ...body }) =>
         transport.execute((client) =>
-          client.POST('/management/projects/{projectRef}/files/download-urls', {
+          client.POST('/management/projects/{projectRef}/files/access-urls', {
             params: { path: { projectRef: project } },
             body,
             signal,

--- a/packages/sdk/src/management.ts
+++ b/packages/sdk/src/management.ts
@@ -118,30 +118,30 @@ export function createManagementClient(transport: Transport): ManagementClient {
   return {
     projects: {
       list: ({ account, signal }) =>
-        transport.execute(() =>
-          transport.client.GET('/management/accounts/{accountId}/projects', {
+        transport.execute((client) =>
+          client.GET('/management/accounts/{accountId}/projects', {
             params: { path: { accountId: account } },
             signal,
           }),
         ),
       create: ({ account, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST('/management/accounts/{accountId}/projects', {
+        transport.execute((client) =>
+          client.POST('/management/accounts/{accountId}/projects', {
             params: { path: { accountId: account } },
             body,
             signal,
           }),
         ),
       get: ({ project, signal }) =>
-        transport.execute(() =>
-          transport.client.GET('/management/projects/{projectRef}', {
+        transport.execute((client) =>
+          client.GET('/management/projects/{projectRef}', {
             params: { path: { projectRef: project } },
             signal,
           }),
         ),
       delete: ({ project, signal }) =>
-        transport.execute(() =>
-          transport.client.DELETE('/management/projects/{projectRef}', {
+        transport.execute((client) =>
+          client.DELETE('/management/projects/{projectRef}', {
             params: { path: { projectRef: project } },
             signal,
           }),
@@ -149,33 +149,30 @@ export function createManagementClient(transport: Transport): ManagementClient {
     },
     buckets: {
       list: ({ project, signal }) =>
-        transport.execute(() =>
-          transport.client.GET('/management/projects/{projectRef}/buckets', {
+        transport.execute((client) =>
+          client.GET('/management/projects/{projectRef}/buckets', {
             params: { path: { projectRef: project } },
             signal,
           }),
         ),
       create: ({ project, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST('/management/projects/{projectRef}/buckets', {
+        transport.execute((client) =>
+          client.POST('/management/projects/{projectRef}/buckets', {
             params: { path: { projectRef: project } },
             body,
             signal,
           }),
         ),
       get: ({ project, bucket, signal }) =>
-        transport.execute(() =>
-          transport.client.GET(
-            '/management/projects/{projectRef}/buckets/{bucketName}',
-            {
-              params: { path: { projectRef: project, bucketName: bucket } },
-              signal,
-            },
-          ),
+        transport.execute((client) =>
+          client.GET('/management/projects/{projectRef}/buckets/{bucketName}', {
+            params: { path: { projectRef: project, bucketName: bucket } },
+            signal,
+          }),
         ),
       update: ({ project, bucket, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.PATCH(
+        transport.execute((client) =>
+          client.PATCH(
             '/management/projects/{projectRef}/buckets/{bucketName}',
             {
               params: { path: { projectRef: project, bucketName: bucket } },
@@ -185,8 +182,8 @@ export function createManagementClient(transport: Transport): ManagementClient {
           ),
         ),
       delete: ({ project, bucket, signal }) =>
-        transport.execute(() =>
-          transport.client.DELETE(
+        transport.execute((client) =>
+          client.DELETE(
             '/management/projects/{projectRef}/buckets/{bucketName}',
             {
               params: { path: { projectRef: project, bucketName: bucket } },
@@ -195,8 +192,8 @@ export function createManagementClient(transport: Transport): ManagementClient {
           ),
         ),
       empty: ({ project, bucket, signal }) =>
-        transport.execute(() =>
-          transport.client.POST(
+        transport.execute((client) =>
+          client.POST(
             '/management/projects/{projectRef}/buckets/{bucketName}/empty',
             {
               params: { path: { projectRef: project, bucketName: bucket } },
@@ -207,8 +204,8 @@ export function createManagementClient(transport: Transport): ManagementClient {
         ),
       emptyJobs: {
         latest: ({ project, bucket, signal }) =>
-          transport.execute(() =>
-            transport.client.GET(
+          transport.execute((client) =>
+            client.GET(
               '/management/projects/{projectRef}/buckets/{bucketName}/empty-job',
               {
                 params: { path: { projectRef: project, bucketName: bucket } },
@@ -217,8 +214,8 @@ export function createManagementClient(transport: Transport): ManagementClient {
             ),
           ),
         get: ({ project, bucket, jobId, signal }) =>
-          transport.execute(() =>
-            transport.client.GET(
+          transport.execute((client) =>
+            client.GET(
               '/management/projects/{projectRef}/buckets/{bucketName}/empty-jobs/{jobId}',
               {
                 params: {
@@ -229,8 +226,8 @@ export function createManagementClient(transport: Transport): ManagementClient {
             ),
           ),
         retry: ({ project, bucket, jobId, signal }) =>
-          transport.execute(() =>
-            transport.client.POST(
+          transport.execute((client) =>
+            client.POST(
               '/management/projects/{projectRef}/buckets/{bucketName}/empty-jobs/{jobId}/retry',
               {
                 params: {
@@ -245,8 +242,8 @@ export function createManagementClient(transport: Transport): ManagementClient {
     },
     files: {
       list: ({ project, bucket, signal, ...query }) =>
-        transport.execute(() =>
-          transport.client.GET(
+        transport.execute((client) =>
+          client.GET(
             '/management/projects/{projectRef}/buckets/{bucketName}/files',
             {
               params: {
@@ -258,43 +255,34 @@ export function createManagementClient(transport: Transport): ManagementClient {
           ),
         ),
       lookup: ({ project, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST(
-            '/management/projects/{projectRef}/files/lookup',
-            {
-              params: { path: { projectRef: project } },
-              body,
-              signal,
-            },
-          ),
+        transport.execute((client) =>
+          client.POST('/management/projects/{projectRef}/files/lookup', {
+            params: { path: { projectRef: project } },
+            body,
+            signal,
+          }),
         ),
       createDownloadUrls: ({ project, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST(
-            '/management/projects/{projectRef}/files/download-urls',
-            {
-              params: { path: { projectRef: project } },
-              body,
-              signal,
-            },
-          ),
+        transport.execute((client) =>
+          client.POST('/management/projects/{projectRef}/files/download-urls', {
+            params: { path: { projectRef: project } },
+            body,
+            signal,
+          }),
         ),
       delete: ({ project, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST(
-            '/management/projects/{projectRef}/files/delete',
-            {
-              params: { path: { projectRef: project } },
-              body,
-              signal,
-            },
-          ),
+        transport.execute((client) =>
+          client.POST('/management/projects/{projectRef}/files/delete', {
+            params: { path: { projectRef: project } },
+            body,
+            signal,
+          }),
         ),
     },
     uploads: {
       request: ({ project, bucket, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST(
+        transport.execute((client) =>
+          client.POST(
             '/management/projects/{projectRef}/buckets/{bucketName}/uploads',
             {
               params: {
@@ -306,18 +294,15 @@ export function createManagementClient(transport: Transport): ManagementClient {
           ),
         ),
       get: ({ project, uploadId, signal }) =>
-        transport.execute(() =>
-          transport.client.GET(
-            '/management/projects/{projectRef}/uploads/{uploadId}',
-            {
-              params: { path: { projectRef: project, uploadId } },
-              signal,
-            },
-          ),
+        transport.execute((client) =>
+          client.GET('/management/projects/{projectRef}/uploads/{uploadId}', {
+            params: { path: { projectRef: project, uploadId } },
+            signal,
+          }),
         ),
       cancel: ({ project, uploadId, signal }) =>
-        transport.execute(() =>
-          transport.client.DELETE(
+        transport.execute((client) =>
+          client.DELETE(
             '/management/projects/{projectRef}/uploads/{uploadId}',
             {
               params: { path: { projectRef: project, uploadId } },
@@ -326,8 +311,8 @@ export function createManagementClient(transport: Transport): ManagementClient {
           ),
         ),
       createParts: ({ project, uploadId, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST(
+        transport.execute((client) =>
+          client.POST(
             '/management/projects/{projectRef}/uploads/{uploadId}/parts',
             {
               params: { path: { projectRef: project, uploadId } },
@@ -337,8 +322,8 @@ export function createManagementClient(transport: Transport): ManagementClient {
           ),
         ),
       completeMultipart: ({ project, uploadId, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST(
+        transport.execute((client) =>
+          client.POST(
             '/management/projects/{projectRef}/uploads/{uploadId}/complete',
             {
               params: { path: { projectRef: project, uploadId } },

--- a/packages/sdk/src/managementContract.test.ts
+++ b/packages/sdk/src/managementContract.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEdgeStoreSdk } from './sdk';
+
+describe('management resource request mappings', () => {
+  it('maps every resource operation to its HTTP contract', async () => {
+    const requests: Request[] = [];
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      requests.push(input instanceof Request ? input : new Request(input));
+      return Response.json({ data: {} });
+    });
+    const sdk = createEdgeStoreSdk({
+      credentials: { token: 'management-token' },
+      baseUrl: 'https://example.com/v2',
+      fetch,
+    });
+    const project = 'project-id';
+    const bucket = 'documents';
+    const uploadId = 'upload-id';
+    const cases: {
+      name: string;
+      invoke: () => Promise<unknown>;
+      method: string;
+      path: string;
+      body?: unknown;
+    }[] = [
+      {
+        name: 'projects.list',
+        invoke: () => sdk.management.projects.list({ account: 'account-id' }),
+        method: 'GET',
+        path: '/v2/management/accounts/account-id/projects',
+      },
+      {
+        name: 'projects.create',
+        invoke: () =>
+          sdk.management.projects.create({
+            account: 'account-id',
+            name: 'Website',
+            createKey: true,
+          }),
+        method: 'POST',
+        path: '/v2/management/accounts/account-id/projects',
+        body: { name: 'Website', createKey: true },
+      },
+      {
+        name: 'projects.get',
+        invoke: () => sdk.management.projects.get({ project }),
+        method: 'GET',
+        path: `/v2/management/projects/${project}`,
+      },
+      {
+        name: 'projects.delete',
+        invoke: () => sdk.management.projects.delete({ project }),
+        method: 'DELETE',
+        path: `/v2/management/projects/${project}`,
+      },
+      {
+        name: 'buckets.list',
+        invoke: () => sdk.management.buckets.list({ project }),
+        method: 'GET',
+        path: `/v2/management/projects/${project}/buckets`,
+      },
+      {
+        name: 'buckets.create',
+        invoke: () =>
+          sdk.management.buckets.create({
+            project,
+            name: bucket,
+            type: 'file',
+            visibility: 'protected',
+          }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/buckets`,
+        body: { name: bucket, type: 'file', visibility: 'protected' },
+      },
+      {
+        name: 'buckets.get',
+        invoke: () => sdk.management.buckets.get({ project, bucket }),
+        method: 'GET',
+        path: `/v2/management/projects/${project}/buckets/${bucket}`,
+      },
+      {
+        name: 'buckets.update',
+        invoke: () =>
+          sdk.management.buckets.update({
+            project,
+            bucket,
+            metadata: { custom: ['category'] },
+          }),
+        method: 'PATCH',
+        path: `/v2/management/projects/${project}/buckets/${bucket}`,
+        body: { metadata: { custom: ['category'] } },
+      },
+      {
+        name: 'buckets.delete',
+        invoke: () => sdk.management.buckets.delete({ project, bucket }),
+        method: 'DELETE',
+        path: `/v2/management/projects/${project}/buckets/${bucket}`,
+      },
+      {
+        name: 'buckets.empty',
+        invoke: () => sdk.management.buckets.empty({ project, bucket }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/buckets/${bucket}/empty`,
+        body: {},
+      },
+      {
+        name: 'buckets.emptyJobs.latest',
+        invoke: () =>
+          sdk.management.buckets.emptyJobs.latest({ project, bucket }),
+        method: 'GET',
+        path: `/v2/management/projects/${project}/buckets/${bucket}/empty-job`,
+      },
+      {
+        name: 'buckets.emptyJobs.get',
+        invoke: () =>
+          sdk.management.buckets.emptyJobs.get({
+            project,
+            bucket,
+            jobId: 'job-id',
+          }),
+        method: 'GET',
+        path: `/v2/management/projects/${project}/buckets/${bucket}/empty-jobs/job-id`,
+      },
+      {
+        name: 'buckets.emptyJobs.retry',
+        invoke: () =>
+          sdk.management.buckets.emptyJobs.retry({
+            project,
+            bucket,
+            jobId: 'job-id',
+          }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/buckets/${bucket}/empty-jobs/job-id/retry`,
+        body: {},
+      },
+      {
+        name: 'files.list',
+        invoke: () =>
+          sdk.management.files.list({
+            project,
+            bucket,
+            cursor: 'next',
+            limit: 10,
+          }),
+        method: 'GET',
+        path: `/v2/management/projects/${project}/buckets/${bucket}/files?cursor=next&limit=10`,
+      },
+      {
+        name: 'files.lookup',
+        invoke: () =>
+          sdk.management.files.lookup({
+            project,
+            file: { id: 'file-id' },
+          }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/files/lookup`,
+        body: { file: { id: 'file-id' } },
+      },
+      {
+        name: 'files.createDownloadUrls',
+        invoke: () =>
+          sdk.management.files.createDownloadUrls({
+            project,
+            files: [{ id: 'file-id' }],
+            expiresIn: 60,
+          }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/files/download-urls`,
+        body: { files: [{ id: 'file-id' }], expiresIn: 60 },
+      },
+      {
+        name: 'files.delete',
+        invoke: () =>
+          sdk.management.files.delete({
+            project,
+            files: [{ id: 'file-id' }],
+          }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/files/delete`,
+        body: { files: [{ id: 'file-id' }] },
+      },
+      {
+        name: 'uploads.request',
+        invoke: () =>
+          sdk.management.uploads.request({
+            project,
+            bucket,
+            sizeBytes: 42,
+          }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/buckets/${bucket}/uploads`,
+        body: { sizeBytes: 42 },
+      },
+      {
+        name: 'uploads.get',
+        invoke: () => sdk.management.uploads.get({ project, uploadId }),
+        method: 'GET',
+        path: `/v2/management/projects/${project}/uploads/${uploadId}`,
+      },
+      {
+        name: 'uploads.cancel',
+        invoke: () => sdk.management.uploads.cancel({ project, uploadId }),
+        method: 'DELETE',
+        path: `/v2/management/projects/${project}/uploads/${uploadId}`,
+      },
+      {
+        name: 'uploads.createParts',
+        invoke: () =>
+          sdk.management.uploads.createParts({
+            project,
+            uploadId,
+            partNumbers: [1],
+          }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/uploads/${uploadId}/parts`,
+        body: { partNumbers: [1] },
+      },
+      {
+        name: 'uploads.completeMultipart',
+        invoke: () =>
+          sdk.management.uploads.completeMultipart({
+            project,
+            uploadId,
+            parts: [{ partNumber: 1, eTag: 'etag-1' }],
+          }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/uploads/${uploadId}/complete`,
+        body: { parts: [{ partNumber: 1, eTag: 'etag-1' }] },
+      },
+    ];
+
+    for (const testCase of cases) {
+      requests.length = 0;
+      await testCase.invoke();
+      expect(requests, testCase.name).toHaveLength(1);
+      const request = requests[0]!;
+      expect(request.method, testCase.name).toBe(testCase.method);
+      const url = new URL(request.url);
+      expect(`${url.pathname}${url.search}`, testCase.name).toBe(testCase.path);
+      if (testCase.body !== undefined) {
+        await expect(request.json(), testCase.name).resolves.toEqual(
+          testCase.body,
+        );
+      }
+    }
+  });
+});

--- a/packages/sdk/src/managementContract.test.ts
+++ b/packages/sdk/src/managementContract.test.ts
@@ -157,15 +157,15 @@ describe('management resource request mappings', () => {
         body: { file: { id: 'file-id' } },
       },
       {
-        name: 'files.createDownloadUrls',
+        name: 'files.generateAccessUrls',
         invoke: () =>
-          sdk.management.files.createDownloadUrls({
+          sdk.management.files.generateAccessUrls({
             project,
             files: [{ id: 'file-id' }],
             expiresIn: 60,
           }),
         method: 'POST',
-        path: `/v2/management/projects/${project}/files/download-urls`,
+        path: `/v2/management/projects/${project}/files/access-urls`,
         body: { files: [{ id: 'file-id' }], expiresIn: 60 },
       },
       {

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -1,8 +1,6 @@
 import type { OperationBody, OperationResult } from './internal/operationTypes';
-import {
-  createRuntimeOperations,
-  type RuntimeOperations,
-} from './internal/runtimeOperations';
+import { scopeProjectOperations } from './internal/projectOperation';
+import { createRuntimeOperations } from './internal/runtimeOperations';
 import type { Transport } from './internal/transport';
 
 export type RuntimeCallOptions = { signal?: AbortSignal };
@@ -147,23 +145,5 @@ export function createExplicitProjectRuntimeClient(
 export function createProjectRuntimeClient(
   transport: Transport,
 ): ProjectRuntimeClient {
-  return scopeRuntimeOperations(createRuntimeOperations(transport), '_current');
-}
-
-function scopeRuntimeOperations(
-  operations: RuntimeOperations,
-  project: string,
-): ProjectRuntimeClient {
-  const entries = Object.entries(operations).map(([resourceName, resource]) => [
-    resourceName,
-    Object.fromEntries(
-      Object.entries(resource).map(([operationName, operation]) => [
-        operationName,
-        (input: object | undefined) =>
-          operation({ ...input, project } as never),
-      ]),
-    ),
-  ]);
-
-  return Object.fromEntries(entries) as ProjectRuntimeClient;
+  return scopeProjectOperations(createRuntimeOperations(transport), '_current');
 }

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -5,6 +5,7 @@ import type {
 } from './credentials';
 import { classifyCredentials } from './credentials';
 import { createTransport } from './internal/transport';
+import { createManagementClient, type ManagementClient } from './management';
 import {
   createExplicitProjectRuntimeClient,
   createProjectRuntimeClient,
@@ -23,6 +24,7 @@ export type EdgeStoreSdkOptions<
 export type ProjectEdgeStoreSdk = { runtime: ProjectRuntimeClient };
 export type ManagementEdgeStoreSdk = {
   runtime: ExplicitProjectRuntimeClient;
+  management: ManagementClient;
 };
 
 export function createEdgeStoreSdk(
@@ -41,6 +43,9 @@ export function createEdgeStoreSdk(
   const transport = createTransport({ ...options, credentials });
 
   return credentials.kind === 'management'
-    ? { runtime: createExplicitProjectRuntimeClient(transport) }
+    ? {
+        runtime: createExplicitProjectRuntimeClient(transport),
+        management: createManagementClient(transport),
+      }
     : { runtime: createProjectRuntimeClient(transport) };
 }


### PR DESCRIPTION
## Summary

- expose management-token methods for projects, buckets, files, and uploads
- cover every API v2 operation in those resource groups
- support cursor queries, abort signals, and asynchronous bucket-empty jobs
- forward complete list queries instead of dropping optional filters
- keep the management namespace absent from project-key clients at the type level
- align creation calls with API v2 after idempotency keys were removed

## Stack

- depends on #141 (`[SDK 04]`)
- next: account and access-administration resources

## DX

```ts
const sdk = createEdgeStoreSdk({
  credentials: { token: managementToken },
});

const project = await sdk.management.projects.create({
  account: accountId,
  name: 'Customer portal',
});

await sdk.management.buckets.create({
  project: project.project.id,
  name: 'documents',
  type: 'file',
  visibility: 'protected',
});
```

## Checks

- `pnpm --filter @edgestore/sdk test`
- `pnpm --filter @edgestore/sdk typecheck`
- `pnpm --filter @edgestore/sdk lint`
- `git diff --check`