### PR TITLE
[Upgrade 08] chore: complete TypeScript 6 migration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ docs/.source/
 .test/
 **/.next/
 **/.astro/
+**/.react-router/
 **/docs/build/
 dist/
 pnpm-lock.yaml

--- a/docs/package.json
+++ b/docs/package.json
@@ -60,6 +60,6 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.5",
     "tw-animate-css": "^1.2.9",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/examples/astro-basic/package.json
+++ b/examples/astro-basic/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/basic-access-control/package.json
+++ b/examples/basic-access-control/package.json
@@ -20,6 +20,6 @@
     "@types/node": "25.0.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/components/package.json
+++ b/examples/components/package.json
@@ -36,6 +36,6 @@
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
     "tailwindcss": "^4",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/express-basic/package.json
+++ b/examples/express-basic/package.json
@@ -17,6 +17,6 @@
     "@types/express": "^5.0.6",
     "dotenv-cli": "^11.0.0",
     "tsx": "4.23.1",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/fastify-basic/package.json
+++ b/examples/fastify-basic/package.json
@@ -15,6 +15,6 @@
     "@types/node": "25.0.3",
     "dotenv-cli": "^11.0.0",
     "tsx": "4.23.1",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/hono-basic/package.json
+++ b/examples/hono-basic/package.json
@@ -17,6 +17,6 @@
     "@types/node": "25.0.3",
     "dotenv-cli": "^11.0.0",
     "tsx": "4.23.1",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/hono-basic/tsconfig.json
+++ b/examples/hono-basic/tsconfig.json
@@ -8,6 +8,7 @@
     "types": ["node"],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx",
+    "rootDir": "./src",
     "outDir": "./dist"
   },
   "exclude": ["node_modules"]

--- a/examples/next-advanced/package.json
+++ b/examples/next-advanced/package.json
@@ -20,6 +20,6 @@
     "@types/node": "25.0.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/next-basic-aws/package.json
+++ b/examples/next-basic-aws/package.json
@@ -23,6 +23,6 @@
     "@types/node": "25.0.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/next-basic-with-intl/package.json
+++ b/examples/next-basic-with-intl/package.json
@@ -21,6 +21,6 @@
     "@types/node": "25.0.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/next-basic/package.json
+++ b/examples/next-basic/package.json
@@ -20,6 +20,6 @@
     "@types/node": "25.0.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/next-complete/package.json
+++ b/examples/next-complete/package.json
@@ -30,6 +30,6 @@
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
     "tailwindcss": "^4",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/examples/remix-basic/package.json
+++ b/examples/remix-basic/package.json
@@ -24,7 +24,7 @@
     "@types/node": "25.0.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "^6.3.3",
     "vite-tsconfig-paths": "^5.1.4"
   }

--- a/examples/remix-basic/tsconfig.json
+++ b/examples/remix-basic/tsconfig.json
@@ -13,7 +13,6 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
     },

--- a/examples/start-basic/package.json
+++ b/examples/start-basic/package.json
@@ -29,7 +29,7 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/start-basic/tsconfig.json
+++ b/examples/start-basic/tsconfig.json
@@ -13,7 +13,6 @@
     "target": "ES2022",
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
     },

--- a/examples/vite-basic/package.json
+++ b/examples/vite-basic/package.json
@@ -18,7 +18,7 @@
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^4.2.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "^5.0.8"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -166,7 +166,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "tsx": "4.23.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "zod": "3.25.76"
   },
   "gitHead": "a223c4cb8df50e6b64f9db5dc2daf93848748da9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@t3-oss/env-nextjs':
         specifier: 0.13.6
-        version: 0.13.6(typescript@5.9.3)(zod@3.25.42)
+        version: 0.13.6(typescript@6.0.3)(zod@3.25.42)
       ai:
         specifier: 6.0.49
         version: 6.0.49(zod@3.25.42)
@@ -153,7 +153,7 @@ importers:
         version: 14.2.4(fdc87a31eef9dfe13cb3f81b7ae32b60)
       fumadocs-twoslash:
         specifier: 3.1.12
-        version: 3.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 3.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       fumadocs-ui:
         specifier: 16.4.6
         version: 16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)
@@ -201,7 +201,7 @@ importers:
         version: 3.3.0
       twoslash:
         specifier: 0.3.6
