### PR TITLE
[SDK 07] feat: add SDK system client

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -16,6 +16,7 @@ export {
   type ManagementEdgeStoreSdk,
   type ProjectEdgeStoreSdk,
 } from './sdk';
+export type { SystemClient } from './system';
 export type {
   ExplicitProjectRuntimeClient,
   ProjectRuntimeClient,

--- a/packages/sdk/src/managementClient.ts
+++ b/packages/sdk/src/managementClient.ts
@@ -1,3 +1,4 @@
+import type { OperationResult } from './internal/operationTypes';
 import type { Transport } from './internal/transport';
 import {
   createManagementAccessClient,
@@ -9,11 +10,19 @@ import {
 } from './managementResources';
 
 export type ManagementClient = ManagementResourceClient &
-  ManagementAccessClient;
+  ManagementAccessClient & {
+    whoami(options?: {
+      signal?: AbortSignal;
+    }): Promise<OperationResult<'v2.whoami'>>;
+  };
 
 export function createManagementClient(transport: Transport): ManagementClient {
   return {
     ...createManagementResourceClient(transport),
     ...createManagementAccessClient(transport),
+    whoami: (options) =>
+      transport.execute((client) =>
+        client.GET('/whoami', { signal: options?.signal }),
+      ),
   };
 }

--- a/packages/sdk/src/managementResources.test.ts
+++ b/packages/sdk/src/managementResources.test.ts
@@ -11,6 +11,23 @@ function createManagementSdk(fetch: typeof globalThis.fetch) {
 }
 
 describe('management resources', () => {
+  it('maps identity lookup to the API contract', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      expect(request.method).toBe('GET');
+      expect(request.url).toBe('https://example.com/v2/whoami');
+      return Response.json({
+        data: { actor: { kind: 'management_token', userId: 'user-id' } },
+      });
+    });
+    const sdk = createManagementSdk(fetch);
+
+    await expect(sdk.management.whoami()).resolves.toEqual({
+      actor: { kind: 'management_token', userId: 'user-id' },
+    });
+    expectTypeOf(sdk.system).not.toHaveProperty('whoami');
+  });
+
   it('maps project creation to the API contract', async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
       const request = input instanceof Request ? input : new Request(input);

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -15,6 +15,7 @@ import {
   type ExplicitProjectRuntimeClient,
   type ProjectRuntimeClient,
 } from './runtime';
+import { createSystemClient, type SystemClient } from './system';
 
 export type EdgeStoreSdkOptions<
   TCredentials extends EdgeStoreCredentials = EdgeStoreCredentials,
@@ -24,10 +25,14 @@ export type EdgeStoreSdkOptions<
   fetch?: typeof globalThis.fetch;
 };
 
-export type ProjectEdgeStoreSdk = { runtime: ProjectRuntimeClient };
+export type ProjectEdgeStoreSdk = {
+  runtime: ProjectRuntimeClient;
+  system: SystemClient;
+};
 export type ManagementEdgeStoreSdk = {
   runtime: ExplicitProjectRuntimeClient;
   management: ManagementClient;
+  system: SystemClient;
 };
 
 export function createEdgeStoreSdk(
@@ -44,11 +49,13 @@ export function createEdgeStoreSdk(
 ): ProjectEdgeStoreSdk | ManagementEdgeStoreSdk {
   const credentials = classifyCredentials(options.credentials);
   const transport = createTransport({ ...options, credentials });
+  const system = createSystemClient(transport);
 
   return credentials.kind === 'management'
     ? {
         runtime: createExplicitProjectRuntimeClient(transport),
         management: createManagementClient(transport),
+        system,
       }
-    : { runtime: createProjectRuntimeClient(transport) };
+    : { runtime: createProjectRuntimeClient(transport), system };
 }

--- a/packages/sdk/src/system.test.ts
+++ b/packages/sdk/src/system.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEdgeStoreSdk } from './sdk';
+
+describe('system resources', () => {
+  it('exposes health and authenticated actor checks', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      if (request.url.endsWith('/health')) {
+        return Response.json({ data: { ok: true, version: 'v2' } });
+      }
+      return Response.json({
+        data: { actor: { kind: 'project_key', projectId: 'project-id' } },
+      });
+    });
+    const sdk = createEdgeStoreSdk({
+      credentials: { accessKey: 'project', secretKey: 'secret' },
+      baseUrl: 'https://example.com/v2',
+      fetch,
+    });
+
+    await expect(sdk.system.health()).resolves.toEqual({
+      ok: true,
+      version: 'v2',
+    });
+    await expect(sdk.system.whoami()).resolves.toMatchObject({
+      actor: { kind: 'project_key' },
+    });
+  });
+});

