### PR TITLE
[Upgrade 05] chore: begin TypeScript 6 migration

### DIFF
--- a/examples/astro-basic/package.json
+++ b/examples/astro-basic/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/react": "19.2.17",
-    "@types/react-dom": "19.2.3"
+    "@types/react-dom": "19.2.3",
+    "typescript": "5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "shadcn": "2.4.0-canary.20",
     "tsx": "4.21.0",
     "turbo": "2.7.2",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "tsd": "^0.33.0",
     "typescript-eslint": "8.65.0",
     "vitest": "^4.1.8"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -87,7 +87,7 @@
     "next": "16.2.11",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "zod": "3.25.76"
   },
   "gitHead": "a223c4cb8df50e6b64f9db5dc2daf93848748da9"

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
   "include": ["src"]
 }

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
   "include": ["src"]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -67,7 +67,7 @@
     "@types/node": "25.0.3",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "zod": "3.25.76"
   },
   "gitHead": "a223c4cb8df50e6b64f9db5dc2daf93848748da9"

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../.."
+  },
   "include": ["src"]
 }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -11,6 +11,6 @@
     "@edgestore/react": "workspace:*",
     "@edgestore/server": "workspace:*",
     "@edgestore/shared": "workspace:*",
-    "zod": "3.25.42"
+    "zod": "3.25.76"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 16.0.3(rollup@4.54.0)
       '@rollup/plugin-typescript':
         specifier: 12.3.0
-        version: 12.3.0(rollup@4.54.0)(tslib@2.8.1)(typescript@5.9.3)
+        version: 12.3.0(rollup@4.54.0)(tslib@2.8.1)(typescript@6.0.3)
       eslint:
         specifier: 9.39.5
         version: 9.39.5(jiti@2.4.2)
@@ -72,7 +72,7 @@ importers:
         version: 0.12.1(@swc/core@1.3.69(@swc/helpers@0.5.15))(rollup@4.54.0)
       shadcn:
         specifier: 2.4.0-canary.20
-        version: 2.4.0-canary.20(@types/node@25.0.3)(typescript@5.9.3)
+        version: 2.4.0-canary.20(@types/node@25.0.3)(typescript@6.0.3)
       tsd:
         specifier: ^0.33.0
         version: 0.33.0
@@ -83,14 +83,14 @@ importers:
         specifier: 2.7.2
         version: 2.7.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       typescript-eslint:
         specifier: 8.65.0
-        version: 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)
+        version: 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jsdom@29.1.1)(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jsdom@29.1.1)(msw@2.7.3(@types/node@25.0.3)(typescript@6.0.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
 
   docs:
     dependencies:
@@ -267,6 +267,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
 
   examples/basic-access-control:
     dependencies:
@@ -843,8 +846,8 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -922,8 +925,8 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -940,8 +943,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       zod:
-        specifier: 3.25.42
-        version: 3.25.42
+        specifier: 3.25.76
+        version: 3.25.76
 
 packages:
 
@@ -11158,6 +11161,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
@@ -15464,11 +15472,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.54.0
 
-  '@rollup/plugin-typescript@12.3.0(rollup@4.54.0)(tslib@2.8.1)(typescript@5.9.3)':
+  '@rollup/plugin-typescript@12.3.0(rollup@4.54.0)(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.54.0)
       resolve: 1.22.10
-      typescript: 5.9.3
+      typescript: 6.0.3
     optionalDependencies:
       rollup: 4.54.0
       tslib: 2.8.1
@@ -16845,40 +16853,40 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3))(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3))(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.65.0
       eslint: 9.39.5(jiti@2.4.2)
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3(supports-color@9.4.0)
       eslint: 9.39.5(jiti@2.4.2)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
       debug: 4.4.3(supports-color@9.4.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16887,47 +16895,47 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
 
-  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)
       debug: 4.4.3(supports-color@9.4.0)
       eslint: 9.39.5(jiti@2.4.2)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3(supports-color@9.4.0)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.0(eslint@9.39.5(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.4.2)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17037,13 +17045,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))':