-        version: 0.3.6(typescript@5.9.3)
+        version: 0.3.6(typescript@6.0.3)
       unist-util-visit:
         specifier: 5.0.0
         version: 5.0.0
@@ -234,8 +234,8 @@ importers:
         specifier: ^1.2.9
         version: 1.3.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/astro-basic:
     dependencies:
@@ -250,7 +250,7 @@ importers:
         version: link:../../packages/server
       astro:
         specifier: ^5.18.2
-        version: 5.18.2(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rollup@4.62.2)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+        version: 5.18.2(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rollup@4.62.2)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -265,8 +265,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.17)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/basic-access-control:
     dependencies:
@@ -299,8 +299,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/components:
     dependencies:
@@ -381,8 +381,8 @@ importers:
         specifier: ^4
         version: 4.1.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/express-basic:
     dependencies:
@@ -415,8 +415,8 @@ importers:
         specifier: 4.23.1
         version: 4.23.1
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/fastify-basic:
     dependencies:
@@ -443,8 +443,8 @@ importers:
         specifier: 4.23.1
         version: 4.23.1
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/hono-basic:
     dependencies:
@@ -468,8 +468,8 @@ importers:
         specifier: 4.23.1
         version: 4.23.1
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/next-advanced:
     dependencies:
@@ -502,8 +502,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/next-basic:
     dependencies:
@@ -536,8 +536,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/next-basic-aws:
     dependencies:
@@ -576,8 +576,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.17)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/next-basic-with-intl:
     dependencies:
@@ -592,7 +592,7 @@ importers:
         version: 16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-intl:
         specifier: ^4.0.2
-        version: 4.0.2(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.0.2(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -613,8 +613,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/next-complete:
     dependencies:
@@ -674,8 +674,8 @@ importers:
         specifier: ^4
         version: 4.1.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   examples/remix-basic:
     dependencies:
@@ -687,10 +687,10 @@ importers:
         version: link:../../packages/server
       '@react-router/node':
         specifier: ^7.5.3
-        version: 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+        version: 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)
       '@react-router/serve':
         specifier: ^7.5.3
-        version: 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+        version: 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)
       isbot:
         specifier: ^5.1.27
         version: 5.1.27
@@ -706,7 +706,7 @@ importers:
     devDependencies:
       '@react-router/dev':
         specifier: ^7.5.3
-        version: 7.6.0(@react-router/serve@7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3))(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+        version: 7.6.0(@react-router/serve@7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3))(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
       '@types/node':
         specifier: 25.0.3
         version: 25.0.3
@@ -717,14 +717,14 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vite:
         specifier: ^6.3.3
         version: 6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 5.1.4(typescript@6.0.3)(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))
 
   examples/start-basic:
     dependencies:
@@ -742,7 +742,7 @@ importers:
         version: 1.106.0(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/start':
         specifier: ^1.106.0
-        version: 1.106.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1))(yaml@2.9.0)
+        version: 1.106.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2))(yaml@2.9.0)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -757,7 +757,7 @@ importers:
         version: 2.6.0
       vinxi:
         specifier: 0.5.3
-        version: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+        version: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       zod:
         specifier: 3.25.42
         version: 3.25.42
@@ -781,11 +781,11 @@ importers:
         specifier: ^3.4.17
         version: 3.4.17
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 5.1.4(typescript@6.0.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))
 
   examples/vite-basic:
     dependencies:
@@ -809,8 +809,8 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1(vite@5.0.8(@types/node@25.0.3)(lightningcss@1.33.0)(terser@5.39.0))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vite:
         specifier: ^5.0.8
         version: 5.0.8(@types/node@25.0.3)(lightningcss@1.33.0)(terser@5.39.0)
@@ -884,7 +884,7 @@ importers:
         version: 25.0.3
       astro:
         specifier: ^5.18.2
-        version: 5.18.2(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rollup@4.62.2)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+        version: 5.18.2(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rollup@4.62.2)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -910,8 +910,8 @@ importers:
         specifier: 4.23.1
         version: 4.23.1
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -1517,6 +1517,10 @@ packages:
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/standalone@7.26.9':
@@ -3556,20 +3560,20 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -3577,8 +3581,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -5791,6 +5795,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -5827,6 +5836,9 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -6117,6 +6129,11 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  browserslist@4.28.7:
+    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
@@ -6194,6 +6211,9 @@ packages:
 
   caniuse-lite@1.0.30001764:
     resolution: {integrity: sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==}