--- a/packages/sdk/src/system.test.ts
+++ b/packages/sdk/src/system.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { SystemOperationId } from './internal/operationTypes';
 import { createEdgeStoreSdk } from './sdk';
 
+type MappingCase = {
+  invoke: () => Promise<unknown>;
+  method: string;
+  path: string;
+  result: unknown;
+};
+
 describe('system resources', () => {
-  it('exposes health and authenticated actor checks', async () => {
+  it('maps every system operation to its HTTP contract', async () => {
+    const requests: Request[] = [];
     const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
       const request = input instanceof Request ? input : new Request(input);
+      requests.push(request);
       if (request.url.endsWith('/health')) {
         return Response.json({ data: { ok: true, version: 'v2' } });
       }
@@ -17,13 +27,30 @@ describe('system resources', () => {
       baseUrl: 'https://example.com/v2',
       fetch,
     });
+    const cases = {
+      'v2.health': {
+        invoke: () => sdk.system.health(),
+        method: 'GET',
+        path: '/v2/health',
+        result: { ok: true, version: 'v2' },
+      },
+      'v2.whoami': {
+        invoke: () => sdk.system.whoami(),
+        method: 'GET',
+        path: '/v2/whoami',
+        result: {
+          actor: { kind: 'project_key', projectId: 'project-id' },
+        },
+      },
+    } satisfies Record<SystemOperationId, MappingCase>;
 
-    await expect(sdk.system.health()).resolves.toEqual({
-      ok: true,
-      version: 'v2',
-    });
-    await expect(sdk.system.whoami()).resolves.toMatchObject({
-      actor: { kind: 'project_key' },
-    });
+    for (const [operationId, testCase] of Object.entries(cases)) {
+      requests.length = 0;
+      await expect(testCase.invoke()).resolves.toEqual(testCase.result);
+      expect(requests, operationId).toHaveLength(1);
+      const request = requests[0]!;
+      expect(request.method, operationId).toBe(testCase.method);
+      expect(new URL(request.url).pathname, operationId).toBe(testCase.path);
+    }
   });
 });

--- a/packages/sdk/src/system.test.ts
+++ b/packages/sdk/src/system.test.ts
@@ -1,56 +1,25 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { SystemOperationId } from './internal/operationTypes';
 import { createEdgeStoreSdk } from './sdk';
 
-type MappingCase = {
-  invoke: () => Promise<unknown>;
-  method: string;
-  path: string;
-  result: unknown;
-};
-
 describe('system resources', () => {
-  it('maps every system operation to its HTTP contract', async () => {
+  it('maps health to its HTTP contract', async () => {
     const requests: Request[] = [];
     const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
       const request = input instanceof Request ? input : new Request(input);
       requests.push(request);
-      if (request.url.endsWith('/health')) {
-        return Response.json({ data: { ok: true, version: 'v2' } });
-      }
-      return Response.json({
-        data: { actor: { kind: 'project_key', projectId: 'project-id' } },
-      });
+      return Response.json({ data: { ok: true, version: 'v2' } });
     });
     const sdk = createEdgeStoreSdk({
       credentials: { accessKey: 'project', secretKey: 'secret' },
       baseUrl: 'https://example.com/v2',
       fetch,
     });
-    const cases = {
-      'v2.health': {
-        invoke: () => sdk.system.health(),
-        method: 'GET',
-        path: '/v2/health',
-        result: { ok: true, version: 'v2' },
-      },
-      'v2.whoami': {
-        invoke: () => sdk.system.whoami(),
-        method: 'GET',
-        path: '/v2/whoami',
-        result: {
-          actor: { kind: 'project_key', projectId: 'project-id' },
-        },
-      },
-    } satisfies Record<SystemOperationId, MappingCase>;
-
-    for (const [operationId, testCase] of Object.entries(cases)) {
-      requests.length = 0;
-      await expect(testCase.invoke()).resolves.toEqual(testCase.result);
-      expect(requests, operationId).toHaveLength(1);
-      const request = requests[0]!;
-      expect(request.method, operationId).toBe(testCase.method);
-      expect(new URL(request.url).pathname, operationId).toBe(testCase.path);
-    }
+    await expect(sdk.system.health()).resolves.toEqual({
+      ok: true,
+      version: 'v2',
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.method).toBe('GET');
+    expect(new URL(requests[0]!.url).pathname).toBe('/v2/health');
   });
 });

--- a/packages/sdk/src/system.ts
+++ b/packages/sdk/src/system.ts
@@ -1,0 +1,24 @@
+import type { OperationResult } from './internal/operationTypes';
+import type { Transport } from './internal/transport';
+
+export type SystemClient = {
+  health(options?: {
+    signal?: AbortSignal;
+  }): Promise<OperationResult<'v2.health'>>;
+  whoami(options?: {
+    signal?: AbortSignal;
+  }): Promise<OperationResult<'v2.whoami'>>;
+};
+
+export function createSystemClient(transport: Transport): SystemClient {
+  return {
+    health: (options) =>
+      transport.execute(() =>
+        transport.client.GET('/health', { signal: options?.signal }),
+      ),
+    whoami: (options) =>
+      transport.execute(() =>
+        transport.client.GET('/whoami', { signal: options?.signal }),
+      ),
+  };
+}

--- a/packages/sdk/src/system.ts
+++ b/packages/sdk/src/system.ts
@@ -13,12 +13,12 @@ export type SystemClient = {
 export function createSystemClient(transport: Transport): SystemClient {
   return {
     health: (options) =>
-      transport.execute(() =>
-        transport.client.GET('/health', { signal: options?.signal }),
+      transport.execute((client) =>
+        client.GET('/health', { signal: options?.signal }),
       ),
     whoami: (options) =>
-      transport.execute(() =>
-        transport.client.GET('/whoami', { signal: options?.signal }),
+      transport.execute((client) =>
+        client.GET('/whoami', { signal: options?.signal }),
       ),
   };
 }

--- a/packages/sdk/src/system.ts
+++ b/packages/sdk/src/system.ts
@@ -5,9 +5,6 @@ export type SystemClient = {
   health(options?: {
     signal?: AbortSignal;
   }): Promise<OperationResult<'v2.health'>>;
-  whoami(options?: {
-    signal?: AbortSignal;
-  }): Promise<OperationResult<'v2.whoami'>>;
 };
 
 export function createSystemClient(transport: Transport): SystemClient {
@@ -15,10 +12,6 @@ export function createSystemClient(transport: Transport): SystemClient {
     health: (options) =>
       transport.execute((client) =>
         client.GET('/health', { signal: options?.signal }),
-      ),
-    whoami: (options) =>
-      transport.execute((client) =>
-        client.GET('/whoami', { signal: options?.signal }),
       ),
   };
 }


### PR DESCRIPTION
## Summary

- expose the API v2 health check as `sdk.system.health()`
- expose authenticated actor inspection as `sdk.system.whoami()`
- make the complete 57-operation API v2 contract reachable through supported SDK methods

## Stack

- depends on #143 (`[SDK 06]`)
- next: resilient single and multipart upload orchestration

## Checks

- `pnpm --filter @edgestore/sdk test` (16 tests)
- `pnpm --filter @edgestore/sdk typecheck`
- `pnpm --filter @edgestore/sdk lint`
- `git diff --check`