+  '@vitest/mocker@4.1.8(msw@2.7.3(@types/node@25.0.3)(typescript@6.0.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.7.3(@types/node@25.0.3)(typescript@5.9.3)
+      msw: 2.7.3(@types/node@25.0.3)(typescript@6.0.3)
       vite: 8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)
 
   '@vitest/pretty-format@4.1.8':
@@ -21321,7 +21329,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3):
+  msw@2.7.3(@types/node@25.0.3)(typescript@6.0.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
@@ -21342,7 +21350,7 @@ snapshots:
       type-fest: 4.35.0
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -22980,7 +22988,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@2.4.0-canary.20(@types/node@25.0.3)(typescript@5.9.3):
+  shadcn@2.4.0-canary.20(@types/node@25.0.3)(typescript@6.0.3):
     dependencies:
       '@antfu/ni': 23.3.1
       '@babel/core': 7.26.9
@@ -22995,7 +23003,7 @@ snapshots:
       fs-extra: 11.3.0
       https-proxy-agent: 6.2.1
       kleur: 4.1.5
-      msw: 2.7.3(@types/node@25.0.3)(typescript@5.9.3)
+      msw: 2.7.3(@types/node@25.0.3)(typescript@6.0.3)
       node-fetch: 3.3.2
       ora: 6.3.1
       postcss: 8.5.3
@@ -23593,9 +23601,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-interface-checker@0.1.13: {}
 
@@ -23758,18 +23766,20 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3):
+  typescript-eslint@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3))(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3))(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.4.2))(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.4.2)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   ufo@1.5.4: {}
 
@@ -24277,10 +24287,10 @@ snapshots:
     optionalDependencies:
       vite: 6.4.3(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.7.0)
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jsdom@29.1.1)(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jsdom@29.1.1)(msw@2.7.3(@types/node@25.0.3)(typescript@6.0.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.7.3(@types/node@25.0.3)(typescript@5.9.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/mocker': 4.1.8(msw@2.7.3(@types/node@25.0.3)(typescript@6.0.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.7.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,7 +12,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "jsx": "react",
     "esModuleInterop": true,
     "skipLibCheck": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,17 +5,15 @@
     "types",
     "scripts",
     "examples",
-    "rollup.config.ts",
-    ".eslintrc.js"
+    "rollup.config.ts"
   ],
   "exclude": [],
   "compilerOptions": {
     "allowJs": false,
-    "baseUrl": ".",
     "paths": {
-      "@edgestore/react": ["packages/react/src"],
-      "@edgestore/react/*": ["packages/react/src/*"],
-      "@edgestore/shared": ["packages/shared/src"]
+      "@edgestore/react": ["./packages/react/src"],
+      "@edgestore/react/*": ["./packages/react/src/*"],
+      "@edgestore/shared": ["./packages/shared/src"]
     },
     "types": ["node"]
   }


### PR DESCRIPTION
## Summary

- move the root toolchain, `@edgestore/react`, and `@edgestore/shared` to TypeScript 6.0.3
- migrate deprecated `node` resolution to `bundler` resolution
- remove deprecated `baseUrl` and make path substitutions explicitly relative
- declare package roots required by TypeScript 6 and preserve Node globals in the React build
- align the type-test Zod fixture and explicitly pin Astro's TypeScript 5 compiler

## Compatibility choices

TypeScript 7.0.2 is not used because `typescript-eslint` 8.65 supports TypeScript below 6.1.

The server, docs, and framework examples remain on TypeScript 5.9.3 where Astro 5, twoslash, React Router 7, next-intl, and TanStack/Vinxi still publish TypeScript 5-only peer ranges. This PR advances the packages whose dependency graphs officially support TypeScript 6 without introducing unsupported peer combinations.

## Validation

- compiler resolution check: root/React/shared use 6.0.3; server/Astro use 5.9.3
- `pnpm build`
- `pnpm test` (123 tests)
- `pnpm typecheck`
- `pnpm test:types` (structural tests plus 19 hover tests)
- `pnpm turbo lint --output-logs=errors-only` (18/18 tasks)
- `pnpm format --check`
- `git diff --check`

## Stack

Depends on #152.