+
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -6795,6 +6815,9 @@ packages:
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
+  electron-to-chromium@1.5.395:
+    resolution: {integrity: sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==}
+
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
@@ -6819,8 +6842,8 @@ packages:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.18.4:
-    resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+  enhanced-resolve@5.24.3:
+    resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -7174,6 +7197,9 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-uri@4.1.1:
     resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
@@ -8540,8 +8566,8 @@ packages:
     resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
     hasBin: true
 
-  loader-runner@4.3.1:
-    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
   local-pkg@1.0.0:
@@ -9178,6 +9204,10 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
 
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
@@ -10111,6 +10141,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   resolve@2.0.0-next.7:
     resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
     engines: {node: '>= 0.4'}
@@ -10314,9 +10349,6 @@ packages:
 
   serialize-javascript@6.0.1:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
-
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serve-placeholder@2.0.2:
     resolution: {integrity: sha512-/TMG8SboeiQbZJWRlfTCqMs2DD3SZgWp0kDQePz9yUuCnDfDh/92gf7/PxGhzXTKBIPASIHxFcZndoNbp6QOLQ==}
@@ -10693,8 +10725,8 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-stream@3.1.7:
@@ -10714,18 +10746,45 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
-  terser-webpack-plugin@5.3.16:
-    resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
+  terser-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
+      '@minify-html/node': '*'
       '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
       esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
       uglify-js: '*'
       webpack: ^5.1.0
     peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
       '@swc/core':
         optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
       esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
         optional: true
       uglify-js:
         optional: true
@@ -10974,11 +11033,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
-
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -11545,8 +11599,8 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  watchpack@2.5.0:
-    resolution: {integrity: sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==}
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
   wcwidth@1.0.1:
@@ -11569,8 +11623,8 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  webpack-sources@3.3.3:
-    resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
+  webpack-sources@3.5.1:
+    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
 
   webpack-virtual-modules@0.6.2:
@@ -11702,8 +11756,8 @@ packages:
   yaml-ast-parser@0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
   yaml@2.7.0:
@@ -12653,6 +12707,9 @@ snapshots:
       - supports-color
 
   '@babel/runtime@7.28.4': {}
+
+  '@babel/runtime@7.29.7':
+    optional: true
 
   '@babel/standalone@7.26.9': {}
 
@@ -14269,24 +14326,23 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.2': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -15019,7 +15075,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@react-router/dev@7.6.0(@react-router/serve@7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3))(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)':
+  '@react-router/dev@7.6.0(@react-router/serve@7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3))(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/generator': 7.27.0
@@ -15030,7 +15086,7 @@ snapshots:
       '@babel/traverse': 7.27.0
       '@babel/types': 7.27.0
       '@npmcli/package-json': 4.0.1
-      '@react-router/node': 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      '@react-router/node': 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.9
       chokidar: 4.0.3
@@ -15047,12 +15103,12 @@ snapshots:
       react-router: 7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       semver: 7.7.1
       set-cookie-parser: 2.7.1
-      valibot: 0.41.0(typescript@5.9.3)
+      valibot: 0.41.0(typescript@6.0.3)
       vite: 6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-node: 3.0.0-beta.2(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)
     optionalDependencies:
-      '@react-router/serve': 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
-      typescript: 5.9.3
+      '@react-router/serve': 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15069,15 +15125,15 @@ snapshots:
       - tsx
       - yaml
 
-  '@react-router/express@7.6.0(express@4.21.2)(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)':
+  '@react-router/express@7.6.0(express@4.21.2)(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)':
     dependencies:
-      '@react-router/node': 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      '@react-router/node': 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)
       express: 4.21.2
       react-router: 7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@react-router/node@7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)':
+  '@react-router/node@7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)':
     dependencies:
       '@mjackson/node-fetch-server': 0.2.0
       react-router: 7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -15085,12 +15141,12 @@ snapshots:
       stream-slice: 0.1.2
       undici: 6.21.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@react-router/serve@7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)':
+  '@react-router/serve@7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)':
     dependencies:
