### PR TITLE
[Upgrade 01] chore: remove stale dependency graph

### DIFF
--- a/.changeset/clean-production-dependencies.md
+++ b/.changeset/clean-production-dependencies.md
@@ -1,0 +1,8 @@
+---
+'@edgestore/react': patch
+'@edgestore/server': patch
+---
+
+Remove unused server-side dependencies from the React client and refresh the
+server's cookie and token dependencies. UUID generation now uses the platform
+crypto API.

--- a/package.json
+++ b/package.json
@@ -43,14 +43,13 @@
     "release": "pnpm build && changeset publish",
     "sync-versions": "tsx scripts/syncVersions.ts"
   },
-  "dependencies": {
+  "devDependencies": {
     "@changesets/changelog-github": "0.5.2",
     "@changesets/cli": "2.29.8",
     "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
     "@manypkg/cli": "^0.21.0",
     "@rollup/plugin-node-resolve": "16.0.3",
     "@rollup/plugin-typescript": "12.3.0",
-    "@types/prettier": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "6.0.0-alpha.158",
     "@typescript-eslint/parser": "6.0.0-alpha.158",
     "eslint": "^8.40.0",
@@ -60,19 +59,18 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-turbo": "2.7.2",
     "eslint-plugin-unicorn": "47.0.0",
-    "npm-run-all": "^4.1.5",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "rollup": "4.54.0",
     "rollup-plugin-delete": "2.2.0",
-    "rollup-plugin-multi-input": "1.6.0",
     "rollup-plugin-node-externals": "8.1.2",
     "rollup-plugin-swc3": "0.12.1",
-    "rollup-plugin-typescript2": "0.36.0",
     "shadcn": "2.4.0-canary.20",
     "tsx": "4.21.0",
     "turbo": "2.7.2",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "tsd": "^0.33.0",
+    "vitest": "^4.1.8"
   },
   "pnpm": {
     "overrides": {
@@ -80,9 +78,5 @@
       "@edgestore/shared": "workspace:*",
       "@edgestore/react": "workspace:*"
     }
-  },
-  "devDependencies": {
-    "tsd": "^0.33.0",
-    "vitest": "^4.1.8"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -72,13 +72,7 @@
     "!**/__tests__"
   ],
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.294.0",
-    "@aws-sdk/s3-request-presigner": "^3.294.0",
-    "@edgestore/shared": "0.7.0",
-    "@panva/hkdf": "^1.0.4",
-    "cookie": "^0.7.0",
-    "jose": "^4.13.1",
-    "uuid": "^9.0.0"
+    "@edgestore/shared": "0.7.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
@@ -86,12 +80,9 @@
     "zod": ">=3.0.0"
   },
   "devDependencies": {
-    "@swc/helpers": "0.5.3",
-    "@types/cookie": "^0.5.1",
     "@types/node": "25.0.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
-    "@types/uuid": "^9.0.1",
     "jsdom": "^29.1.1",
     "next": "16.1.1",
     "react": "19.2.3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -124,10 +124,9 @@
   ],
   "dependencies": {
     "@edgestore/shared": "0.7.0",
-    "@panva/hkdf": "^1.0.4",
-    "cookie": "^0.7.0",
-    "jose": "^4.13.1",
-    "uuid": "^9.0.0"
+    "@panva/hkdf": "^1.2.1",
+    "cookie": "^0.7.2",
+    "jose": "^4.15.9"
   },
   "peerDependencies": {
     "@aws-sdk/client-s3": ">=3.0.0",
@@ -153,10 +152,8 @@
     "@aws-sdk/client-s3": "^3.420.0",
     "@aws-sdk/s3-request-presigner": "^3.420.0",
     "@azure/storage-blob": "^12.17.0",
-    "@types/cookie": "^0.5.1",
     "@types/express": "^4.17.21",
     "@types/node": "25.0.3",
-    "@types/uuid": "^9.0.1",
     "astro": "^5.7.12",
     "dotenv": "^16.4.7",
     "express": "^4.18.2",

--- a/packages/server/src/adapters/shared.ts
+++ b/packages/server/src/adapters/shared.ts
@@ -11,7 +11,6 @@ import {
 import { hkdf } from '@panva/hkdf';
 import { serialize } from 'cookie';
 import { EncryptJWT, jwtDecrypt } from 'jose';
-import { v4 as uuidv4 } from 'uuid';
 import type Logger from '../libs/logger';
 import { IMAGE_MIME_TYPES } from './imageTypes';
 
@@ -614,7 +613,7 @@ async function encryptJWT(ctx: any) {
     .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
     .setIssuedAt()
     .setExpirationTime(Date.now() / 1000 + DEFAULT_MAX_AGE)
-    .setJti(uuidv4())
+    .setJti(crypto.randomUUID())
     .encrypt(encryptionSecret);
 }
 

--- a/packages/server/src/providers/aws/index.test.ts
+++ b/packages/server/src/providers/aws/index.test.ts
@@ -42,7 +42,9 @@ const awsMocks = vi.hoisted(() => {
   return {
     send,
     getSignedUrl: vi.fn(),
-    uuidv4: vi.fn(),
+    randomUUID: vi.fn(
+      () => 'generated-uuid' as ReturnType<typeof crypto.randomUUID>,
+    ),
     S3Client,
     PutObjectCommand,
     DeleteObjectCommand,
@@ -59,10 +61,6 @@ vi.mock('@aws-sdk/client-s3', () => ({
 
 vi.mock('@aws-sdk/s3-request-presigner', () => ({
   getSignedUrl: awsMocks.getSignedUrl,
-}));
-
-vi.mock('uuid', () => ({
-  v4: awsMocks.uuidv4,
 }));
 
 function uploadParams(
@@ -85,8 +83,9 @@ function uploadParams(
 
 describe('AWSProvider', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
-    awsMocks.uuidv4.mockReturnValue('generated-uuid');
+    vi.spyOn(crypto, 'randomUUID').mockImplementation(awsMocks.randomUUID);
     awsMocks.getSignedUrl.mockResolvedValue(
       'https://signed-upload.example.com',
     );
@@ -182,7 +181,7 @@ describe('AWSProvider', () => {
     expect(result.accessUrl).toBe(
       'https://storage-bucket.s3.us-east-1.amazonaws.com/documents/manual-name.pdf',
     );
-    expect(awsMocks.uuidv4).not.toHaveBeenCalled();
+    expect(awsMocks.randomUUID).not.toHaveBeenCalled();
     expect(awsMocks.getSignedUrl).toHaveBeenCalledWith(
       expect.any(awsMocks.S3Client),
       expect.objectContaining({

--- a/packages/server/src/providers/aws/index.ts
+++ b/packages/server/src/providers/aws/index.ts
@@ -11,7 +11,6 @@ import {
   type MaybePromise,
   type RequestUploadParams,
 } from '@edgestore/shared';
-import { v4 as uuidv4 } from 'uuid';
 import { getEnv } from '../../adapters/shared';
 
 // FileInfo type as received by the provider's requestUpload, part of RequestUploadParams
@@ -179,7 +178,7 @@ export function AWSProvider(options?: AWSProviderOptions): EdgeStoreProvider {
         ? `.${fileInfo.extension.replace('.', '')}`
         : '';
       const defaultResolvedFileName =
-        fileInfo.fileName ?? `${uuidv4()}${extension}`;
+        fileInfo.fileName ?? `${crypto.randomUUID()}${extension}`;
       const defaultFilePathFromMetadata = fileInfo.path.reduce((acc, item) => {
         return `${acc}/${item.value}`;
       }, '');

--- a/packages/server/src/providers/azure/index.test.ts
+++ b/packages/server/src/providers/azure/index.test.ts
@@ -7,7 +7,9 @@ const mocks = vi.hoisted(() => ({
   getBlobClient: vi.fn(),
   getContainerClient: vi.fn(),
   getProperties: vi.fn(),
-  uuidv4: vi.fn(),
+  randomUUID: vi.fn(
+    () => 'generated-id' as ReturnType<typeof crypto.randomUUID>,
+  ),
 }));
 
 vi.mock('@azure/storage-blob', () => ({
@@ -16,10 +18,6 @@ vi.mock('@azure/storage-blob', () => ({
       getContainerClient = mocks.getContainerClient;
     },
   ),
-}));
-
-vi.mock('uuid', () => ({
-  v4: mocks.uuidv4,
 }));
 
 function encodeBlobName(blobName: string) {
@@ -49,8 +47,9 @@ describe('AzureProvider', () => {
   const containerUrl = 'http://localhost:10000/devstoreaccount1/files';
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
-    mocks.uuidv4.mockReturnValue('generated-id');
+    vi.spyOn(crypto, 'randomUUID').mockImplementation(mocks.randomUUID);
     mocks.getProperties.mockResolvedValue({
       contentLength: 123,
       lastModified: new Date('2026-01-02T03:04:05.000Z'),
@@ -141,7 +140,7 @@ describe('AzureProvider', () => {
       const res = await provider.requestUpload(createUploadParams(fileInfo));
 
       expect(mocks.getBlobClient).toHaveBeenCalledWith(expectedBlobName);
-      expect(mocks.uuidv4).toHaveBeenCalledTimes(expectedUuidCalls);
+      expect(mocks.randomUUID).toHaveBeenCalledTimes(expectedUuidCalls);
       expect(res).toEqual({
         accessUrl: `${containerUrl}/${encodeBlobName(expectedBlobName)}`,
         uploadUrl: `${containerUrl}/${encodeBlobName(expectedBlobName)}`,

--- a/packages/server/src/providers/azure/index.ts
+++ b/packages/server/src/providers/azure/index.ts
@@ -1,6 +1,5 @@
 import { BlobServiceClient } from '@azure/storage-blob';
 import { type Provider } from '@edgestore/shared';
-import { v4 as uuidv4 } from 'uuid';
 import { getEnv } from '../../adapters/shared';
 
 /**
@@ -81,7 +80,7 @@ export function AzureProvider(options?: AzureProviderOptions): Provider {
     const extension = fileInfo.extension
       ? `.${fileInfo.extension.replace('.', '')}`
       : '';
-    const fileName = fileInfo.fileName ?? `${uuidv4()}${extension}`;
+    const fileName = fileInfo.fileName ?? `${crypto.randomUUID()}${extension}`;
 
     return [
       esBucketName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       '@changesets/changelog-github':
         specifier: 0.5.2
         version: 0.5.2(encoding@0.1.13)
@@ -31,9 +31,6 @@ importers:
       '@rollup/plugin-typescript':
         specifier: 12.3.0
         version: 12.3.0(rollup@4.54.0)(tslib@2.8.1)(typescript@5.9.3)
-      '@types/prettier':
-        specifier: ^3.0.0
-        version: 3.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: 6.0.0-alpha.158
         version: 6.0.0-alpha.158(@typescript-eslint/parser@6.0.0-alpha.158(eslint@8.40.0)(typescript@5.9.3))(eslint@8.40.0)(typescript@5.9.3)
@@ -61,9 +58,6 @@ importers:
       eslint-plugin-unicorn:
         specifier: 47.0.0
         version: 47.0.0(eslint@8.40.0)
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -76,21 +70,18 @@ importers:
       rollup-plugin-delete:
         specifier: 2.2.0
         version: 2.2.0(rollup@4.54.0)
-      rollup-plugin-multi-input:
-        specifier: 1.6.0
-        version: 1.6.0
       rollup-plugin-node-externals:
         specifier: 8.1.2
         version: 8.1.2(rollup@4.54.0)
       rollup-plugin-swc3:
         specifier: 0.12.1
         version: 0.12.1(@swc/core@1.3.69(@swc/helpers@0.5.15))(rollup@4.54.0)
-      rollup-plugin-typescript2:
-        specifier: 0.36.0
-        version: 0.36.0(rollup@4.54.0)(typescript@5.9.3)
       shadcn:
         specifier: 2.4.0-canary.20
         version: 2.4.0-canary.20(@types/node@25.0.3)(typescript@5.9.3)
+      tsd:
+        specifier: ^0.33.0
+        version: 0.33.0
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -100,10 +91,6 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
-    devDependencies:
-      tsd:
-        specifier: ^0.33.0
-        version: 0.33.0
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jsdom@29.1.1)(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
@@ -124,7 +111,7 @@ importers:
         version: link:../packages/server
       '@fumadocs/mdx-remote':
         specifier: 1.4.4
-        version: 1.4.4(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(react@19.2.3)
+        version: 1.4.4(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(react@19.2.3)
       '@langfuse/otel':
         specifier: 4.5.1
         version: 4.5.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))
@@ -166,16 +153,16 @@ importers:
         version: 2.1.1
       fumadocs-core:
         specifier: 16.4.6
-        version: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
+        version: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
       fumadocs-mdx:
         specifier: 14.2.4
-        version: 14.2.4(509046bae908f7535f1f0aef521a0684)
+        version: 14.2.4(29419607b4ed6ee1193e0bf9b48b2a1c)
       fumadocs-twoslash:
         specifier: 3.1.12
-        version: 3.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 3.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       fumadocs-ui:
         specifier: 16.4.6
-        version: 16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)
+        version: 16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)
       hast-util-to-jsx-runtime:
         specifier: 2.3.6
         version: 2.3.6
@@ -187,7 +174,7 @@ importers:
         version: 12.16.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       posthog-js:
         specifier: 1.249.5
         version: 1.249.5
@@ -294,7 +281,7 @@ importers:
         version: link:../../packages/server
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -352,10 +339,10 @@ importers:
         version: 0.487.0(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.2.1(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       postcss:
         specifier: 8.4.21
         version: 8.4.21
@@ -503,7 +490,7 @@ importers:
         version: link:../../packages/server
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -537,7 +524,7 @@ importers:
         version: link:../../packages/server
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -577,7 +564,7 @@ importers:
         version: link:../../packages/server
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -611,10 +598,10 @@ importers:
         version: link:../../packages/server
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-intl:
         specifier: ^4.0.2
-        version: 4.0.2(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.0.2(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -660,7 +647,7 @@ importers:
         version: 0.487.0(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -854,34 +841,10 @@ importers:
 
   packages/react:
     dependencies:
-      '@aws-sdk/client-s3':
-        specifier: ^3.294.0
-        version: 3.294.0
-      '@aws-sdk/s3-request-presigner':
-        specifier: ^3.294.0
-        version: 3.294.0
       '@edgestore/shared':
         specifier: workspace:*
         version: link:../shared
-      '@panva/hkdf':
-        specifier: ^1.0.4
-        version: 1.0.4
-      cookie:
-        specifier: ^0.7.0
-        version: 0.7.2
-      jose:
-        specifier: ^4.13.1
-        version: 4.13.1
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
     devDependencies:
-      '@swc/helpers':
-        specifier: 0.5.3
-        version: 0.5.3
-      '@types/cookie':
-        specifier: ^0.5.1
-        version: 0.5.1
       '@types/node':
         specifier: 25.0.3
         version: 25.0.3
@@ -891,15 +854,12 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
-      '@types/uuid':
-        specifier: ^9.0.1
-        version: 9.0.1
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -919,17 +879,14 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@panva/hkdf':
-        specifier: ^1.0.4
-        version: 1.0.4
+        specifier: ^1.2.1
+        version: 1.2.1
       cookie:
-        specifier: ^0.7.0
+        specifier: ^0.7.2
         version: 0.7.2
       jose:
-        specifier: ^4.13.1
-        version: 4.13.1
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^4.15.9
+        version: 4.15.9
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.420.0
@@ -940,18 +897,12 @@ importers:
       '@azure/storage-blob':
         specifier: ^12.17.0
         version: 12.17.0(encoding@0.1.13)
-      '@types/cookie':
-        specifier: ^0.5.1
-        version: 0.5.1
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
       '@types/node':
         specifier: 25.0.3
         version: 25.0.3
-      '@types/uuid':
-        specifier: ^9.0.1
-        version: 9.0.1
       astro:
         specifier: ^5.7.12
         version: 5.7.12(@azure/storage-blob@12.17.0(encoding@0.1.13))(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.54.0)(terser@5.39.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.7.0)
@@ -969,7 +920,7 @@ importers:
         version: 4.7.9
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1131,439 +1082,128 @@ packages:
   '@aws-crypto/util@3.0.0':
     resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
 
-  '@aws-sdk/abort-controller@3.292.0':
-    resolution: {integrity: sha512-lf+OPptL01kvryIJy7+dvFux5KbJ6OTwLPPEekVKZ2AfEvwcVtOZWFUhyw3PJCBTVncjKB1Kjl3V/eTS3YuPXQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/chunked-blob-reader-native@3.292.0':
-    resolution: {integrity: sha512-A34sBrnggm9mXPZeeEie4jDv9zHRMS0LSm85VkfrBLuYYsfsw9DxmW59wJkuo6DIm/RK04oH5+lRMt34koBgrw==}
-
-  '@aws-sdk/chunked-blob-reader@3.292.0':
-    resolution: {integrity: sha512-ccFPnzBjLbDCmFjTXwhsfD58vtEiAjbor3A9tvnou+3Dj6RrMEGPaTu5tcw3mwWb2zh1K3HFJg6Bmb0no49TRw==}
-
-  '@aws-sdk/client-s3@3.294.0':
-    resolution: {integrity: sha512-J0rTBpZlmeNWgpYaGM7w55Hdmh8LWfYFmb09Fr0Oee/VGFgi28p3vCCnP+ploo1TlFRdsPlGZJ7zod+m/iPeBg==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/client-s3@3.420.0':
     resolution: {integrity: sha512-fmU0b8tM8vPCrEW8kNcY2yhFQBGuN4asYUAqybiSpzyF9Xy3Q0diQQE9WmoJVTO+DXB8tOhZZqUC1kxHCUDjww==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/client-sso-oidc@3.294.0':
-    resolution: {integrity: sha512-/ZfDud76MdSPJ/TxjV2xLE30XbBQDZwKQ32axwoK1eziPvrAIUBYVgpBwj+m0quhoiQhBKkg3aFl6j39AF2thw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/client-sso@3.294.0':
-    resolution: {integrity: sha512-+FuxQTi5WvnaXM5JbNLkBIzQ3An4gA0ox61N1u+3xled+nywKb1yQ7WmRpyMG5bLbkmnj3aqoo5/uskFc4c4EA==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/client-sso@3.418.0':
     resolution: {integrity: sha512-fakz3YeSW/kCAOJ5w4ObrrQBxsYO8sU8i6WHLv6iWAsYZKAws2Mqa8g89P61+GitSH4z9waksdLouS6ep78/5A==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/client-sts@3.294.0':
-    resolution: {integrity: sha512-AefqwhFjTDzelZuSYhriJbiI+GQwf2yKiKAnCt0gRj6rswewStM63Gtlhfb01sFPp+ZiqPcyQ47LqUaHp1mz/g==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/client-sts@3.418.0':
     resolution: {integrity: sha512-L0n0Hw+Pm+BhXTN1bYZ0y4JAMArYgazdHf1nUSlEHndgZicCCuQtlMLxfo3i/IbtWi0dzfZcZ9d/MdAM8p4Jyw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/config-resolver@3.292.0':
-    resolution: {integrity: sha512-cB3twnNR7vYvlt2jvw8VlA1+iv/tVzl+/S39MKqw2tepU+AbJAM0EHwb/dkf1OKSmlrnANXhshx80MHF9zL4mA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.292.0':
-    resolution: {integrity: sha512-YbafSG0ZEKE2969CJWVtUhh3hfOeLPecFVoXOtegCyAJgY5Ghtu4TsVhL4DgiGAgOC30ojAmUVQEXzd7xJF5xA==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/credential-provider-env@3.418.0':
     resolution: {integrity: sha512-e74sS+x63EZUBO+HaI8zor886YdtmULzwKdctsZp5/37Xho1CVUNtEC+fYa69nigBD9afoiH33I4JggaHgrekQ==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/credential-provider-imds@3.292.0':
-    resolution: {integrity: sha512-W/peOgDSRYulgzFpUhvgi1pCm6piBz6xrVN17N4QOy+3NHBXRVMVzYk6ct2qpLPgJUSEZkcpP+Gds+bBm8ed1A==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.294.0':
-    resolution: {integrity: sha512-pdTPbaAb5bWA+DnuKoL2TpXeNDp6Ejpv/OYt+bw2gdzl9w5r/ZCtUTTbW+Vvejr4WL5s3c1bY96kwdqCn7iLqA==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/credential-provider-ini@3.418.0':
     resolution: {integrity: sha512-LTAeKKV85unlSqGNIeqEZ4N9gufaSoH+670n5YTUEk564zHCkUQW0PJomzLF5jKBco6Yfzv6rPBTukd+x9XWqw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.294.0':
-    resolution: {integrity: sha512-zUL1Qhb4BsQIZCs/TPpG4oIYH/9YsGiS+Se1tasSGjTOLfBy7jhOZ0QIdpEeyAx/EP8blOBredM9xWfEXgiHVA==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/credential-provider-node@3.418.0':
     resolution: {integrity: sha512-VveTjtSC6m8YXj3fQDkMKEZuHv+CR2Z4u/NAN51Fi4xOtIWUtOBj5rfZ8HmBYoBjRF0DtRlPXuMiNnXAzTctfQ==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.292.0':
-    resolution: {integrity: sha512-CFVXuMuUvg/a4tknzRikEDwZBnKlHs1LZCpTXIGjBdUTdosoi4WNzDLzGp93ZRTtcgFz+4wirz2f7P3lC0NrQw==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/credential-provider-process@3.418.0':
     resolution: {integrity: sha512-xPbdm2WKz1oH6pTkrJoUmr3OLuqvvcPYTQX0IIlc31tmDwDWPQjXGGFD/vwZGIZIkKaFpFxVMgAzfFScxox7dw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.294.0':
-    resolution: {integrity: sha512-UxrcAA/0l7j9+3tolYcG5M61D/IE1Bjd/9H87H1i2A2BrwUUBhW1Dp/vvROEDrrywlMDG3CDF3T/7ADtTak+sg==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.418.0':
     resolution: {integrity: sha512-tUF5Hg/HfaU5t+E7IuvohYlodSIlBXa28xAJPPFxhKrUnvP6AIoW6JLazOtCIQjQgJYEUILV29XX+ojUuITcaw==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.292.0':
-    resolution: {integrity: sha512-4DbtIEM9gGVfqYlMdYXg3XY+vBhemjB1zXIequottW8loLYM8Vuz4/uGxxKNze6evVVzowsA0wKrYclE1aj/Rg==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/credential-provider-web-identity@3.418.0':
     resolution: {integrity: sha512-do7ang565n9p3dS1JdsQY01rUfRx8vkxQqz5M8OlcEHBNiCdi2PvSjNwcBdrv/FKkyIxZb0TImOfBSt40hVdxQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/eventstream-codec@3.292.0':
-    resolution: {integrity: sha512-P0np4vhCKf/JH6I39Id8DxZR+UZzG+Br+vOrTinerMfOhzTa2229XmL8pwlMpOoxnJLMPmEDtD1KQqLslBEXtw==}
-
-  '@aws-sdk/eventstream-serde-browser@3.292.0':
-    resolution: {integrity: sha512-VzRbJqqE444GOuoNTxTJ1dC1IhNhA6jfHjgsI8iDRHraaEukGqsPx1vkc+byxrDEjgxKN5IqOwZ4yJWMIAozBA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/eventstream-serde-config-resolver@3.292.0':
-    resolution: {integrity: sha512-Ndx+qJyWmBCW9FSm68AGLoO4AZ0AaL/wjpJEgFF2sZBWjYe9O9PB9IGR/yuqCBTElf3YtSiFMsloikQaz2ft6g==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/eventstream-serde-node@3.292.0':
-    resolution: {integrity: sha512-NFCEiNCetNye7jQfRd5y/7J9dLg9+uL57698wYeXeadlwJ8Cd/Nhsz+t7RIbP05VqshU+anXARMB1avl9oAijQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/eventstream-serde-universal@3.292.0':
-    resolution: {integrity: sha512-1gqZNx+S1EUpl3Tq6uIesiDx8gnkpXqPsFfCZT7lSWWXBpnHmnUZAh3jbiO9UlQbYuB9SfT0EBKb1iOY9z4j1Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/fetch-http-handler@3.292.0':
-    resolution: {integrity: sha512-zh3bhUJbL8RSa39ZKDcy+AghtUkIP8LwcNlwRIoxMQh3Row4D1s4fCq0KZCx98NJBEXoiTLyTQlZxxI//BOb1Q==}
-
-  '@aws-sdk/hash-blob-browser@3.292.0':
-    resolution: {integrity: sha512-4+Fm4IOkxGqgx8dU0EbExCq6xx30y369ZSXz89h9YDQYdJ2Muw7iNCHAg/4VM+gfp0vo9J8zPOTsSju8LNS5Jg==}
-
-  '@aws-sdk/hash-node@3.292.0':
-    resolution: {integrity: sha512-1yLxmIsvE+eK36JXEgEIouTITdykQLVhsA5Oai//Lar6Ddgu1sFpLDbdkMtKbrh4I0jLN9RacNCkeVQjZPTCCQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/hash-stream-node@3.292.0':
-    resolution: {integrity: sha512-p2nj9A5lZKQU45Q4Od3iZDvpziEpojAyuyAI0HPzpIuJIfzFQ0/7pMBKde1li6wq93rpyFLwNufV6FEZnKCYRg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/invalid-dependency@3.292.0':
-    resolution: {integrity: sha512-39OUV78CD3TmEbjhpt+V+Fk4wAGWhixqHxDSN8+4WL0uB4Fl7k5m3Z9hNY78AttHQSl2twR7WtLztnXPAFsriw==}
-
-  '@aws-sdk/is-array-buffer@3.292.0':
-    resolution: {integrity: sha512-kW/G5T/fzI0sJH5foZG6XJiNCevXqKLxV50qIT4B1pMuw7regd4ALIy0HwSqj1nnn9mSbRWBfmby0jWCJsMcwg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/md5-js@3.292.0':
-    resolution: {integrity: sha512-ngfsKLgQenXW3EbsDf47PVNys1SecTbsq6k88h7+Aa8BU49+9ZOIz4VDpWuPiNyYpeV7jJdl1dfD+ujOYvvgNw==}
-
-  '@aws-sdk/middleware-bucket-endpoint@3.292.0':
-    resolution: {integrity: sha512-XRy9RSUIRcbxYfH504ywhQllgfdf3wVhk2k0mMPYnUbeEhAFe1/eUog2v/bi07/q5TQ4Hppi+W3nHCVualQEow==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.418.0':
     resolution: {integrity: sha512-gj/mj1UfbKkGbQ1N4YUvjTTp8BVs5fO1QAL2AjFJ+jfJOToLReX72aNEkm7sPGbHML0TqOY4cQbJuWYy+zdD5g==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/middleware-content-length@3.292.0':
-    resolution: {integrity: sha512-2gMWzQus5mj14menolpPDbYBeaOYcj7KNFZOjTjjI3iQ0KqyetG6XasirNrcJ/8QX1BRmpTol8Xjp2Ue3Gbzwg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-endpoint@3.292.0':
-    resolution: {integrity: sha512-cPMkiSxpZGG6tYlW4OS+ucS6r43f9ddX9kcUoemJCY10MOuogdPjulCAjE0HTs2PLKSOrrG4CTP4Q4wWDrH4Bw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-expect-continue@3.292.0':
-    resolution: {integrity: sha512-bZ2bsBud3E6BebZWGxVcWxBSg09bP0KyX8PT0jI66JM0yTbZSJhoGhlKAqfNG46R9h4K5tCYB2uYgV/3oU/ZpQ==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/middleware-expect-continue@3.418.0':
     resolution: {integrity: sha512-6x4rcIj685EmqDLQkbWoCur3Dg5DRClHMen6nHXmD3CR5Xyt3z1Gk/+jmZICxyJo9c6M4AeZht8o95BopkmYAQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-flexible-checksums@3.292.0':
-    resolution: {integrity: sha512-AxU/Gb+TRdl/0jHmbreYh3QnB0jR25zgjPZ4/JbGBJ2SQI9jm3LCNK9XOrPUmZp/vu9wsvyxtmKQidpQ5+FX5w==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/middleware-flexible-checksums@3.418.0':
     resolution: {integrity: sha512-3O203dqS2JU5P1TAAbo7p1qplXQh59pevw9nqzPVb3EG8B+mSucVf2kKmF7kGHqKSk+nK/mB/4XGSsZBzGt6Wg==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.292.0':
-    resolution: {integrity: sha512-mHuCWe3Yg2S5YZ7mB7sKU6C97XspfqrimWjMW9pfV2usAvLA3R0HrB03jpR5vpZ3P4q7HB6wK3S6CjYMGGRNag==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/middleware-host-header@3.418.0':
     resolution: {integrity: sha512-LrMTdzalkPw/1ujLCKPLwCGvPMCmT4P+vOZQRbSEVZPnlZk+Aj++aL/RaHou0jL4kJH3zl8iQepriBt4a7UvXQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-location-constraint@3.292.0':
-    resolution: {integrity: sha512-WTbMyoCckdkmq7Yok0gI4226gTmxP/zM1fbFiC+liZXBJ+H5EvIFmu30tWbX+4m41LL/XQVm65olXJFwhoExGQ==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/middleware-location-constraint@3.418.0':
     resolution: {integrity: sha512-cc8M3VEaESHJhDsDV8tTpt2QYUprDWhvAVVSlcL43cTdZ54Quc0W+toDiaVOUlwrAZz2Y7g5NDj22ibJGFbOvw==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/middleware-logger@3.292.0':
-    resolution: {integrity: sha512-yZNY1XYmG3NG+uonET7jzKXNiwu61xm/ZZ6i/l51SusuaYN+qQtTAhOFsieQqTehF9kP4FzbsWgPDwD8ZZX9lw==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/middleware-logger@3.418.0':
     resolution: {integrity: sha512-StKGmyPVfoO/wdNTtKemYwoJsqIl4l7oqarQY7VSf2Mp3mqaa+njLViHsQbirYpyqpgUEusOnuTlH5utxJ1NsQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-recursion-detection@3.292.0':
-    resolution: {integrity: sha512-kA3VZpPko0Zqd7CYPTKAxhjEv0HJqFu2054L04dde1JLr43ro+2MTdX7vsHzeAFUVRphqatFFofCumvXmU6Mig==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/middleware-recursion-detection@3.418.0':
     resolution: {integrity: sha512-kKFrIQglBLUFPbHSDy1+bbe3Na2Kd70JSUC3QLMbUHmqipXN8KeXRfAj7vTv97zXl0WzG0buV++WcNwOm1rFjg==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/middleware-retry@3.293.0':
-    resolution: {integrity: sha512-7tiaz2GzRecNHaZ6YnF+Nrtk3au8qF6oiipf11R7MJiqJ0fkMLnz/iRrlakDziS9qF/a9v+3yxb4W4NHK3f4Tw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-sdk-s3@3.292.0':
-    resolution: {integrity: sha512-kEUmh3ZM34H+2bEQfpZhVotJCNYpSbq9Q4YxlWVbnjiO/VS+S9BFEM3Fcj5+EzEgI02tNNi6/qTXj3iS8tT6hA==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/middleware-sdk-s3@3.418.0':
     resolution: {integrity: sha512-rei32LF45SyqL3NlWDjEOfMwAca9A5F4QgUyXJqvASc43oWC1tJnLIhiCxNh8qkWAiRyRzFpcanTeqyaRSsZpA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-sdk-sts@3.292.0':
-    resolution: {integrity: sha512-GN5ZHEqXZqDi+HkVbaXRX9HaW/vA5rikYpWKYsmxTUZ7fB7ijvEO3co3lleJv2C+iGYRtUIHC4wYNB5xgoTCxg==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/middleware-sdk-sts@3.418.0':
     resolution: {integrity: sha512-cW8ijrCTP+mgihvcq4+TbhAcE/we5lFl4ydRqvTdtcSnYQAVQADg47rnTScQiFsPFEB3NKq7BGeyTJF9MKolPA==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/middleware-serde@3.292.0':
-    resolution: {integrity: sha512-6hN9mTQwSvV8EcGvtXbS/MpK7WMCokUku5Wu7X24UwCNMVkoRHLIkYcxHcvBTwttuOU0d8hph1/lIX4dkLwkQw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-signing@3.292.0':
-    resolution: {integrity: sha512-GVfoSjDjEQ4TaO6x9MffyP3uRV+2KcS5FtexLCYOM9pJcnE9tqq9FJOrZ1xl1g+YjUVKxo4x8lu3tpEtIb17qg==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/middleware-signing@3.418.0':
     resolution: {integrity: sha512-onvs5KoYQE8OlOE740RxWBGtsUyVIgAo0CzRKOQO63ZEYqpL1Os+MS1CGzdNhvQnJgJruE1WW+Ix8fjN30zKPA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-ssec@3.292.0':
-    resolution: {integrity: sha512-VfwrTEs9nYU6sCnt/cffhnJ2djGkMyMbBEysMZm2HEbFMloGKBd0Wtvk9y+SWPa6+DDRe2CqqX8jMzrO4JT4Eg==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/middleware-ssec@3.418.0':
     resolution: {integrity: sha512-J7K+5h6aP7IYMlu/NwHEIjb0+WDu1eFvO8TCPo6j1H9xYRi8B/6h+6pa9Rk9IgRUzFnrdlDu9FazG8Tp0KKLyg==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/middleware-stack@3.292.0':
-    resolution: {integrity: sha512-WdQpRkuMysrEwrkByCM1qCn2PPpFGGQ2iXqaFha5RzCdZDlxJni9cVNb6HzWUcgjLEYVTXCmOR9Wxm3CNW44Qg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.293.0':
-    resolution: {integrity: sha512-gZ7/e6XwpKk9mvgA78q4Ffc796jTn02TUKx2qMDnkLVbeJXBNN2jnvYEKq8v70+o7fd/ALRudg8gBDmkkhM/Hw==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/middleware-user-agent@3.418.0':
     resolution: {integrity: sha512-Jdcztg9Tal9SEAL0dKRrnpKrm6LFlWmAhvuwv0dQ7bNTJxIxyEFbpqdgy7mpQHsLVZgq1Aad/7gT/72c9igyZw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/node-config-provider@3.292.0':
-    resolution: {integrity: sha512-S3NnC9dQ5GIbJYSDIldZb4zdpCOEua1tM7bjYL3VS5uqCEM93kIi/o/UkIUveMp/eqTS2LJa5HjNIz5Te6je0A==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/node-http-handler@3.292.0':
-    resolution: {integrity: sha512-L/E3UDSwXLXjt1XWWh0RBD55F+aZI1AEdPwdES9i1PjnZLyuxuDhEDptVibNN56+I9/4Q3SbmuVRVlOD0uzBag==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/property-provider@3.292.0':
-    resolution: {integrity: sha512-dHArSvsiqhno/g55N815gXmAMrmN8DP7OeFNqJ4wJG42xsF2PFN3DAsjIuHuXMwu+7A3R1LHqIpvv0hA9KeoJQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/protocol-http@3.292.0':
-    resolution: {integrity: sha512-NLi4fq3k41aXIh1I97yX0JTy+3p6aW1NdwFwdMa674z86QNfb4SfRQRZBQe9wEnAZ/eWHVnlKIuII+U1URk/Kg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/querystring-builder@3.292.0':
-    resolution: {integrity: sha512-XElIFJaReIm24eEvBtV2dOtZvcm3gXsGu/ftG8MLJKbKXFKpAP1q+K6En0Bs7/T88voKghKdKpKT+eZUWgTqlg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/querystring-parser@3.292.0':
-    resolution: {integrity: sha512-iTYpYo7a8X9RxiPbjjewIpm6XQPx2EOcF1dWCPRII9EFlmZ4bwnX+PDI36fIo9oVs8TIKXmwNGODU9nsg7CSAw==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/region-config-resolver@3.418.0':
     resolution: {integrity: sha512-lJRZ/9TjZU6yLz+mAwxJkcJZ6BmyYoIJVo1p5+BN//EFdEmC8/c0c9gXMRzfISV/mqWSttdtccpAyN4/goHTYA==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/s3-request-presigner@3.294.0':
-    resolution: {integrity: sha512-zFUgDpWLYD9vN2C5Q2/Aqm1UjvhbSyyZ7e/N8bo+Rq0IcazgUHbGFgVvGEM7yp8FS/Ncz0ouliZLFk3VtV2LxQ==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/s3-request-presigner@3.420.0':
     resolution: {integrity: sha512-zR7TY0n4BZTL7KoHFWAhHnw51lBFFcU2rJ4NZBb4bSRIccIDbCJKXMku3Cn5S8UDFxtP+yWZ59xqjSeL2/z/EQ==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/service-error-classification@3.292.0':
-    resolution: {integrity: sha512-X1k3sixCeC45XSNHBe+kRBQBwPDyTFtFITb8O5Qw4dS9XWGhrUJT4CX0qE5aj8qP3F9U5nRizs9c2mBVVP0Caw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/shared-ini-file-loader@3.292.0':
-    resolution: {integrity: sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.292.0':
-    resolution: {integrity: sha512-MjWEIjbAr7n9vsFeLpoRzNSYFgWOROf1mLj6Db8TfRowaortUBO7PbleLV4n3SPujSnxhaVBzlmnCY2AjatH9g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@aws-sdk/signature-v4-crt': ^3.118.0
-    peerDependenciesMeta:
-      '@aws-sdk/signature-v4-crt':
-        optional: true
-
   '@aws-sdk/signature-v4-multi-region@3.418.0':
     resolution: {integrity: sha512-LeVYMZeUQUURFqDf4yZxTEv016g64hi0LqYBjU0mjwd8aPc0k6hckwvshezc80jCNbuLyjNfQclvlg3iFliItQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/signature-v4@3.292.0':
-    resolution: {integrity: sha512-+rw47VY5mvBecn13tDQTl1ipGWg5tE63faWgmZe68HoBL87ZiDzsd7bUKOvjfW21iMgWlwAppkaNNQayYRb2zg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/smithy-client@3.292.0':
-    resolution: {integrity: sha512-S8PKzjPkZ6SXYZuZiU787dMsvQ0d/LFEhw2OI4Oe2An9Fc2IwJ2FYukyHoQJOV2tV0DiuMebPo7eMyQyjKElvA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/token-providers@3.294.0':
-    resolution: {integrity: sha512-6nwO04LtC5f4AsUvGZXyjaswuEK4Rr2VsuANpMKrPCgunRfI58a8YXLniudOSXN6e7CFJ6M3uo/h5YXqtnzGug==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/token-providers@3.418.0':
     resolution: {integrity: sha512-9P7Q0VN0hEzTngy3Sz5eya2qEOEf0Q8qf1vB3um0gE6ID6EVAdz/nc/DztfN32MFxk8FeVBrCP5vWdoOzmd72g==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/types@3.292.0':
-    resolution: {integrity: sha512-1teYAY2M73UXZxMAxqZxVS2qwXjQh0OWtt7qyLfha0TtIk/fZ1hRwFgxbDCHUFcdNBSOSbKH/ESor90KROXLCQ==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/types@3.418.0':
     resolution: {integrity: sha512-y4PQSH+ulfFLY0+FYkaK4qbIaQI9IJNMO2xsxukW6/aNoApNymN1D2FSi2la8Qbp/iPjNDKsG8suNPm9NtsWXQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/url-parser@3.292.0':
-    resolution: {integrity: sha512-NZeAuZCk1x6TIiWuRfbOU6wHPBhf0ly2qOHzWut4BCH+b4RrDmFF8EmXcH1auEfGhE7yRyR6XqIN0t3S+hYACA==}
-
-  '@aws-sdk/util-arn-parser@3.292.0':
-    resolution: {integrity: sha512-xfE4U94TfjMC2WNNDte/kDByf16GrQKaS0BKsm+Fk/PaeHUofEp8suOEz/EVdEoa3Ayy2Uc5QdhrGnlqf8MxeA==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/util-arn-parser@3.310.0':
     resolution: {integrity: sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/util-base64@3.292.0':
-    resolution: {integrity: sha512-zjNCwNdy617yFvEjZorepNWXB2sQCVfsShCwFy/kIQ5iW5tT2jQKaqc0K77diU9atkooxw9p1W9m9sOgrkOFNw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-body-length-browser@3.292.0':
-    resolution: {integrity: sha512-Wd/BM+JsMiKvKs/bN3z6TredVEHh2pKudGfg3CSjTRpqFpOG903KDfyHBD42yg5PuCHoHoewJvTPKwgn7/vhaw==}
-
-  '@aws-sdk/util-body-length-node@3.292.0':
-    resolution: {integrity: sha512-BBgipZ2P6RhogWE/qj0oqpdlyd3iSBYmb+aD/TBXwB2lA/X8A99GxweBd/kp06AmcJRoMS9WIXgbWkiiBlRlSA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-buffer-from@3.292.0':
-    resolution: {integrity: sha512-RxNZjLoXNxHconH9TYsk5RaEBjSgTtozHeyIdacaHPj5vlQKi4hgL2hIfKeeNiAfQEVjaUFF29lv81xpNMzVMQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-config-provider@3.292.0':
-    resolution: {integrity: sha512-t3noYll6bPRSxeeNNEkC5czVjAiTPcsq00OwfJ2xyUqmquhLEfLwoJKmrT1uP7DjIEXdUtfoIQ2jWiIVm/oO5A==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-create-request@3.292.0':
-    resolution: {integrity: sha512-/Pyah55EeCt4Q3vN2Z3SPGd1mrza+B/Rx0nasJCcWVRmiDGiFvmxKVQIVlL8n7HoZ003O5lRIVxzwqnuM5FMeg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-defaults-mode-browser@3.292.0':
-    resolution: {integrity: sha512-7+zVUlMGfa8/KT++9humHo6IDxTnxMCmWUj5jVNlkpk6h7Ecmppf7aXotviyVIA43lhtz0p2AErs0N0ekEUK+w==}
-    engines: {node: '>= 10.0.0'}
-
-  '@aws-sdk/util-defaults-mode-node@3.292.0':
-    resolution: {integrity: sha512-SSIw85eF4BVs0fOJRyshT+R3b/UmBPhiVKCUZm2rq6+lIGkDPiSwQU3d/80AhXtiL5SFT/IzAKKgQd8qMa7q3A==}
-    engines: {node: '>= 10.0.0'}
-
-  '@aws-sdk/util-endpoints@3.293.0':
-    resolution: {integrity: sha512-R/99aNV49Refpv5guiUjEUrZYlvnfaNBniB+/ZtMO3ixxUopapssCrUivuJrmhccmrYaTCZw7dRzIWjU1jJhKg==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/util-endpoints@3.418.0':
     resolution: {integrity: sha512-sYSDwRTl7yE7LhHkPzemGzmIXFVHSsi3AQ1KeNEk84eBqxMHHcCc2kqklaBk2roXWe50QDgRMy1ikZUxvtzNHQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-format-url@3.292.0':
-    resolution: {integrity: sha512-GWZu8TgQBMBY2TS+plaH4m7A/gYHWogH1kTv/Rp7drGD/wbzdmw60KmD58KecAGGxNGiKHmjEO/PHNb0UyBNTw==}
     engines: {node: '>=14.0.0'}
 
   '@aws-sdk/util-format-url@3.418.0':
     resolution: {integrity: sha512-7/Xy+8J1txuOYOKsez6vpKTIkHYIIX4c7anjp/aQgUQL23FDwkPisj56cIlevJ7useGugnYw1rUR6fMULGzQ/g==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/util-hex-encoding@3.292.0':
-    resolution: {integrity: sha512-qBd5KFIUywQ3qSSbj814S2srk0vfv8A6QMI+Obs1y2LHZFdQN5zViptI4UhXhKOHe+NnrHWxSuLC/LMH6q3SmA==}
-    engines: {node: '>=14.0.0'}
-
   '@aws-sdk/util-locate-window@3.310.0':
     resolution: {integrity: sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==}
     engines: {node: '>=14.0.0'}
 
-  '@aws-sdk/util-middleware@3.292.0':
-    resolution: {integrity: sha512-KjhS7flfoBKDxbiBZjLjMvEizXgjfQb7GQEItgzGoI9rfGCmZtvqCcqQQoIlxb8bIzGRggAUHtBGWnlLbpb+GQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-retry@3.292.0':
-    resolution: {integrity: sha512-JEHyF7MpVeRF5uR4LDYgpOKcFpOPiAj8TqN46SVOQQcL1K+V7cSr7O7N7J6MwJaN9XOzAcBadeIupMm7/BFbgw==}
-    engines: {node: '>= 14.0.0'}
-
-  '@aws-sdk/util-stream-browser@3.292.0':
-    resolution: {integrity: sha512-yzwpjq18oefyp/Sv+Z0VWh7ziRPp+qM0pDUrTfuAnXg+mrlxaPDXJOhp5LoY8AVHcDPOEdIbzz0b00G48FabIg==}
-
-  '@aws-sdk/util-stream-node@3.292.0':
-    resolution: {integrity: sha512-p3DHXvWo4Zdka75HwewUnWjpFp/gOT4SYYEOAsv3BwuZGxfmnojK9OVCkUBJ7s6LeHMKTgGqQPwAnVFu7iIZNg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-uri-escape@3.292.0':
-    resolution: {integrity: sha512-hOQtUMQ4VcQ9iwKz50AoCp1XBD5gJ9nly/gJZccAM7zSA5mOO8RRKkbdonqquVHxrO0CnYgiFeCh3V35GFecUw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-user-agent-browser@3.292.0':
-    resolution: {integrity: sha512-dld+lpC3QdmTQHdBWJ0WFDkXDSrJgfz03q6mQ8+7H+BC12ZhT0I0g9iuvUjolqy7QR00OxOy47Y9FVhq8EC0Gg==}
-
   '@aws-sdk/util-user-agent-browser@3.418.0':
     resolution: {integrity: sha512-c4p4mc0VV/jIeNH0lsXzhJ1MpWRLuboGtNEpqE4s1Vl9ck2amv9VdUUZUmHbg+bVxlMgRQ4nmiovA4qIrqGuyg==}
-
-  '@aws-sdk/util-user-agent-node@3.292.0':
-    resolution: {integrity: sha512-f+NfIMal5E61MDc5WGhUEoicr7b1eNNhA+GgVdSB/Hg5fYhEZvFK9RZizH5rrtsLjjgcr9nPYSR7/nDKCJLumw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
 
   '@aws-sdk/util-user-agent-node@3.418.0':
     resolution: {integrity: sha512-BXMskXFtg+dmzSCgmnWOffokxIbPr1lFqa1D9kvM3l3IFRiFGx2IyDg+8MAhq11aPDLvoa/BDuQ0Yqma5izOhg==}
@@ -1576,18 +1216,6 @@ packages:
 
   '@aws-sdk/util-utf8-browser@3.259.0':
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
-
-  '@aws-sdk/util-utf8@3.292.0':
-    resolution: {integrity: sha512-FPkj+Z59/DQWvoVu2wFaRncc3KVwe/pgK3MfVb0Lx+Ibey5KUx+sNpJmYcVYHUAe/Nv/JeIpOtYuC96IXOnI6w==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-waiter@3.292.0':
-    resolution: {integrity: sha512-+7j+mcWUY4GwU8nTK4MvLWpOzS34SJZL85qLxQ04pysoCSHkInyS51D1ejBVNlJdbUSFvIcU0WHU0y6MDDeJzg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/xml-builder@3.292.0':
-    resolution: {integrity: sha512-0zgnhdwUy30q/1NPXi5ekdzHQqCs3ZJaUeGbvYMO54osi4K5hygAyTsyWtv6oaJggRqZrB0LAZ9xN6hG+sA8/g==}
-    engines: {node: '>=14.0.0'}
 
   '@aws-sdk/xml-builder@3.310.0':
     resolution: {integrity: sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==}
@@ -3583,8 +3211,8 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
-  '@panva/hkdf@1.0.4':
-    resolution: {integrity: sha512-003xWiCuvePbLaPHT+CRuaV4GlyCAVm6XYSbBZDHoWZGn1mNkVKFaDbGJjjxmEFvizUwlCoM6O18FCBMMky2zQ==}
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -4593,10 +4221,6 @@ packages:
       tslib:
         optional: true
 
-  '@rollup/pluginutils@4.2.1':
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
-
   '@rollup/pluginutils@5.1.4':
     resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
     engines: {node: '>=14.0.0'}
@@ -5188,9 +4812,6 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@swc/helpers@0.5.3':
-    resolution: {integrity: sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==}
-
   '@szmarczak/http-timer@1.1.2':
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}
     engines: {node: '>=6'}
@@ -5601,9 +5222,6 @@ packages:
   '@types/cookie-parser@1.4.6':
     resolution: {integrity: sha512-KoooCrD56qlLskXPLGUiJxOMnv5l/8m7cQD2OxJ73NPMhuSz9PmvwRD6EpjDyKBVrdJDdQ4bQK7JFNHnNmax0w==}
 
-  '@types/cookie@0.5.1':
-    resolution: {integrity: sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==}
-
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -5700,10 +5318,6 @@ packages:
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
-  '@types/prettier@3.0.0':
-    resolution: {integrity: sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==}
-    deprecated: This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.
-
   '@types/qs@6.9.7':
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
 
@@ -5750,9 +5364,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@9.0.1':
-    resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
 
   '@typescript-eslint/eslint-plugin@6.0.0-alpha.158':
     resolution: {integrity: sha512-fzcdANIIKtQxen+IdXue1u4EHY8h84M8L+eSSYgQQUxJy7tTN4EfBK4jlAAVxGCE+TkmTzBMe52hMAV0PwNLiQ==}
@@ -6721,10 +6332,6 @@ packages:
   cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
 
-  cross-spawn@6.0.5:
-    resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
-    engines: {node: '>=4.8'}
-
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -7356,10 +6963,6 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
-  fast-glob@3.3.2:
-    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
-    engines: {node: '>=8.6.0'}
-
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -7385,10 +6988,6 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
-  fast-xml-parser@4.1.2:
-    resolution: {integrity: sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==}
-    hasBin: true
 
   fast-xml-parser@4.2.5:
     resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
@@ -7453,10 +7052,6 @@ packages:
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
-
-  find-cache-dir@3.3.2:
-    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
-    engines: {node: '>=8'}
 
   find-my-way@9.3.0:
     resolution: {integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==}
@@ -8280,8 +7875,8 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  jose@4.13.1:
-    resolution: {integrity: sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ==}
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -8333,9 +7928,6 @@ packages:
 
   json-buffer@3.0.0:
     resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
-
-  json-parse-better-errors@1.0.2:
-    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -8546,10 +8138,6 @@ packages:
     resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
     hasBin: true
 
-  load-json-file@4.0.0:
-    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
-    engines: {node: '>=4'}
-
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
@@ -8652,10 +8240,6 @@ packages:
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
-
   map-obj@1.0.1:
     resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
     engines: {node: '>=0.10.0'}
@@ -8735,10 +8319,6 @@ packages:
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
-
-  memorystream@0.3.1:
-    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
-    engines: {node: '>= 0.10.0'}
 
   meow@9.0.0:
     resolution: {integrity: sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==}
@@ -9107,9 +8687,6 @@ packages:
       sass:
         optional: true
 
-  nice-try@1.0.5:
-    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
-
   nitropack@2.10.4:
     resolution: {integrity: sha512-sJiG/MIQlZCVSw2cQrFG1H6mLeSqHlYfFerRjLKz69vUfdu0EL2l0WdOxlQbzJr3mMv/l4cOlCCLzVRzjzzF/g==}
     engines: {node: ^16.11.0 || >=17.0.0}
@@ -9216,11 +8793,6 @@ packages:
   npm-pick-manifest@8.0.1:
     resolution: {integrity: sha512-mRtvlBjTsJvfCCdmPtiu2bdlx8d/KXtF7yNXNWe7G0Z36qWA9Ny5zXsI2PfBZEv7SXgoxTmNaTzGSbbzDZChoA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  npm-run-all@4.1.5:
-    resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
-    engines: {node: '>= 4'}
-    hasBin: true
 
   npm-run-path@5.1.0:
     resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
@@ -9416,10 +8988,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  parse-json@4.0.0:
-    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
-    engines: {node: '>=4'}
-
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -9452,10 +9020,6 @@ packages:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
 
-  path-key@2.0.1:
-    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
-    engines: {node: '>=4'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -9482,10 +9046,6 @@ packages:
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
-
-  path-type@3.0.0:
-    resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
-    engines: {node: '>=4'}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -9519,18 +9079,9 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
-  pidtree@0.3.1:
-    resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
-
-  pify@3.0.0:
-    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
-    engines: {node: '>=4'}
 
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -9549,10 +9100,6 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
-
-  pkg-dir@4.2.0:
-    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
-    engines: {node: '>=8'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -9945,10 +9492,6 @@ packages:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
     engines: {node: '>=8'}
 
-  read-pkg@3.0.0:
-    resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
-    engines: {node: '>=4'}
-
   read-pkg@5.2.0:
     resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
     engines: {node: '>=8'}
@@ -10177,10 +9720,6 @@ packages:
     peerDependencies:
       rollup: '*'
 
-  rollup-plugin-multi-input@1.6.0:
-    resolution: {integrity: sha512-4m+YggEiRavXMidP4eSzJLcwp0wQ7rHBtihlBuYDwVC35GA8LT7xoHlW9bW9kw/T2B0bDSoCLZfI5xJh01qhvg==}
-    engines: {node: '>=16'}
-
   rollup-plugin-node-externals@8.1.2:
     resolution: {integrity: sha512-EuB6/lolkMLK16gvibUjikERq5fCRVIGwD2xue/CrM8D0pz5GXD2V6N8IrgxegwbcUoKkUFI8VYCEEv8MMvgpA==}
     engines: {node: '>= 21 || ^20.6.0 || ^18.19.0'}
@@ -10193,12 +9732,6 @@ packages:
     peerDependencies:
       '@swc/core': '>=1.2.165'
       rollup: ^2.0.0 || ^3.0.0 || ^4.0.0
-
-  rollup-plugin-typescript2@0.36.0:
-    resolution: {integrity: sha512-NB2CSQDxSe9+Oe2ahZbf+B4bh7pHwjV5L+RSYpCu7Q5ROuN94F9b6ioWwKfz3ueL3KTtmX4o2MUH2cgHDIEUsw==}
-    peerDependencies:
-      rollup: '>=1.26.3'
-      typescript: '>=2.4.0'
 
   rollup-plugin-visualizer@5.14.0:
     resolution: {integrity: sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==}
@@ -10379,9 +9912,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.1:
-    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
-
   shiki@3.21.0:
     resolution: {integrity: sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==}
 
@@ -10521,10 +10051,6 @@ packages:
 
   string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
-
-  string.prototype.padend@3.1.4:
-    resolution: {integrity: sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==}
-    engines: {node: '>= 0.4'}
 
   string.prototype.trim@1.2.7:
     resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
@@ -11283,11 +10809,6 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  uuid@9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   valibot@0.41.0:
     resolution: {integrity: sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng==}
     peerDependencies:
@@ -11868,80 +11389,6 @@ snapshots:
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
 
-  '@aws-sdk/abort-controller@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/chunked-blob-reader-native@3.292.0':
-    dependencies:
-      '@aws-sdk/util-base64': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/chunked-blob-reader@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/client-s3@3.294.0':
-    dependencies:
-      '@aws-crypto/sha1-browser': 3.0.0
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.294.0
-      '@aws-sdk/config-resolver': 3.292.0
-      '@aws-sdk/credential-provider-node': 3.294.0
-      '@aws-sdk/eventstream-serde-browser': 3.292.0
-      '@aws-sdk/eventstream-serde-config-resolver': 3.292.0
-      '@aws-sdk/eventstream-serde-node': 3.292.0
-      '@aws-sdk/fetch-http-handler': 3.292.0
-      '@aws-sdk/hash-blob-browser': 3.292.0
-      '@aws-sdk/hash-node': 3.292.0
-      '@aws-sdk/hash-stream-node': 3.292.0
-      '@aws-sdk/invalid-dependency': 3.292.0
-      '@aws-sdk/md5-js': 3.292.0
-      '@aws-sdk/middleware-bucket-endpoint': 3.292.0
-      '@aws-sdk/middleware-content-length': 3.292.0
-      '@aws-sdk/middleware-endpoint': 3.292.0
-      '@aws-sdk/middleware-expect-continue': 3.292.0
-      '@aws-sdk/middleware-flexible-checksums': 3.292.0
-      '@aws-sdk/middleware-host-header': 3.292.0
-      '@aws-sdk/middleware-location-constraint': 3.292.0
-      '@aws-sdk/middleware-logger': 3.292.0
-      '@aws-sdk/middleware-recursion-detection': 3.292.0
-      '@aws-sdk/middleware-retry': 3.293.0
-      '@aws-sdk/middleware-sdk-s3': 3.292.0
-      '@aws-sdk/middleware-serde': 3.292.0
-      '@aws-sdk/middleware-signing': 3.292.0
-      '@aws-sdk/middleware-ssec': 3.292.0
-      '@aws-sdk/middleware-stack': 3.292.0
-      '@aws-sdk/middleware-user-agent': 3.293.0
-      '@aws-sdk/node-config-provider': 3.292.0
-      '@aws-sdk/node-http-handler': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/signature-v4-multi-region': 3.292.0
-      '@aws-sdk/smithy-client': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/url-parser': 3.292.0
-      '@aws-sdk/util-base64': 3.292.0
-      '@aws-sdk/util-body-length-browser': 3.292.0
-      '@aws-sdk/util-body-length-node': 3.292.0
-      '@aws-sdk/util-defaults-mode-browser': 3.292.0
-      '@aws-sdk/util-defaults-mode-node': 3.292.0
-      '@aws-sdk/util-endpoints': 3.293.0
-      '@aws-sdk/util-retry': 3.292.0
-      '@aws-sdk/util-stream-browser': 3.292.0
-      '@aws-sdk/util-stream-node': 3.292.0
-      '@aws-sdk/util-user-agent-browser': 3.292.0
-      '@aws-sdk/util-user-agent-node': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
-      '@aws-sdk/util-waiter': 3.292.0
-      '@aws-sdk/xml-builder': 3.292.0
-      fast-xml-parser: 4.1.2
-      tslib: 2.6.0
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
-      - aws-crt
-
   '@aws-sdk/client-s3@3.420.0':
     dependencies:
       '@aws-crypto/sha1-browser': 3.0.0
@@ -12002,80 +11449,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.294.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/config-resolver': 3.292.0
-      '@aws-sdk/fetch-http-handler': 3.292.0
-      '@aws-sdk/hash-node': 3.292.0
-      '@aws-sdk/invalid-dependency': 3.292.0
-      '@aws-sdk/middleware-content-length': 3.292.0
-      '@aws-sdk/middleware-endpoint': 3.292.0
-      '@aws-sdk/middleware-host-header': 3.292.0
-      '@aws-sdk/middleware-logger': 3.292.0
-      '@aws-sdk/middleware-recursion-detection': 3.292.0
-      '@aws-sdk/middleware-retry': 3.293.0
-      '@aws-sdk/middleware-serde': 3.292.0
-      '@aws-sdk/middleware-stack': 3.292.0
-      '@aws-sdk/middleware-user-agent': 3.293.0
-      '@aws-sdk/node-config-provider': 3.292.0
-      '@aws-sdk/node-http-handler': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/smithy-client': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/url-parser': 3.292.0
-      '@aws-sdk/util-base64': 3.292.0
-      '@aws-sdk/util-body-length-browser': 3.292.0
-      '@aws-sdk/util-body-length-node': 3.292.0
-      '@aws-sdk/util-defaults-mode-browser': 3.292.0
-      '@aws-sdk/util-defaults-mode-node': 3.292.0
-      '@aws-sdk/util-endpoints': 3.293.0
-      '@aws-sdk/util-retry': 3.292.0
-      '@aws-sdk/util-user-agent-browser': 3.292.0
-      '@aws-sdk/util-user-agent-node': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-sso@3.294.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/config-resolver': 3.292.0
-      '@aws-sdk/fetch-http-handler': 3.292.0
-      '@aws-sdk/hash-node': 3.292.0
-      '@aws-sdk/invalid-dependency': 3.292.0
-      '@aws-sdk/middleware-content-length': 3.292.0
-      '@aws-sdk/middleware-endpoint': 3.292.0
-      '@aws-sdk/middleware-host-header': 3.292.0
-      '@aws-sdk/middleware-logger': 3.292.0
-      '@aws-sdk/middleware-recursion-detection': 3.292.0
-      '@aws-sdk/middleware-retry': 3.293.0
-      '@aws-sdk/middleware-serde': 3.292.0
-      '@aws-sdk/middleware-stack': 3.292.0
-      '@aws-sdk/middleware-user-agent': 3.293.0
-      '@aws-sdk/node-config-provider': 3.292.0
-      '@aws-sdk/node-http-handler': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/smithy-client': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/url-parser': 3.292.0
-      '@aws-sdk/util-base64': 3.292.0
-      '@aws-sdk/util-body-length-browser': 3.292.0
-      '@aws-sdk/util-body-length-node': 3.292.0
-      '@aws-sdk/util-defaults-mode-browser': 3.292.0
-      '@aws-sdk/util-defaults-mode-node': 3.292.0
-      '@aws-sdk/util-endpoints': 3.293.0
-      '@aws-sdk/util-retry': 3.292.0
-      '@aws-sdk/util-user-agent-browser': 3.292.0
-      '@aws-sdk/util-user-agent-node': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/client-sso@3.418.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
@@ -12111,47 +11484,6 @@ snapshots:
       '@smithy/util-defaults-mode-node': 2.0.13
       '@smithy/util-retry': 2.0.2
       '@smithy/util-utf8': 2.0.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-sts@3.294.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/config-resolver': 3.292.0
-      '@aws-sdk/credential-provider-node': 3.294.0
-      '@aws-sdk/fetch-http-handler': 3.292.0
-      '@aws-sdk/hash-node': 3.292.0
-      '@aws-sdk/invalid-dependency': 3.292.0
-      '@aws-sdk/middleware-content-length': 3.292.0
-      '@aws-sdk/middleware-endpoint': 3.292.0
-      '@aws-sdk/middleware-host-header': 3.292.0
-      '@aws-sdk/middleware-logger': 3.292.0
-      '@aws-sdk/middleware-recursion-detection': 3.292.0
-      '@aws-sdk/middleware-retry': 3.293.0
-      '@aws-sdk/middleware-sdk-sts': 3.292.0
-      '@aws-sdk/middleware-serde': 3.292.0
-      '@aws-sdk/middleware-signing': 3.292.0
-      '@aws-sdk/middleware-stack': 3.292.0
-      '@aws-sdk/middleware-user-agent': 3.293.0
-      '@aws-sdk/node-config-provider': 3.292.0
-      '@aws-sdk/node-http-handler': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/smithy-client': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/url-parser': 3.292.0
-      '@aws-sdk/util-base64': 3.292.0
-      '@aws-sdk/util-body-length-browser': 3.292.0
-      '@aws-sdk/util-body-length-node': 3.292.0
-      '@aws-sdk/util-defaults-mode-browser': 3.292.0
-      '@aws-sdk/util-defaults-mode-node': 3.292.0
-      '@aws-sdk/util-endpoints': 3.293.0
-      '@aws-sdk/util-retry': 3.292.0
-      '@aws-sdk/util-user-agent-browser': 3.292.0
-      '@aws-sdk/util-user-agent-node': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
-      fast-xml-parser: 4.1.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -12199,48 +11531,12 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/config-resolver@3.292.0':
-    dependencies:
-      '@aws-sdk/signature-v4': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-config-provider': 3.292.0
-      '@aws-sdk/util-middleware': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.292.0':
-    dependencies:
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-env@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
       '@smithy/property-provider': 2.0.10
       '@smithy/types': 2.3.3
       tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-imds@3.292.0':
-    dependencies:
-      '@aws-sdk/node-config-provider': 3.292.0
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/url-parser': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.294.0':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.292.0
-      '@aws-sdk/credential-provider-imds': 3.292.0
-      '@aws-sdk/credential-provider-process': 3.292.0
-      '@aws-sdk/credential-provider-sso': 3.294.0
-      '@aws-sdk/credential-provider-web-identity': 3.292.0
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/shared-ini-file-loader': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-ini@3.418.0':
     dependencies:
@@ -12253,21 +11549,6 @@ snapshots:
       '@smithy/property-provider': 2.0.10
       '@smithy/shared-ini-file-loader': 2.0.11
       '@smithy/types': 2.3.3
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.294.0':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.292.0
-      '@aws-sdk/credential-provider-imds': 3.292.0
-      '@aws-sdk/credential-provider-ini': 3.294.0
-      '@aws-sdk/credential-provider-process': 3.292.0
-      '@aws-sdk/credential-provider-sso': 3.294.0
-      '@aws-sdk/credential-provider-web-identity': 3.292.0
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/shared-ini-file-loader': 3.292.0
-      '@aws-sdk/types': 3.292.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -12288,13 +11569,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.292.0':
-    dependencies:
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/shared-ini-file-loader': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-process@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
@@ -12302,17 +11576,6 @@ snapshots:
       '@smithy/shared-ini-file-loader': 2.0.11
       '@smithy/types': 2.3.3
       tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.294.0':
-    dependencies:
-      '@aws-sdk/client-sso': 3.294.0
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/shared-ini-file-loader': 3.292.0
-      '@aws-sdk/token-providers': 3.294.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-sso@3.418.0':
     dependencies:
@@ -12326,98 +11589,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.292.0':
-    dependencies:
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-web-identity@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
       '@smithy/property-provider': 2.0.10
       '@smithy/types': 2.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/eventstream-codec@3.292.0':
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-hex-encoding': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/eventstream-serde-browser@3.292.0':
-    dependencies:
-      '@aws-sdk/eventstream-serde-universal': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/eventstream-serde-config-resolver@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/eventstream-serde-node@3.292.0':
-    dependencies:
-      '@aws-sdk/eventstream-serde-universal': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/eventstream-serde-universal@3.292.0':
-    dependencies:
-      '@aws-sdk/eventstream-codec': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/fetch-http-handler@3.292.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/querystring-builder': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-base64': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/hash-blob-browser@3.292.0':
-    dependencies:
-      '@aws-sdk/chunked-blob-reader': 3.292.0
-      '@aws-sdk/chunked-blob-reader-native': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/hash-node@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-buffer-from': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/hash-stream-node@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/invalid-dependency@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/is-array-buffer@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/md5-js@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-bucket-endpoint@3.292.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-arn-parser': 3.292.0
-      '@aws-sdk/util-config-provider': 3.292.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-bucket-endpoint@3.418.0':
@@ -12430,44 +11606,11 @@ snapshots:
       '@smithy/util-config-provider': 2.0.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-content-length@3.292.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-endpoint@3.292.0':
-    dependencies:
-      '@aws-sdk/middleware-serde': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/signature-v4': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/url-parser': 3.292.0
-      '@aws-sdk/util-config-provider': 3.292.0
-      '@aws-sdk/util-middleware': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-expect-continue@3.292.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-expect-continue@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
       '@smithy/protocol-http': 3.0.5
       '@smithy/types': 2.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-flexible-checksums@3.292.0':
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@aws-crypto/crc32c': 3.0.0
-      '@aws-sdk/is-array-buffer': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.418.0':
@@ -12481,22 +11624,11 @@ snapshots:
       '@smithy/util-utf8': 2.0.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-host-header@3.292.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-host-header@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
       '@smithy/protocol-http': 3.0.5
       '@smithy/types': 2.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-location-constraint@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-location-constraint@3.418.0':
@@ -12505,21 +11637,10 @@ snapshots:
       '@smithy/types': 2.3.3
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-logger@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-logger@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
       '@smithy/types': 2.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-recursion-detection@3.292.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/types': 3.292.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.418.0':
@@ -12527,23 +11648,6 @@ snapshots:
       '@aws-sdk/types': 3.418.0
       '@smithy/protocol-http': 3.0.5
       '@smithy/types': 2.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-retry@3.293.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/service-error-classification': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-middleware': 3.292.0
-      '@aws-sdk/util-retry': 3.292.0
-      tslib: 2.8.1
-      uuid: 8.3.2
-
-  '@aws-sdk/middleware-sdk-s3@3.292.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-arn-parser': 3.292.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.418.0':
@@ -12555,34 +11659,11 @@ snapshots:
       '@smithy/types': 2.3.3
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-sts@3.292.0':
-    dependencies:
-      '@aws-sdk/middleware-signing': 3.292.0
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/signature-v4': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-sdk-sts@3.418.0':
     dependencies:
       '@aws-sdk/middleware-signing': 3.418.0
       '@aws-sdk/types': 3.418.0
       '@smithy/types': 2.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-serde@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-signing@3.292.0':
-    dependencies:
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/signature-v4': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-middleware': 3.292.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-signing@3.418.0':
@@ -12595,26 +11676,10 @@ snapshots:
       '@smithy/util-middleware': 2.0.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-ssec@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-ssec@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
       '@smithy/types': 2.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-stack@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-user-agent@3.293.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-endpoints': 3.293.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.418.0':
@@ -12625,42 +11690,6 @@ snapshots:
       '@smithy/types': 2.3.3
       tslib: 2.8.1
 
-  '@aws-sdk/node-config-provider@3.292.0':
-    dependencies:
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/shared-ini-file-loader': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/node-http-handler@3.292.0':
-    dependencies:
-      '@aws-sdk/abort-controller': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/querystring-builder': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/property-provider@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/protocol-http@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/querystring-builder@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-uri-escape': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/querystring-parser@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/region-config-resolver@3.418.0':
     dependencies:
       '@smithy/node-config-provider': 2.0.12
@@ -12668,20 +11697,6 @@ snapshots:
       '@smithy/util-config-provider': 2.0.0
       '@smithy/util-middleware': 2.0.2
       tslib: 2.8.1
-
-  '@aws-sdk/s3-request-presigner@3.294.0':
-    dependencies:
-      '@aws-sdk/middleware-endpoint': 3.292.0
-      '@aws-sdk/middleware-sdk-s3': 3.292.0
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/signature-v4-multi-region': 3.292.0
-      '@aws-sdk/smithy-client': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-create-request': 3.292.0
-      '@aws-sdk/util-format-url': 3.292.0
-      tslib: 2.6.0
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
 
   '@aws-sdk/s3-request-presigner@3.420.0':
     dependencies:
@@ -12694,21 +11709,6 @@ snapshots:
       '@smithy/types': 2.3.3
       tslib: 2.6.0
 
-  '@aws-sdk/service-error-classification@3.292.0': {}
-
-  '@aws-sdk/shared-ini-file-loader@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.292.0':
-    dependencies:
-      '@aws-sdk/protocol-http': 3.292.0
-      '@aws-sdk/signature-v4': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-arn-parser': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/signature-v4-multi-region@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
@@ -12716,32 +11716,6 @@ snapshots:
       '@smithy/signature-v4': 2.0.9
       '@smithy/types': 2.3.3
       tslib: 2.8.1
-
-  '@aws-sdk/signature-v4@3.292.0':
-    dependencies:
-      '@aws-sdk/is-array-buffer': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-hex-encoding': 3.292.0
-      '@aws-sdk/util-middleware': 3.292.0
-      '@aws-sdk/util-uri-escape': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/smithy-client@3.292.0':
-    dependencies:
-      '@aws-sdk/middleware-stack': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.294.0':
-    dependencies:
-      '@aws-sdk/client-sso-oidc': 3.294.0
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/shared-ini-file-loader': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/token-providers@3.418.0':
     dependencies:
@@ -12783,88 +11757,18 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/types@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
   '@aws-sdk/types@3.418.0':
     dependencies:
       '@smithy/types': 2.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/url-parser@3.292.0':
-    dependencies:
-      '@aws-sdk/querystring-parser': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-arn-parser@3.292.0':
-    dependencies:
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.310.0':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-base64@3.292.0':
-    dependencies:
-      '@aws-sdk/util-buffer-from': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-body-length-browser@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-body-length-node@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-buffer-from@3.292.0':
-    dependencies:
-      '@aws-sdk/is-array-buffer': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-config-provider@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-create-request@3.292.0':
-    dependencies:
-      '@aws-sdk/middleware-stack': 3.292.0
-      '@aws-sdk/smithy-client': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-defaults-mode-browser@3.292.0':
-    dependencies:
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      bowser: 2.11.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-defaults-mode-node@3.292.0':
-    dependencies:
-      '@aws-sdk/config-resolver': 3.292.0
-      '@aws-sdk/credential-provider-imds': 3.292.0
-      '@aws-sdk/node-config-provider': 3.292.0
-      '@aws-sdk/property-provider': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-endpoints@3.293.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
   '@aws-sdk/util-endpoints@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-format-url@3.292.0':
-    dependencies:
-      '@aws-sdk/querystring-builder': 3.292.0
-      '@aws-sdk/types': 3.292.0
       tslib: 2.8.1
 
   '@aws-sdk/util-format-url@3.418.0':
@@ -12874,60 +11778,15 @@ snapshots:
       '@smithy/types': 2.3.3
       tslib: 2.8.1
 
-  '@aws-sdk/util-hex-encoding@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
   '@aws-sdk/util-locate-window@3.310.0':
     dependencies:
       tslib: 2.6.0
-
-  '@aws-sdk/util-middleware@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-retry@3.292.0':
-    dependencies:
-      '@aws-sdk/service-error-classification': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-stream-browser@3.292.0':
-    dependencies:
-      '@aws-sdk/fetch-http-handler': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-base64': 3.292.0
-      '@aws-sdk/util-hex-encoding': 3.292.0
-      '@aws-sdk/util-utf8': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-stream-node@3.292.0':
-    dependencies:
-      '@aws-sdk/node-http-handler': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      '@aws-sdk/util-buffer-from': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-uri-escape@3.292.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-browser@3.292.0':
-    dependencies:
-      '@aws-sdk/types': 3.292.0
-      bowser: 2.11.0
-      tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-browser@3.418.0':
     dependencies:
       '@aws-sdk/types': 3.418.0
       '@smithy/types': 2.3.3
       bowser: 2.11.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.292.0':
-    dependencies:
-      '@aws-sdk/node-config-provider': 3.292.0
-      '@aws-sdk/types': 3.292.0
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.418.0':
@@ -12940,21 +11799,6 @@ snapshots:
   '@aws-sdk/util-utf8-browser@3.259.0':
     dependencies:
       tslib: 2.6.0
-
-  '@aws-sdk/util-utf8@3.292.0':
-    dependencies:
-      '@aws-sdk/util-buffer-from': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-waiter@3.292.0':
-    dependencies:
-      '@aws-sdk/abort-controller': 3.292.0
-      '@aws-sdk/types': 3.292.0
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.292.0':
-    dependencies:
-      tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.310.0':
     dependencies:
@@ -14248,10 +13092,10 @@ snapshots:
       '@formatjs/fast-memoize': 3.0.3
       tslib: 2.8.1
 
-  '@fumadocs/mdx-remote@1.4.4(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(react@19.2.3)':
+  '@fumadocs/mdx-remote@1.4.4(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(react@19.2.3)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
-      fumadocs-core: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
+      fumadocs-core: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
       gray-matter: 4.0.3
       react: 19.2.3
       zod: 4.3.5
@@ -14260,9 +13104,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fumadocs/ui@16.4.6(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)':
+  '@fumadocs/ui@16.4.6(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)':
     dependencies:
-      fumadocs-core: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
+      fumadocs-core: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       postcss-selector-parser: 7.1.1
       react: 19.2.3
@@ -14270,7 +13114,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.7
-      next: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwindcss: 4.1.8
 
   '@hono/node-server@1.14.1(hono@4.7.9)':
@@ -14862,7 +13706,7 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
-  '@panva/hkdf@1.0.4': {}
+  '@panva/hkdf@1.2.1': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -15870,11 +14714,6 @@ snapshots:
       rollup: 4.54.0
       tslib: 2.8.1
 
-  '@rollup/pluginutils@4.2.1':
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-
   '@rollup/pluginutils@5.1.4(rollup@4.54.0)':
     dependencies:
       '@types/estree': 1.0.8
@@ -16455,10 +15294,6 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
-
-  '@swc/helpers@0.5.3':
-    dependencies:
-      tslib: 2.6.0
 
   '@szmarczak/http-timer@1.1.2':
     dependencies:
@@ -17354,8 +16189,6 @@ snapshots:
     dependencies:
       '@types/express': 4.17.21
 
-  '@types/cookie@0.5.1': {}
-
   '@types/cookie@0.6.0': {}
 
   '@types/cors@2.8.17':
@@ -17467,10 +16300,6 @@ snapshots:
   '@types/parse-json@4.0.2':
     optional: true
 
-  '@types/prettier@3.0.0':
-    dependencies:
-      prettier: 3.5.3
-
   '@types/qs@6.9.7': {}
 
   '@types/range-parser@1.2.4': {}
@@ -17515,8 +16344,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/uuid@9.0.1': {}
 
   '@typescript-eslint/eslint-plugin@6.0.0-alpha.158(@typescript-eslint/parser@6.0.0-alpha.158(eslint@8.40.0)(typescript@5.9.3))(eslint@8.40.0)(typescript@5.9.3)':
     dependencies:
@@ -18779,14 +17606,6 @@ snapshots:
       shebang-command: 1.2.0
       which: 1.3.1
 
-  cross-spawn@6.0.5:
-    dependencies:
-      nice-try: 1.0.5
-      path-key: 2.0.1
-      semver: 5.7.2
-      shebang-command: 1.2.0
-      which: 1.3.1
-
   cross-spawn@7.0.3:
     dependencies:
       path-key: 3.1.1
@@ -19649,14 +18468,6 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
-  fast-glob@3.3.2:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -19688,10 +18499,6 @@ snapshots:
 
   fast-uri@3.1.0:
     optional: true
-
-  fast-xml-parser@4.1.2:
-    dependencies:
-      strnum: 1.0.5
 
   fast-xml-parser@4.2.5:
     dependencies:
@@ -19781,12 +18588,6 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-
-  find-cache-dir@3.3.2:
-    dependencies:
-      commondir: 1.0.1
-      make-dir: 3.1.0
-      pkg-dir: 4.2.0
 
   find-my-way@9.3.0:
     dependencies:
@@ -19899,7 +18700,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42):
+  fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42):
     dependencies:
       '@formatjs/intl-localematcher': 0.7.5
       '@orama/orama': 3.1.18
@@ -19924,7 +18725,7 @@ snapshots:
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react': 19.2.7
       lucide-react: 0.510.0(react@19.2.3)
-      next: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       react-router: 7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -19932,14 +18733,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.4(509046bae908f7535f1f0aef521a0684):
+  fumadocs-mdx@14.2.4(29419607b4ed6ee1193e0bf9b48b2a1c):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
+      fumadocs-core: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
       js-yaml: 4.1.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -19953,19 +18754,19 @@ snapshots:
       vfile: 6.0.3
       zod: 4.3.5
     optionalDependencies:
-      '@fumadocs/mdx-remote': 1.4.4(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(react@19.2.3)
+      '@fumadocs/mdx-remote': 1.4.4(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(react@19.2.3)
       '@types/react': 19.2.7
-      next: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       vite: 6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-twoslash@3.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  fumadocs-twoslash@3.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@shikijs/twoslash': 3.21.0(typescript@5.9.3)
-      fumadocs-ui: 16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)
+      fumadocs-ui: 16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
@@ -19981,9 +18782,9 @@ snapshots:
       - supports-color
       - typescript
 
-  fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8):
+  fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8):
     dependencies:
-      '@fumadocs/ui': 16.4.6(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)
+      '@fumadocs/ui': 16.4.6(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -19995,7 +18796,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.7)(react@19.2.3)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
+      fumadocs-core: 16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42)
       lucide-react: 0.562.0(react@19.2.3)
       next-themes: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
@@ -20004,7 +18805,7 @@ snapshots:
       scroll-into-view-if-needed: 3.1.0
     optionalDependencies:
       '@types/react': 19.2.7
-      next: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwindcss: 4.1.8
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -20715,7 +19516,7 @@ snapshots:
 
   jju@1.4.0: {}
 
-  jose@4.13.1: {}
+  jose@4.15.9: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -20771,8 +19572,6 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.0: {}
-
-  json-parse-better-errors@1.0.2: {}
 
   json-parse-even-better-errors@2.3.1: {}
 
@@ -20953,13 +19752,6 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.2
 
-  load-json-file@4.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      parse-json: 4.0.0
-      pify: 3.0.0
-      strip-bom: 3.0.0
-
   loader-runner@4.3.1:
     optional: true
 
@@ -21052,10 +19844,6 @@ snapshots:
       '@babel/parser': 7.27.0
       '@babel/types': 7.27.0
       source-map-js: 1.2.1
-
-  make-dir@3.1.0:
-    dependencies:
-      semver: 6.3.1
 
   map-obj@1.0.1: {}
 
@@ -21241,8 +20029,6 @@ snapshots:
   mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
-
-  memorystream@0.3.1: {}
 
   meow@9.0.0:
     dependencies:
@@ -21702,19 +20488,19 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next-intl@4.0.2(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  next-intl@4.0.2(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.4
       negotiator: 1.0.0
-      next: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       use-intl: 4.0.2(react@19.2.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  next-themes@0.2.1(next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next-themes@0.2.1(next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      next: 16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
@@ -21723,7 +20509,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.1(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -21732,7 +20518,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.26.9)(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.27.1)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.1
       '@next/swc-darwin-x64': 16.1.1
@@ -21747,8 +20533,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-
-  nice-try@1.0.5: {}
 
   nitropack@2.10.4(encoding@0.1.13)(typescript@5.9.3):
     dependencies:
@@ -21937,18 +20721,6 @@ snapshots:
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 10.1.0
       semver: 7.7.3
-
-  npm-run-all@4.1.5:
-    dependencies:
-      ansi-styles: 3.2.1
-      chalk: 2.4.2
-      cross-spawn: 6.0.5
-      memorystream: 0.3.1
-      minimatch: 3.1.2
-      pidtree: 0.3.1
-      read-pkg: 3.0.0
-      shell-quote: 1.8.1
-      string.prototype.padend: 3.1.4
 
   npm-run-path@5.1.0:
     dependencies:
@@ -22162,11 +20934,6 @@ snapshots:
 
   parse-github-url@1.0.2: {}
 
-  parse-json@4.0.0:
-    dependencies:
-      error-ex: 1.3.2
-      json-parse-better-errors: 1.0.2
-
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -22205,8 +20972,6 @@ snapshots:
 
   path-is-absolute@1.0.1: {}
 
-  path-key@2.0.1: {}
-
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -22226,10 +20991,6 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
-  path-type@3.0.0:
-    dependencies:
-      pify: 3.0.0
-
   path-type@4.0.0: {}
 
   path-type@6.0.0: {}
@@ -22248,11 +21009,7 @@ snapshots:
 
   picomatch@4.0.3: {}
 
-  pidtree@0.3.1: {}
-
   pify@2.3.0: {}
-
-  pify@3.0.0: {}
 
   pify@4.0.1: {}
 
@@ -22277,10 +21034,6 @@ snapshots:
       thread-stream: 3.1.0
 
   pirates@4.0.6: {}
-
-  pkg-dir@4.2.0:
-    dependencies:
-      find-up: 4.1.0
 
   pkg-types@1.3.1:
     dependencies:
@@ -22600,12 +21353,6 @@ snapshots:
       read-pkg: 5.2.0
       type-fest: 0.8.1
 
-  read-pkg@3.0.0:
-    dependencies:
-      load-json-file: 4.0.0
-      normalize-package-data: 2.5.0
-      path-type: 3.0.0
-
   read-pkg@5.2.0:
     dependencies:
       '@types/normalize-package-data': 2.4.1
@@ -22918,10 +21665,6 @@ snapshots:
       del: 6.1.1
       rollup: 4.54.0
 
-  rollup-plugin-multi-input@1.6.0:
-    dependencies:
-      fast-glob: 3.3.2
-
   rollup-plugin-node-externals@8.1.2(rollup@4.54.0):
     dependencies:
       rollup: 4.54.0
@@ -22935,16 +21678,6 @@ snapshots:
       get-tsconfig: 4.10.0
       rollup: 4.54.0
       rollup-preserve-directives: 1.1.3(rollup@4.54.0)
-
-  rollup-plugin-typescript2@0.36.0(rollup@4.54.0)(typescript@5.9.3):
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      find-cache-dir: 3.3.2
-      fs-extra: 10.1.0
-      rollup: 4.54.0
-      semver: 7.7.2
-      tslib: 2.8.1
-      typescript: 5.9.3
 
   rollup-plugin-visualizer@5.14.0(rollup@4.54.0):
     dependencies:
@@ -23284,8 +22017,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.1: {}
-
   shiki@3.21.0:
     dependencies:
       '@shikijs/core': 3.21.0
@@ -23445,12 +22176,6 @@ snapshots:
       regexp.prototype.flags: 1.5.0
       side-channel: 1.1.0
 
-  string.prototype.padend@3.1.4:
-    dependencies:
-      call-bind: 1.0.5
-      define-properties: 1.2.0
-      es-abstract: 1.21.3
-
   string.prototype.trim@1.2.7:
     dependencies:
       call-bind: 1.0.5
@@ -23524,12 +22249,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.26.9)(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.27.1)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
     optionalDependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.27.1
 
   sucrase@3.35.0:
     dependencies:
@@ -24153,8 +22878,6 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@8.3.2: {}
-
-  uuid@9.0.0: {}
 
   valibot@0.41.0(typescript@5.9.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- remove unused AWS, token, cookie, and UUID dependencies from `@edgestore/react`
- replace server UUID generation with the platform crypto API
- update the server to the latest compatible `jose` 4.x, `cookie` 0.x, and HKDF releases
- remove unused and deprecated root tooling dependencies and classify private root tooling as development-only
- add patch changesets for the published React and server packages

## Why

The React client was pulling a large server-only AWS and authentication dependency graph into every consumer despite not importing it. Several of those packages carried known advisories. Root-only tooling was also classified as production dependencies, which made production audits noisier and retained an unused vulnerable `npm-run-all` chain.

`cookie@2` was tested but is not included here because its changed export shape breaks the repository's current dual CJS/ESM build. This slice uses the newest compatible stable `cookie@0.7.2`; the later package-format slice can revisit that major migration explicitly.

## Impact

The production audit changes from 7 critical / 119 high / 137 moderate findings to 6 critical / 109 high / 130 moderate. React consumers no longer install the unused AWS and authentication graph.

## Validation

- `pnpm turbo run build test typecheck lint --filter=@edgestore/react --filter=@edgestore/server`
- 118 focused runtime tests passed
- `pnpm audit --prod --json`
- `git diff --check`

## Stack

- base: `next`
- next: Upgrade 02, provider and adapter framework dependencies