### PR TITLE
[SDK 06] feat: add management access client

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,7 +9,7 @@ export {
   EdgeStoreError,
   EdgeStoreNetworkError,
 } from './errors';
-export type { ManagementClient } from './management';
+export type { ManagementClient } from './managementClient';
 export {
   createEdgeStoreSdk,
   type EdgeStoreSdkOptions,

--- a/packages/sdk/src/managementAccess.test.ts
+++ b/packages/sdk/src/managementAccess.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEdgeStoreSdk } from './sdk';
+
+describe('management access resources', () => {
+  it('maps invitation creation and idempotency to the API contract', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      expect(request.method).toBe('POST');
+      expect(request.url).toBe(
+        'https://example.com/v2/management/accounts/account-id/invitations',
+      );
+      expect(request.headers.get('idempotency-key')).toBe('invite-request');
+      await expect(request.json()).resolves.toEqual({
+        email: 'dev@example.com',
+        role: 'MEMBER',
+      });
+      return Response.json({ data: { invitation: { id: 'invitation-id' } } });
+    });
+    const sdk = createEdgeStoreSdk({
+      credentials: { token: 'management-token' },
+      baseUrl: 'https://example.com/v2',
+      fetch,
+    });
+
+    const result = await sdk.management.invitations.create({
+      account: 'account-id',
+      email: 'dev@example.com',
+      role: 'MEMBER',
+      idempotencyKey: 'invite-request',
+    });
+
+    expect(result.invitation.id).toBe('invitation-id');
+  });
+
+  it('serializes user token pagination without an account selector', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      expect(request.url).toBe(
+        'https://example.com/v2/management/users/me/tokens?page=2&pageSize=25',
+      );
+      return Response.json({ data: { tokens: [], pagination: {} } });
+    });
+    const sdk = createEdgeStoreSdk({
+      credentials: { token: 'management-token' },
+      baseUrl: 'https://example.com/v2',
+      fetch,
+    });
+
+    await sdk.management.tokens.listUser({ page: 2, pageSize: 25 });
+
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/sdk/src/managementAccess.test.ts
+++ b/packages/sdk/src/managementAccess.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { createEdgeStoreSdk } from './sdk';
 
 describe('management access resources', () => {
-  it('maps invitation creation and idempotency to the API contract', async () => {
+  it('maps invitation creation to the API contract', async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
       const request = input instanceof Request ? input : new Request(input);
       expect(request.method).toBe('POST');
       expect(request.url).toBe(
         'https://example.com/v2/management/accounts/account-id/invitations',
       );
-      expect(request.headers.get('idempotency-key')).toBe('invite-request');
+      expect(request.headers.has('idempotency-key')).toBe(false);
       await expect(request.json()).resolves.toEqual({
         email: 'dev@example.com',
         role: 'MEMBER',
@@ -26,7 +26,6 @@ describe('management access resources', () => {
       account: 'account-id',
       email: 'dev@example.com',
       role: 'MEMBER',
-      idempotencyKey: 'invite-request',
     });
 
     expect(result.invitation.id).toBe('invitation-id');

--- a/packages/sdk/src/managementAccess.ts
+++ b/packages/sdk/src/managementAccess.ts
@@ -1,0 +1,282 @@
+import type {
+  OperationBody,
+  OperationQuery,
+  OperationResult,
+} from './internal/operationTypes';
+import type { Transport } from './internal/transport';
+
+type CallOptions = { signal?: AbortSignal };
+type AccountInput = { account: string };
+type ProjectInput = { project: string };
+type UserInput = AccountInput & { userId: string };
+type InvitationInput = AccountInput & { invitationId: string };
+type Idempotent = { idempotencyKey?: string };
+
+export type ManagementAccessClient = {
+  accounts: {
+    list(
+      options?: CallOptions,
+    ): Promise<OperationResult<'v2.management.accounts.list'>>;
+    get(
+      input: AccountInput & CallOptions,
+    ): Promise<OperationResult<'v2.management.accounts.get'>>;
+    leave(
+      input: AccountInput & CallOptions,
+    ): Promise<OperationResult<'v2.management.accounts.leave'>>;
+  };
+  projectKeys: {
+    list(
+      input: ProjectInput & CallOptions,
+    ): Promise<OperationResult<'v2.management.projectKeys.list'>>;
+    create(
+      input: ProjectInput &
+        OperationBody<'v2.management.projectKeys.create'> &
+        Idempotent &
+        CallOptions,
+    ): Promise<OperationResult<'v2.management.projectKeys.create'>>;
+    revoke(
+      input: ProjectInput & { keyId: string } & CallOptions,
+    ): Promise<OperationResult<'v2.management.projectKeys.revoke'>>;
+  };
+  members: {
+    list(
+      input: AccountInput &
+        OperationQuery<'v2.management.members.list'> &
+        CallOptions,
+    ): Promise<OperationResult<'v2.management.members.list'>>;
+    update(
+      input: UserInput &
+        OperationBody<'v2.management.members.update'> &
+        CallOptions,
+    ): Promise<OperationResult<'v2.management.members.update'>>;
+    remove(
+      input: UserInput & CallOptions,
+    ): Promise<OperationResult<'v2.management.members.remove'>>;
+  };
+  invitations: {
+    list(
+      input: AccountInput &
+        OperationQuery<'v2.management.invitations.list'> &
+        CallOptions,
+    ): Promise<OperationResult<'v2.management.invitations.list'>>;
+    create(
+      input: AccountInput &
+        OperationBody<'v2.management.invitations.create'> &
+        Idempotent &
+        CallOptions,
+    ): Promise<OperationResult<'v2.management.invitations.create'>>;
+    revoke(
+      input: InvitationInput & CallOptions,
+    ): Promise<OperationResult<'v2.management.invitations.revoke'>>;
+    resend(
+      input: InvitationInput & CallOptions,
+    ): Promise<OperationResult<'v2.management.invitations.resend'>>;
+  };
+  tokens: {
+    listAccount(
+      input: AccountInput &
+        OperationQuery<'v2.management.tokens.listAccount'> &
+        CallOptions,
+    ): Promise<OperationResult<'v2.management.tokens.listAccount'>>;
+    createAccount(
+      input: AccountInput &
+        OperationBody<'v2.management.tokens.createAccount'> &
+        Idempotent &
+        CallOptions,
+    ): Promise<OperationResult<'v2.management.tokens.createAccount'>>;
+    listUser(
+      input?: OperationQuery<'v2.management.tokens.listUser'> & CallOptions,
+    ): Promise<OperationResult<'v2.management.tokens.listUser'>>;
+    createUser(
+      input: OperationBody<'v2.management.tokens.createUser'> &
+        Idempotent &
+        CallOptions,
+    ): Promise<OperationResult<'v2.management.tokens.createUser'>>;
+    revoke(
+      input: { tokenId: string } & CallOptions,
+    ): Promise<OperationResult<'v2.management.tokens.revoke'>>;
+  };
+};
+
+export function createManagementAccessClient(
+  transport: Transport,
+): ManagementAccessClient {
+  return {
+    accounts: {
+      list: (options) =>
+        transport.execute(() =>
+          transport.client.GET('/management/accounts', {
+            signal: options?.signal,
+          }),
+        ),
+      get: ({ account, signal }) =>
+        transport.execute(() =>
+          transport.client.GET('/management/accounts/{accountId}', {
+            params: { path: { accountId: account } },
+            signal,
+          }),
+        ),
+      leave: ({ account, signal }) =>
+        transport.execute(() =>
+          transport.client.POST('/management/accounts/{accountId}/leave', {
+            params: { path: { accountId: account } },
+            signal,
+          }),
+        ),
+    },
+    projectKeys: {
+      list: ({ project, signal }) =>
+        transport.execute(() =>
+          transport.client.GET('/management/projects/{projectRef}/keys', {
+            params: { path: { projectRef: project } },
+            signal,
+          }),
+        ),
+      create: ({ project, idempotencyKey, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST('/management/projects/{projectRef}/keys', {
+            params: {
+              path: { projectRef: project },
+              header: { 'idempotency-key': idempotencyKey },
+            },
+            body,
+            signal,
+          }),
+        ),
+      revoke: ({ project, keyId, signal }) =>
+        transport.execute(() =>
+          transport.client.DELETE(
+            '/management/projects/{projectRef}/keys/{keyId}',
+            {
+              params: { path: { projectRef: project, keyId } },
+              signal,
+            },
+          ),
+        ),
+    },
+    members: {
+      list: ({ account, page, pageSize, signal }) =>
+        transport.execute(() =>
+          transport.client.GET('/management/accounts/{accountId}/members', {
+            params: {
+              path: { accountId: account },
+              query: { page, pageSize },
+            },
+            signal,
+          }),
+        ),
+      update: ({ account, userId, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.PATCH(
+            '/management/accounts/{accountId}/members/{userId}',
+            {
+              params: { path: { accountId: account, userId } },
+              body,
+              signal,
+            },
+          ),
+        ),
+      remove: ({ account, userId, signal }) =>
+        transport.execute(() =>
+          transport.client.DELETE(
+            '/management/accounts/{accountId}/members/{userId}',
+            {
+              params: { path: { accountId: account, userId } },
+              signal,
+            },
+          ),
+        ),
+    },
+    invitations: {
+      list: ({ account, page, pageSize, signal }) =>
+        transport.execute(() =>
+          transport.client.GET('/management/accounts/{accountId}/invitations', {
+            params: {
+              path: { accountId: account },
+              query: { page, pageSize },
+            },
+            signal,
+          }),
+        ),
+      create: ({ account, idempotencyKey, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST(
+            '/management/accounts/{accountId}/invitations',
+            {
+              params: {
+                path: { accountId: account },
+                header: { 'idempotency-key': idempotencyKey },
+              },
+              body,
+              signal,
+            },
+          ),
+        ),
+      revoke: ({ account, invitationId, signal }) =>
+        transport.execute(() =>
+          transport.client.DELETE(
+            '/management/accounts/{accountId}/invitations/{invitationId}',
+            {
+              params: { path: { accountId: account, invitationId } },
+              signal,
+            },
+          ),
+        ),
+      resend: ({ account, invitationId, signal }) =>
+        transport.execute(() =>
+          transport.client.POST(
+            '/management/accounts/{accountId}/invitations/{invitationId}/resend',
+            {
+              params: { path: { accountId: account, invitationId } },
+              signal,
+            },
+          ),
+        ),
+    },
+    tokens: {
+      listAccount: ({ account, page, pageSize, signal }) =>
+        transport.execute(() =>
+          transport.client.GET('/management/accounts/{accountId}/tokens', {
+            params: {
+              path: { accountId: account },
+              query: { page, pageSize },
+            },
+            signal,
+          }),
+        ),
+      createAccount: ({ account, idempotencyKey, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST('/management/accounts/{accountId}/tokens', {
+            params: {
+              path: { accountId: account },
+              header: { 'idempotency-key': idempotencyKey },
+            },
+            body,
+            signal,
+          }),
+        ),
+      listUser: (input) =>
+        transport.execute(() =>
+          transport.client.GET('/management/users/me/tokens', {
+            params: { query: { page: input?.page, pageSize: input?.pageSize } },
+            signal: input?.signal,
+          }),
+        ),
+      createUser: ({ idempotencyKey, signal, ...body }) =>
+        transport.execute(() =>
+          transport.client.POST('/management/users/me/tokens', {
+            params: { header: { 'idempotency-key': idempotencyKey } },
+            body,
+            signal,
+          }),
+        ),
+      revoke: ({ tokenId, signal }) =>
+        transport.execute(() =>
+          transport.client.DELETE('/management/tokens/{tokenId}', {
+            params: { path: { tokenId } },
+            signal,
+          }),
+        ),
+    },
+  };
+}

--- a/packages/sdk/src/managementAccess.ts
+++ b/packages/sdk/src/managementAccess.ts
@@ -98,21 +98,21 @@ export function createManagementAccessClient(
   return {
     accounts: {
       list: (options) =>
-        transport.execute(() =>
-          transport.client.GET('/management/accounts', {
+        transport.execute((client) =>
+          client.GET('/management/accounts', {
             signal: options?.signal,
           }),
         ),
       get: ({ account, signal }) =>
-        transport.execute(() =>
-          transport.client.GET('/management/accounts/{accountId}', {
+        transport.execute((client) =>
+          client.GET('/management/accounts/{accountId}', {
             params: { path: { accountId: account } },
             signal,
           }),
         ),
       leave: ({ account, signal }) =>
-        transport.execute(() =>
-          transport.client.POST('/management/accounts/{accountId}/leave', {
+        transport.execute((client) =>
+          client.POST('/management/accounts/{accountId}/leave', {
             params: { path: { accountId: account } },
             signal,
           }),
@@ -120,35 +120,32 @@ export function createManagementAccessClient(
     },
     projectKeys: {
       list: ({ project, signal }) =>
-        transport.execute(() =>
-          transport.client.GET('/management/projects/{projectRef}/keys', {
+        transport.execute((client) =>
+          client.GET('/management/projects/{projectRef}/keys', {
             params: { path: { projectRef: project } },
             signal,
           }),
         ),
       create: ({ project, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST('/management/projects/{projectRef}/keys', {
+        transport.execute((client) =>
+          client.POST('/management/projects/{projectRef}/keys', {
             params: { path: { projectRef: project } },
             body,
             signal,
           }),
         ),
       revoke: ({ project, keyId, signal }) =>
-        transport.execute(() =>
-          transport.client.DELETE(
-            '/management/projects/{projectRef}/keys/{keyId}',
-            {
-              params: { path: { projectRef: project, keyId } },
-              signal,
-            },
-          ),
+        transport.execute((client) =>
+          client.DELETE('/management/projects/{projectRef}/keys/{keyId}', {
+            params: { path: { projectRef: project, keyId } },
+            signal,
+          }),
         ),
     },
     members: {
       list: ({ account, signal, ...query }) =>
-        transport.execute(() =>
-          transport.client.GET('/management/accounts/{accountId}/members', {
+        transport.execute((client) =>
+          client.GET('/management/accounts/{accountId}/members', {
             params: {
               path: { accountId: account },
               query,
@@ -157,31 +154,25 @@ export function createManagementAccessClient(
           }),
         ),
       update: ({ account, userId, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.PATCH(
-            '/management/accounts/{accountId}/members/{userId}',
-            {
-              params: { path: { accountId: account, userId } },
-              body,
-              signal,
-            },
-          ),
+        transport.execute((client) =>
+          client.PATCH('/management/accounts/{accountId}/members/{userId}', {
+            params: { path: { accountId: account, userId } },
+            body,
+            signal,
+          }),
         ),
       remove: ({ account, userId, signal }) =>
-        transport.execute(() =>
-          transport.client.DELETE(
-            '/management/accounts/{accountId}/members/{userId}',
-            {
-              params: { path: { accountId: account, userId } },
-              signal,
-            },
-          ),
+        transport.execute((client) =>
+          client.DELETE('/management/accounts/{accountId}/members/{userId}', {
+            params: { path: { accountId: account, userId } },
+            signal,
+          }),
         ),
     },
     invitations: {
       list: ({ account, signal, ...query }) =>
-        transport.execute(() =>
-          transport.client.GET('/management/accounts/{accountId}/invitations', {
+        transport.execute((client) =>
+          client.GET('/management/accounts/{accountId}/invitations', {
             params: {
               path: { accountId: account },
               query,
@@ -190,21 +181,18 @@ export function createManagementAccessClient(
           }),
         ),
       create: ({ account, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST(
-            '/management/accounts/{accountId}/invitations',
-            {
-              params: {
-                path: { accountId: account },
-              },
-              body,
-              signal,
+        transport.execute((client) =>
+          client.POST('/management/accounts/{accountId}/invitations', {
+            params: {
+              path: { accountId: account },
             },
-          ),
+            body,
+            signal,
+          }),
         ),
       revoke: ({ account, invitationId, signal }) =>
-        transport.execute(() =>
-          transport.client.DELETE(
+        transport.execute((client) =>
+          client.DELETE(
             '/management/accounts/{accountId}/invitations/{invitationId}',
             {
               params: { path: { accountId: account, invitationId } },
@@ -213,8 +201,8 @@ export function createManagementAccessClient(
           ),
         ),
       resend: ({ account, invitationId, signal }) =>
-        transport.execute(() =>
-          transport.client.POST(
+        transport.execute((client) =>
+          client.POST(
             '/management/accounts/{accountId}/invitations/{invitationId}/resend',
             {
               params: { path: { accountId: account, invitationId } },
@@ -225,8 +213,8 @@ export function createManagementAccessClient(
     },
     tokens: {
       listAccount: ({ account, signal, ...query }) =>
-        transport.execute(() =>
-          transport.client.GET('/management/accounts/{accountId}/tokens', {
+        transport.execute((client) =>
+          client.GET('/management/accounts/{accountId}/tokens', {
             params: {
               path: { accountId: account },
               query,
@@ -235,30 +223,30 @@ export function createManagementAccessClient(
           }),
         ),
       createAccount: ({ account, signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST('/management/accounts/{accountId}/tokens', {
+        transport.execute((client) =>
+          client.POST('/management/accounts/{accountId}/tokens', {
             params: { path: { accountId: account } },
             body,
             signal,
           }),
         ),
       listUser: ({ signal, ...query } = {}) =>
-        transport.execute(() =>
-          transport.client.GET('/management/users/me/tokens', {
+        transport.execute((client) =>
+          client.GET('/management/users/me/tokens', {
             params: { query },
             signal,
           }),
         ),
       createUser: ({ signal, ...body }) =>
-        transport.execute(() =>
-          transport.client.POST('/management/users/me/tokens', {
+        transport.execute((client) =>
+          client.POST('/management/users/me/tokens', {
             body,
             signal,
           }),
         ),
       revoke: ({ tokenId, signal }) =>
-        transport.execute(() =>
-          transport.client.DELETE('/management/tokens/{tokenId}', {
+        transport.execute((client) =>
+          client.DELETE('/management/tokens/{tokenId}', {
             params: { path: { tokenId } },
             signal,
           }),

--- a/packages/sdk/src/managementAccess.ts
+++ b/packages/sdk/src/managementAccess.ts
@@ -10,7 +10,6 @@ type AccountInput = { account: string };
 type ProjectInput = { project: string };
 type UserInput = AccountInput & { userId: string };
 type InvitationInput = AccountInput & { invitationId: string };
-type Idempotent = { idempotencyKey?: string };
 
 export type ManagementAccessClient = {
   accounts: {
@@ -31,7 +30,6 @@ export type ManagementAccessClient = {
     create(
       input: ProjectInput &
         OperationBody<'v2.management.projectKeys.create'> &
-        Idempotent &
         CallOptions,
     ): Promise<OperationResult<'v2.management.projectKeys.create'>>;
     revoke(
@@ -62,7 +60,6 @@ export type ManagementAccessClient = {
     create(
       input: AccountInput &
         OperationBody<'v2.management.invitations.create'> &
-        Idempotent &
         CallOptions,
     ): Promise<OperationResult<'v2.management.invitations.create'>>;
     revoke(
@@ -81,16 +78,13 @@ export type ManagementAccessClient = {
     createAccount(
       input: AccountInput &
         OperationBody<'v2.management.tokens.createAccount'> &
-        Idempotent &
         CallOptions,
     ): Promise<OperationResult<'v2.management.tokens.createAccount'>>;
     listUser(
       input?: OperationQuery<'v2.management.tokens.listUser'> & CallOptions,
     ): Promise<OperationResult<'v2.management.tokens.listUser'>>;
     createUser(
-      input: OperationBody<'v2.management.tokens.createUser'> &
-        Idempotent &
-        CallOptions,
+      input: OperationBody<'v2.management.tokens.createUser'> & CallOptions,
     ): Promise<OperationResult<'v2.management.tokens.createUser'>>;
     revoke(
       input: { tokenId: string } & CallOptions,
@@ -132,13 +126,10 @@ export function createManagementAccessClient(
             signal,
           }),
         ),
-      create: ({ project, idempotencyKey, signal, ...body }) =>
+      create: ({ project, signal, ...body }) =>
         transport.execute(() =>
           transport.client.POST('/management/projects/{projectRef}/keys', {
-            params: {
-              path: { projectRef: project },
-              header: { 'idempotency-key': idempotencyKey },
-            },
+            params: { path: { projectRef: project } },
             body,
             signal,
           }),
@@ -155,12 +146,12 @@ export function createManagementAccessClient(
         ),
     },
     members: {
-      list: ({ account, page, pageSize, signal }) =>
+      list: ({ account, signal, ...query }) =>
         transport.execute(() =>
           transport.client.GET('/management/accounts/{accountId}/members', {
             params: {
               path: { accountId: account },
-              query: { page, pageSize },
+              query,
             },
             signal,
           }),
@@ -188,24 +179,23 @@ export function createManagementAccessClient(
         ),
     },
     invitations: {
-      list: ({ account, page, pageSize, signal }) =>
+      list: ({ account, signal, ...query }) =>
         transport.execute(() =>
           transport.client.GET('/management/accounts/{accountId}/invitations', {
             params: {
               path: { accountId: account },
-              query: { page, pageSize },
+              query,
             },
             signal,
           }),
         ),
-      create: ({ account, idempotencyKey, signal, ...body }) =>
+      create: ({ account, signal, ...body }) =>
         transport.execute(() =>
           transport.client.POST(
             '/management/accounts/{accountId}/invitations',
             {
               params: {
                 path: { accountId: account },
-                header: { 'idempotency-key': idempotencyKey },
               },
               body,
               signal,
@@ -234,38 +224,34 @@ export function createManagementAccessClient(
         ),
     },
     tokens: {
-      listAccount: ({ account, page, pageSize, signal }) =>
+      listAccount: ({ account, signal, ...query }) =>
         transport.execute(() =>
           transport.client.GET('/management/accounts/{accountId}/tokens', {
             params: {
               path: { accountId: account },
-              query: { page, pageSize },
+              query,
             },
             signal,
           }),
         ),
-      createAccount: ({ account, idempotencyKey, signal, ...body }) =>
+      createAccount: ({ account, signal, ...body }) =>
         transport.execute(() =>
           transport.client.POST('/management/accounts/{accountId}/tokens', {
-            params: {
-              path: { accountId: account },
-              header: { 'idempotency-key': idempotencyKey },
-            },
+            params: { path: { accountId: account } },
             body,
             signal,
           }),
         ),
-      listUser: (input) =>
+      listUser: ({ signal, ...query } = {}) =>
         transport.execute(() =>
           transport.client.GET('/management/users/me/tokens', {
-            params: { query: { page: input?.page, pageSize: input?.pageSize } },
-            signal: input?.signal,
+            params: { query },
+            signal,
           }),
         ),
-      createUser: ({ idempotencyKey, signal, ...body }) =>
+      createUser: ({ signal, ...body }) =>
         transport.execute(() =>
           transport.client.POST('/management/users/me/tokens', {
-            params: { header: { 'idempotency-key': idempotencyKey } },
             body,
             signal,
           }),

--- a/packages/sdk/src/managementAccessContract.test.ts
+++ b/packages/sdk/src/managementAccessContract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ManagementAccessOperationId } from './internal/operationTypes';
+import type { ManagementAccessOperationId } from './operationGroups.test.helper';
 import { createEdgeStoreSdk } from './sdk';
 
 type MappingCase = {

--- a/packages/sdk/src/managementAccessContract.test.ts
+++ b/packages/sdk/src/managementAccessContract.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { ManagementAccessOperationId } from './internal/operationTypes';
 import { createEdgeStoreSdk } from './sdk';
+
+type MappingCase = {
+  invoke: () => Promise<unknown>;
+  method: string;
+  path: string;
+  body?: unknown;
+};
 
 describe('management access request mappings', () => {
   it('maps every access operation to its HTTP contract', async () => {
@@ -15,61 +23,47 @@ describe('management access request mappings', () => {
     });
     const account = 'account-id';
     const project = 'project-id';
-    const cases: {
-      name: string;
-      invoke: () => Promise<unknown>;
-      method: string;
-      path: string;
-      body?: unknown;
-    }[] = [
-      {
-        name: 'accounts.list',
+    const cases = {
+      'v2.management.accounts.list': {
         invoke: () => sdk.management.accounts.list(),
         method: 'GET',
         path: '/v2/management/accounts',
       },
-      {
-        name: 'accounts.get',
+      'v2.management.accounts.get': {
         invoke: () => sdk.management.accounts.get({ account }),
         method: 'GET',
         path: `/v2/management/accounts/${account}`,
       },
-      {
-        name: 'accounts.leave',
+      'v2.management.accounts.leave': {
         invoke: () => sdk.management.accounts.leave({ account }),
         method: 'POST',
         path: `/v2/management/accounts/${account}/leave`,
       },
-      {
-        name: 'projectKeys.list',
+      'v2.management.projectKeys.list': {
         invoke: () => sdk.management.projectKeys.list({ project }),
         method: 'GET',
         path: `/v2/management/projects/${project}/keys`,
       },
-      {
-        name: 'projectKeys.create',
+      'v2.management.projectKeys.create': {
         invoke: () =>
           sdk.management.projectKeys.create({ project, name: 'Deploy key' }),
         method: 'POST',
         path: `/v2/management/projects/${project}/keys`,
         body: { name: 'Deploy key' },
       },
-      {
-        name: 'projectKeys.revoke',
+      'v2.management.projectKeys.revoke': {
         invoke: () =>
           sdk.management.projectKeys.revoke({ project, keyId: 'key-id' }),
         method: 'DELETE',
         path: `/v2/management/projects/${project}/keys/key-id`,
       },
-      {
-        name: 'members.list',
+      'v2.management.members.list': {
         invoke: () =>
           sdk.management.members.list({ account, page: 2, pageSize: 10 }),
         method: 'GET',
         path: `/v2/management/accounts/${account}/members?page=2&pageSize=10`,
       },
-      {
-        name: 'members.update',
+      'v2.management.members.update': {
         invoke: () =>
           sdk.management.members.update({
             account,
@@ -80,22 +74,19 @@ describe('management access request mappings', () => {
         path: `/v2/management/accounts/${account}/members/user-id`,
         body: { role: 'MEMBER' },
       },
-      {
-        name: 'members.remove',
+      'v2.management.members.remove': {
         invoke: () =>
           sdk.management.members.remove({ account, userId: 'user-id' }),
         method: 'DELETE',
         path: `/v2/management/accounts/${account}/members/user-id`,
       },
-      {
-        name: 'invitations.list',
+      'v2.management.invitations.list': {
         invoke: () =>
           sdk.management.invitations.list({ account, page: 2, pageSize: 10 }),
         method: 'GET',
         path: `/v2/management/accounts/${account}/invitations?page=2&pageSize=10`,
       },
-      {
-        name: 'invitations.create',
+      'v2.management.invitations.create': {
         invoke: () =>
           sdk.management.invitations.create({
             account,
@@ -106,8 +97,7 @@ describe('management access request mappings', () => {
         path: `/v2/management/accounts/${account}/invitations`,
         body: { email: 'dev@example.com', role: 'MEMBER' },
       },
-      {
-        name: 'invitations.revoke',
+      'v2.management.invitations.revoke': {
         invoke: () =>
           sdk.management.invitations.revoke({
             account,
@@ -116,8 +106,7 @@ describe('management access request mappings', () => {
         method: 'DELETE',
         path: `/v2/management/accounts/${account}/invitations/invitation-id`,
       },
-      {
-        name: 'invitations.resend',
+      'v2.management.invitations.resend': {
         invoke: () =>
           sdk.management.invitations.resend({
             account,
@@ -126,8 +115,7 @@ describe('management access request mappings', () => {
         method: 'POST',
         path: `/v2/management/accounts/${account}/invitations/invitation-id/resend`,
       },
-      {
-        name: 'tokens.listAccount',
+      'v2.management.tokens.listAccount': {
         invoke: () =>
           sdk.management.tokens.listAccount({
             account,
@@ -137,8 +125,7 @@ describe('management access request mappings', () => {
         method: 'GET',
         path: `/v2/management/accounts/${account}/tokens?page=2&pageSize=10`,
       },
-      {
-        name: 'tokens.createAccount',
+      'v2.management.tokens.createAccount': {
         invoke: () =>
           sdk.management.tokens.createAccount({
             account,
@@ -149,14 +136,12 @@ describe('management access request mappings', () => {
         path: `/v2/management/accounts/${account}/tokens`,
         body: { name: 'CI token', scopes: ['project:read'] },
       },
-      {
-        name: 'tokens.listUser',
+      'v2.management.tokens.listUser': {
         invoke: () => sdk.management.tokens.listUser({ page: 2, pageSize: 10 }),
         method: 'GET',
         path: '/v2/management/users/me/tokens?page=2&pageSize=10',
       },
-      {
-        name: 'tokens.createUser',
+      'v2.management.tokens.createUser': {
         invoke: () =>
           sdk.management.tokens.createUser({
             name: 'CLI token',
@@ -166,24 +151,23 @@ describe('management access request mappings', () => {
         path: '/v2/management/users/me/tokens',
         body: { name: 'CLI token', scopes: ['account:read'] },
       },
-      {
-        name: 'tokens.revoke',
+      'v2.management.tokens.revoke': {
         invoke: () => sdk.management.tokens.revoke({ tokenId: 'token-id' }),
         method: 'DELETE',
         path: '/v2/management/tokens/token-id',
       },
-    ];
+    } satisfies Record<ManagementAccessOperationId, MappingCase>;
 
-    for (const testCase of cases) {
+    for (const [operationId, testCase] of Object.entries(cases)) {
       requests.length = 0;
       await testCase.invoke();
-      expect(requests, testCase.name).toHaveLength(1);
+      expect(requests, operationId).toHaveLength(1);
       const request = requests[0]!;
-      expect(request.method, testCase.name).toBe(testCase.method);
+      expect(request.method, operationId).toBe(testCase.method);
       const url = new URL(request.url);
-      expect(`${url.pathname}${url.search}`, testCase.name).toBe(testCase.path);
-      if (testCase.body !== undefined) {
-        await expect(request.json(), testCase.name).resolves.toEqual(
+      expect(`${url.pathname}${url.search}`, operationId).toBe(testCase.path);
+      if ('body' in testCase) {
+        await expect(request.json(), operationId).resolves.toEqual(
           testCase.body,
         );
       }

--- a/packages/sdk/src/managementAccessContract.test.ts
+++ b/packages/sdk/src/managementAccessContract.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEdgeStoreSdk } from './sdk';
+
+describe('management access request mappings', () => {
+  it('maps every access operation to its HTTP contract', async () => {
+    const requests: Request[] = [];
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      requests.push(input instanceof Request ? input : new Request(input));
+      return Response.json({ data: {} });
+    });
+    const sdk = createEdgeStoreSdk({
+      credentials: { token: 'management-token' },
+      baseUrl: 'https://example.com/v2',
+      fetch,
+    });
+    const account = 'account-id';
+    const project = 'project-id';
+    const cases: {
+      name: string;
+      invoke: () => Promise<unknown>;
+      method: string;
+      path: string;
+      body?: unknown;
+    }[] = [
+      {
+        name: 'accounts.list',
+        invoke: () => sdk.management.accounts.list(),
+        method: 'GET',
+        path: '/v2/management/accounts',
+      },
+      {
+        name: 'accounts.get',
+        invoke: () => sdk.management.accounts.get({ account }),
+        method: 'GET',
+        path: `/v2/management/accounts/${account}`,
+      },
+      {
+        name: 'accounts.leave',
+        invoke: () => sdk.management.accounts.leave({ account }),
+        method: 'POST',
+        path: `/v2/management/accounts/${account}/leave`,
+      },
+      {
+        name: 'projectKeys.list',
+        invoke: () => sdk.management.projectKeys.list({ project }),
+        method: 'GET',
+        path: `/v2/management/projects/${project}/keys`,
+      },
+      {
+        name: 'projectKeys.create',
+        invoke: () =>
+          sdk.management.projectKeys.create({ project, name: 'Deploy key' }),
+        method: 'POST',
+        path: `/v2/management/projects/${project}/keys`,
+        body: { name: 'Deploy key' },
+      },
+      {
+        name: 'projectKeys.revoke',
+        invoke: () =>
+          sdk.management.projectKeys.revoke({ project, keyId: 'key-id' }),
+        method: 'DELETE',
+        path: `/v2/management/projects/${project}/keys/key-id`,
+      },
+      {
+        name: 'members.list',
+        invoke: () =>
+          sdk.management.members.list({ account, page: 2, pageSize: 10 }),
+        method: 'GET',
+        path: `/v2/management/accounts/${account}/members?page=2&pageSize=10`,
+      },
+      {
+        name: 'members.update',
+        invoke: () =>
+          sdk.management.members.update({
+            account,
+            userId: 'user-id',
+            role: 'MEMBER',
+          }),
+        method: 'PATCH',
+        path: `/v2/management/accounts/${account}/members/user-id`,
+        body: { role: 'MEMBER' },
+      },
+      {
+        name: 'members.remove',
+        invoke: () =>
+          sdk.management.members.remove({ account, userId: 'user-id' }),
+        method: 'DELETE',
+        path: `/v2/management/accounts/${account}/members/user-id`,
+      },
+      {
+        name: 'invitations.list',
+        invoke: () =>
+          sdk.management.invitations.list({ account, page: 2, pageSize: 10 }),
+        method: 'GET',
+        path: `/v2/management/accounts/${account}/invitations?page=2&pageSize=10`,
+      },
+      {
+        name: 'invitations.create',
+        invoke: () =>
+          sdk.management.invitations.create({
+            account,
+            email: 'dev@example.com',
+            role: 'MEMBER',
+          }),
+        method: 'POST',
+        path: `/v2/management/accounts/${account}/invitations`,
+        body: { email: 'dev@example.com', role: 'MEMBER' },
+      },
+      {
+        name: 'invitations.revoke',
+        invoke: () =>
+          sdk.management.invitations.revoke({
+            account,
+            invitationId: 'invitation-id',
+          }),
+        method: 'DELETE',
+        path: `/v2/management/accounts/${account}/invitations/invitation-id`,
+      },
+      {
+        name: 'invitations.resend',
+        invoke: () =>
+          sdk.management.invitations.resend({
+            account,
+            invitationId: 'invitation-id',
+          }),
+        method: 'POST',
+        path: `/v2/management/accounts/${account}/invitations/invitation-id/resend`,
+      },
+      {
+        name: 'tokens.listAccount',
+        invoke: () =>
+          sdk.management.tokens.listAccount({
+            account,
+            page: 2,
+            pageSize: 10,
+          }),
+        method: 'GET',
+        path: `/v2/management/accounts/${account}/tokens?page=2&pageSize=10`,
+      },
+      {
+        name: 'tokens.createAccount',
+        invoke: () =>
+          sdk.management.tokens.createAccount({
+            account,
+            name: 'CI token',
+            scopes: ['project:read'],
+          }),
+        method: 'POST',
+        path: `/v2/management/accounts/${account}/tokens`,
+        body: { name: 'CI token', scopes: ['project:read'] },
+      },
+      {
+        name: 'tokens.listUser',
+        invoke: () => sdk.management.tokens.listUser({ page: 2, pageSize: 10 }),
+        method: 'GET',
+        path: '/v2/management/users/me/tokens?page=2&pageSize=10',
+      },
+      {
+        name: 'tokens.createUser',
+        invoke: () =>
+          sdk.management.tokens.createUser({
+            name: 'CLI token',
+            scopes: ['account:read'],
+          }),
+        method: 'POST',
+        path: '/v2/management/users/me/tokens',
+        body: { name: 'CLI token', scopes: ['account:read'] },
+      },
+      {
+        name: 'tokens.revoke',
+        invoke: () => sdk.management.tokens.revoke({ tokenId: 'token-id' }),
+        method: 'DELETE',
+        path: '/v2/management/tokens/token-id',
+      },
+    ];
+
+    for (const testCase of cases) {
+      requests.length = 0;
+      await testCase.invoke();
+      expect(requests, testCase.name).toHaveLength(1);
+      const request = requests[0]!;
+      expect(request.method, testCase.name).toBe(testCase.method);
+      const url = new URL(request.url);
+      expect(`${url.pathname}${url.search}`, testCase.name).toBe(testCase.path);
+      if (testCase.body !== undefined) {
+        await expect(request.json(), testCase.name).resolves.toEqual(
+          testCase.body,
+        );
+      }
+    }
+  });
+});

--- a/packages/sdk/src/managementClient.ts
+++ b/packages/sdk/src/managementClient.ts
@@ -1,0 +1,19 @@
+import type { Transport } from './internal/transport';
+import {
+  createManagementAccessClient,
+  type ManagementAccessClient,
+} from './managementAccess';
+import {
+  createManagementResourceClient,
+  type ManagementResourceClient,
+} from './managementResources';
+
+export type ManagementClient = ManagementResourceClient &
+  ManagementAccessClient;
+
+export function createManagementClient(transport: Transport): ManagementClient {
+  return {
+    ...createManagementResourceClient(transport),
+    ...createManagementAccessClient(transport),
+  };
+}

--- a/packages/sdk/src/managementResources.test.ts
+++ b/packages/sdk/src/managementResources.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
-import type { ManagementClient } from './management';
+import type { ManagementClient } from './managementClient';
 import { createEdgeStoreSdk } from './sdk';
 
 function createManagementSdk(fetch: typeof globalThis.fetch) {

--- a/packages/sdk/src/managementResources.ts
+++ b/packages/sdk/src/managementResources.ts
@@ -15,7 +15,7 @@ type EmptyJobInput = BucketInput & { jobId: string };
 
 type Result<TOperation extends OperationId> = OperationResult<TOperation>;
 
-export type ManagementClient = {
+export type ManagementResourceClient = {
   projects: {
     list(
       input: AccountInput & CallOptions,
@@ -114,7 +114,9 @@ export type ManagementClient = {
   };
 };
 
-export function createManagementClient(transport: Transport): ManagementClient {
+export function createManagementResourceClient(
+  transport: Transport,
+): ManagementResourceClient {
   return {
     projects: {
       list: ({ account, signal }) =>

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -5,7 +5,10 @@ import type {
 } from './credentials';
 import { classifyCredentials } from './credentials';
 import { createTransport } from './internal/transport';
-import { createManagementClient, type ManagementClient } from './management';
+import {
+  createManagementClient,
+  type ManagementClient,
+} from './managementClient';
 import {
   createExplicitProjectRuntimeClient,
   createProjectRuntimeClient,


### PR DESCRIPTION
## Summary

- expose the remaining API v2 management access operations
- add accounts, project keys, members, invitations, and management-token resources
- forward pagination and filter queries for list operations
- support abort signals and revoke/remove operations
- align creation calls with API v2 after idempotency keys were removed
- split management implementation by resource administration vs access administration

## Stack

- depends on #142 (`[SDK 05]`)
- next: the SDK system client

## Coverage

Together with `[SDK 05]`, all API v2 management operations are available through the supported SDK.

## Checks

- `pnpm --filter @edgestore/sdk test`
- `pnpm --filter @edgestore/sdk typecheck`
- `pnpm --filter @edgestore/sdk lint`
- `git diff --check`