-      '@react-router/express': 7.6.0(express@4.21.2)(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
-      '@react-router/node': 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      '@react-router/express': 7.6.0(express@4.21.2)(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)
+      '@react-router/node': 7.6.0(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.3)
       compression: 1.8.0
       express: 4.21.2
       get-port: 5.1.1
@@ -15483,12 +15539,12 @@ snapshots:
       '@shikijs/core': 3.21.0
       '@shikijs/types': 3.21.0
 
-  '@shikijs/twoslash@3.21.0(typescript@5.9.3)':
+  '@shikijs/twoslash@3.21.0(typescript@6.0.3)':
     dependencies:
       '@shikijs/core': 3.21.0
       '@shikijs/types': 3.21.0
-      twoslash: 0.3.6(typescript@5.9.3)
-      typescript: 5.9.3
+      twoslash: 0.3.6(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -15588,16 +15644,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@t3-oss/env-core@0.13.6(typescript@5.9.3)(zod@3.25.42)':
+  '@t3-oss/env-core@0.13.6(typescript@6.0.3)(zod@3.25.42)':
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
       zod: 3.25.42
 
-  '@t3-oss/env-nextjs@0.13.6(typescript@5.9.3)(zod@3.25.42)':
+  '@t3-oss/env-nextjs@0.13.6(typescript@6.0.3)(zod@3.25.42)':
     dependencies:
-      '@t3-oss/env-core': 0.13.6(typescript@5.9.3)(zod@3.25.42)
+      '@t3-oss/env-core': 0.13.6(typescript@6.0.3)(zod@3.25.42)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
       zod: 3.25.42
 
   '@tailwindcss/node@4.1.3':
@@ -15804,7 +15860,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@tanstack/router-plugin@1.106.0(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1))':
+  '@tanstack/router-plugin@1.106.0(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2))':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
@@ -15825,7 +15881,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       vite: 8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)
-      webpack: 5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)
+      webpack: 5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -15857,13 +15913,13 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@tanstack/start-api-routes@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)':
+  '@tanstack/start-api-routes@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/start-server': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      '@tanstack/start-server': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vinxi: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      vinxi: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15907,7 +15963,7 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-client@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)':
+  '@tanstack/start-client@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@tanstack/react-cross-context': 1.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -15916,7 +15972,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       tiny-invariant: 1.3.3
-      vinxi: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      vinxi: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15960,21 +16016,21 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-config@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1))(yaml@2.9.0)':
+  '@tanstack/start-config@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2))(yaml@2.9.0)':
     dependencies:
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/router-generator': 1.106.0(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      '@tanstack/router-plugin': 1.106.0(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1))
+      '@tanstack/router-plugin': 1.106.0(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2))
       '@tanstack/server-functions-plugin': 1.106.0(babel-plugin-macros@3.1.0)
       '@tanstack/start-plugin': 1.107.0
-      '@tanstack/start-server-functions-handler': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      '@tanstack/start-server-functions-handler': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       '@vitejs/plugin-react': 4.3.4(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))
       import-meta-resolve: 4.1.0
-      nitropack: 2.10.4(@azure/storage-blob@12.33.0)(encoding@0.1.13)(rolldown@1.1.5)(typescript@5.9.3)
+      nitropack: 2.10.4(@azure/storage-blob@12.33.0)(encoding@0.1.13)(rolldown@1.1.5)(typescript@6.0.3)
       ofetch: 1.4.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vinxi: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      vinxi: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       vite: 8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -16042,12 +16098,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/start-router-manifest@1.106.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)':
+  '@tanstack/start-router-manifest@1.106.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vinxi: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      vinxi: 0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -16091,10 +16147,10 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-server-functions-client@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)':
+  '@tanstack/start-server-functions-client@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@tanstack/server-functions-plugin': 1.106.0(babel-plugin-macros@3.1.0)
-      '@tanstack/start-server-functions-fetcher': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      '@tanstack/start-server-functions-fetcher': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
@@ -16141,10 +16197,10 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-server-functions-fetcher@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)':
+  '@tanstack/start-server-functions-fetcher@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
@@ -16190,11 +16246,11 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-server-functions-handler@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)':
+  '@tanstack/start-server-functions-handler@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
-      '@tanstack/start-server': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@tanstack/start-server': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       tiny-invariant: 1.3.3
@@ -16251,12 +16307,12 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@tanstack/start-server-functions-ssr@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)':
+  '@tanstack/start-server-functions-ssr@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@tanstack/server-functions-plugin': 1.106.0(babel-plugin-macros@3.1.0)
-      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
-      '@tanstack/start-server': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
-      '@tanstack/start-server-functions-fetcher': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@tanstack/start-server': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@tanstack/start-server-functions-fetcher': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       tiny-invariant: 1.3.3
@@ -16304,11 +16360,11 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start-server@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)':
+  '@tanstack/start-server@1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@tanstack/react-cross-context': 1.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router': 1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       h3: 1.13.0
       isbot: 5.1.27
       jsesc: 3.1.0
@@ -16358,17 +16414,17 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/start@1.106.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1))(yaml@2.9.0)':
+  '@tanstack/start@1.106.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2))(yaml@2.9.0)':
     dependencies:
-      '@tanstack/start-api-routes': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
-      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
-      '@tanstack/start-config': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1))(yaml@2.9.0)
-      '@tanstack/start-router-manifest': 1.106.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
-      '@tanstack/start-server': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
-      '@tanstack/start-server-functions-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
-      '@tanstack/start-server-functions-handler': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      '@tanstack/start-api-routes': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@tanstack/start-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@tanstack/start-config': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2))(yaml@2.9.0)
+      '@tanstack/start-router-manifest': 1.106.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@tanstack/start-server': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@tanstack/start-server-functions-client': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      '@tanstack/start-server-functions-handler': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       '@tanstack/start-server-functions-server': 1.106.0(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/start-server-functions-ssr': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      '@tanstack/start-server-functions-ssr': 1.107.0(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       vite: 8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -16727,10 +16783,10 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/vfs@1.6.2(typescript@5.9.3)':
+  '@typescript/vfs@1.6.2(typescript@6.0.3)':
     dependencies:
       debug: 4.4.3(supports-color@9.4.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16988,6 +17044,9 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  acorn@8.17.0:
+    optional: true
+
   agent-base@7.1.3: {}
 
   ai@6.0.49(zod@3.25.42):
@@ -16998,18 +17057,18 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.42
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
     optional: true
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
     optional: true
 
@@ -17026,6 +17085,14 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    optional: true
 
   ansi-align@3.0.1:
     dependencies:
@@ -17176,7 +17243,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@5.18.2(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rollup@4.62.2)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0):
+  astro@5.18.2(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rollup@4.62.2)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -17227,7 +17294,7 @@ snapshots:
       svgo: 4.0.2
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(typescript@6.0.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.0.0
@@ -17240,7 +17307,7 @@ snapshots:
       yocto-spinner: 0.2.3
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@6.0.3)(zod@3.25.76)
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -17326,9 +17393,9 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       cosmiconfig: 7.1.0
-      resolve: 1.22.11
+      resolve: 1.22.12
     optional: true
 
   bail@2.0.2: {}
@@ -17465,6 +17532,15 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  browserslist@4.28.7:
+    dependencies:
+      baseline-browser-mapping: 2.11.0
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.395
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
+    optional: true
+
   buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
@@ -17543,6 +17619,9 @@ snapshots:
   caniuse-lite@1.0.30001700: {}
 
   caniuse-lite@1.0.30001764: {}
+
+  caniuse-lite@1.0.30001806:
+    optional: true
 
   ccount@2.0.1: {}
 
@@ -17767,7 +17846,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
+      yaml: 1.10.3
     optional: true
 
   cosmiconfig@8.2.0:
@@ -18047,6 +18126,9 @@ snapshots:
 
   electron-to-chromium@1.5.267: {}
 
+  electron-to-chromium@1.5.395:
+    optional: true
+
   emoji-regex@10.4.0: {}
 
   emoji-regex@8.0.0: {}
@@ -18067,10 +18149,10 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.2.1
 
-  enhanced-resolve@5.18.4:
+  enhanced-resolve@5.24.3:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.3
     optional: true
 
   enquirer@2.4.1:
@@ -18835,6 +18917,9 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-uri@3.1.4:
+    optional: true
+
   fast-uri@4.1.1: {}
 
   fast-xml-builder@1.3.0:
@@ -19105,10 +19190,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-twoslash@3.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  fumadocs-twoslash@3.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-ui@16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
     dependencies:
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@shikijs/twoslash': 3.21.0(typescript@5.9.3)
+      '@shikijs/twoslash': 3.21.0(typescript@6.0.3)
       fumadocs-ui: 16.4.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.4.6(@tanstack/react-router@1.106.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(lucide-react@0.510.0(react@19.2.3))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.42))(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.8)
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.1.0
@@ -19116,7 +19201,7 @@ snapshots:
       react: 19.2.3
       shiki: 3.21.0
       tailwind-merge: 3.4.0
-      twoslash: 0.3.6(typescript@5.9.3)
+      twoslash: 0.3.6(typescript@6.0.3)
     optionalDependencies:
       '@types/react': 19.2.7
     transitivePeerDependencies:
@@ -20299,7 +20384,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.2
 
-  loader-runner@4.3.1:
+  loader-runner@4.3.2:
     optional: true
 
   local-pkg@1.0.0:
@@ -21046,7 +21131,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next-intl@4.0.2(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  next-intl@4.0.2(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.4
       negotiator: 1.0.0
@@ -21054,7 +21139,7 @@ snapshots:
       react: 19.2.3
       use-intl: 4.0.2(react@19.2.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   next-themes@0.2.1(next@16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -21117,7 +21202,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.10.4(@azure/storage-blob@12.33.0)(encoding@0.1.13)(rolldown@1.1.5)(typescript@5.9.3):
+  nitropack@2.10.4(@azure/storage-blob@12.33.0)(encoding@0.1.13)(rolldown@1.1.5)(typescript@6.0.3):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@netlify/functions': 2.8.2
@@ -21166,7 +21251,7 @@ snapshots:
       node-fetch-native: 1.6.6
       ofetch: 1.4.1
       ohash: 1.1.4
-      openapi-typescript: 7.6.1(typescript@5.9.3)
+      openapi-typescript: 7.6.1(typescript@6.0.3)
       pathe: 1.1.2
       perfect-debounce: 1.0.0
       pkg-types: 1.3.1
@@ -21255,6 +21340,9 @@ snapshots:
   node-releases@2.0.19: {}
 
   node-releases@2.0.27: {}
+
+  node-releases@2.0.51:
+    optional: true
 
   nopt@8.1.0:
     dependencies:
@@ -21425,14 +21513,14 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openapi-typescript@7.6.1(typescript@5.9.3):
+  openapi-typescript@7.6.1(typescript@6.0.3):
     dependencies:
       '@redocly/openapi-core': 1.29.0(supports-color@9.4.0)
       ansi-colors: 4.1.3
       change-case: 5.4.4
       parse-json: 8.1.0
       supports-color: 9.4.0
-      typescript: 5.9.3
+      typescript: 6.0.3
       yargs-parser: 21.1.1
 
   optionator@0.9.3:
@@ -21787,14 +21875,14 @@ snapshots:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 25.0.3
       long: 5.3.2
 
@@ -22231,6 +22319,14 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    optional: true
+
   resolve@2.0.0-next.7:
     dependencies:
       es-errors: 1.3.0
@@ -22469,9 +22565,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
     optional: true
 
   scroll-into-view-if-needed@3.1.0:
@@ -22556,11 +22652,6 @@ snapshots:
   serialize-javascript@6.0.1:
     dependencies:
       randombytes: 2.1.0
-
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
-    optional: true
 
   serve-placeholder@2.0.2:
     dependencies:
@@ -23079,7 +23170,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  tapable@2.3.0:
+  tapable@2.3.3:
     optional: true
 
   tar-stream@3.1.7:
@@ -23108,17 +23199,18 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.16(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2)(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
       terser: 5.39.0
-      webpack: 5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)
+      webpack: 5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2)
     optionalDependencies:
       '@swc/core': 1.3.69(@swc/helpers@0.5.15)
       esbuild: 0.28.1
+      lightningcss: 1.33.0
+      postcss: 8.5.2
     optional: true
 
   terser@5.19.0:
@@ -23131,7 +23223,7 @@ snapshots:
   terser@5.39.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
     optional: true
@@ -23233,13 +23325,13 @@ snapshots:
       '@ts-morph/common': 0.19.0
       code-block-writer: 12.0.0
 
-  tsconfck@3.1.5(typescript@5.9.3):
+  tsconfck@3.1.5(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  tsconfck@3.1.6(typescript@5.9.3):
+  tsconfck@3.1.6(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -23280,11 +23372,11 @@ snapshots:
 
   twoslash-protocol@0.3.6: {}
 
-  twoslash@0.3.6(typescript@5.9.3):
+  twoslash@0.3.6(typescript@6.0.3):
     dependencies:
-      '@typescript/vfs': 1.6.2(typescript@5.9.3)
+      '@typescript/vfs': 1.6.2(typescript@6.0.3)
       twoslash-protocol: 0.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -23372,8 +23464,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 
@@ -23593,6 +23683,13 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
+    dependencies:
+      browserslist: 4.28.7
+      escalade: 3.2.0
+      picocolors: 1.1.1
+    optional: true
+
   uqr@0.1.2: {}
 
   uri-js-replace@1.0.1: {}
@@ -23642,9 +23739,9 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  valibot@0.41.0(typescript@5.9.3):
+  valibot@0.41.0(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -23674,7 +23771,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vinxi@0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0):
+  vinxi@0.5.3(@azure/storage-blob@12.33.0)(@types/node@25.0.3)(db0@0.2.4)(encoding@0.1.13)(ioredis@5.5.0)(jiti@2.4.2)(lightningcss@1.33.0)(rolldown@1.1.5)(terser@5.39.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.6)
@@ -23696,7 +23793,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.5
-      nitropack: 2.10.4(@azure/storage-blob@12.33.0)(encoding@0.1.13)(rolldown@1.1.5)(typescript@5.9.3)
+      nitropack: 2.10.4(@azure/storage-blob@12.33.0)(encoding@0.1.13)(rolldown@1.1.5)(typescript@6.0.3)
       node-fetch-native: 1.6.6
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -23774,22 +23871,22 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vite-tsconfig-paths@5.1.4(typescript@6.0.3)(vite@6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 3.1.5(typescript@5.9.3)
+      tsconfck: 3.1.5(typescript@6.0.3)
     optionalDependencies:
       vite: 6.3.5(@types/node@25.0.3)(jiti@2.4.2)(lightningcss@1.33.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vite-tsconfig-paths@5.1.4(typescript@6.0.3)(vite@8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 3.1.5(typescript@5.9.3)
+      tsconfck: 3.1.5(typescript@6.0.3)
     optionalDependencies:
       vite: 8.1.5(@types/node@25.0.3)(esbuild@0.28.1)(jiti@2.4.2)(terser@5.39.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -23894,9 +23991,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  watchpack@2.5.0:
+  watchpack@2.5.2:
     dependencies:
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
     optional: true
 
@@ -23914,39 +24010,48 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  webpack-sources@3.3.3:
+  webpack-sources@3.5.1:
     optional: true
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1):
+  webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      browserslist: 4.28.1
+      acorn: 8.17.0
+      browserslist: 4.28.7
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.4
+      enhanced-resolve: 5.24.3
       es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
+      loader-runner: 4.3.2
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1))
-      watchpack: 2.5.0
-      webpack-sources: 3.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2)(webpack@5.99.2(@swc/core@1.3.69(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.2))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
     transitivePeerDependencies:
+      - '@minify-html/node'
       - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
       - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
       - uglify-js
     optional: true
 
@@ -24094,7 +24199,7 @@ snapshots:
 
   yaml-ast-parser@0.0.43: {}
 
-  yaml@1.10.2:
+  yaml@1.10.3:
     optional: true
 
   yaml@2.7.0: {}
@@ -24137,9 +24242,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
+  zod-to-ts@1.2.0(typescript@6.0.3)(zod@3.25.76):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
       zod: 3.25.76
 
   zod-validation-error@4.0.2(zod@3.25.76):


### PR DESCRIPTION
## What changed

- move the server package, docs, and every example workspace to TypeScript 6.0.3
- remove the remaining deprecated `baseUrl` settings from docs, React Router, and TanStack Start configurations
- ignore React Router's generated type directory during repository-wide formatting checks

## Why

Upgrade 05 introduced TypeScript 6 where the dependency graph already accepted it. Because this stack targets the next major, this slice finishes the migration instead of retaining a split TypeScript 5/6 toolchain.

## Impact

All EdgeStore workspaces now use one TypeScript version. Some framework packages still advertise TypeScript 5-only peer ranges, but their actual type generation and compilation pass with TypeScript 6; subsequent framework-upgrade slices will reduce those stale peer warnings.

This slice intentionally leaves Zod untouched for the separately developed Standard Schema stack.

## Validation

- `pnpm turbo run typecheck --output-logs=errors-only` (all workspaces with typecheck tasks)
- `pnpm build`
- `pnpm test` (123 tests)
- `pnpm test:types` (including 19 hover tests)
- `pnpm turbo lint --output-logs=errors-only`
- `pnpm format --check`
- `git diff --check`