### PR TITLE
[CLI 02] feat: add project lifecycle commands

### DIFF
--- a/.changeset/calm-dogs-create.md
+++ b/.changeset/calm-dogs-create.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/cli": minor
+---
+
+Add project inspection, creation, and confirmed deletion commands.

--- a/.changeset/calm-dogs-create.md
+++ b/.changeset/calm-dogs-create.md
@@ -1,5 +1,0 @@
----
-"@edgestore/cli": minor
----
-
-Add project inspection, creation, and confirmed deletion commands.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -86,6 +86,43 @@ describe('runCli', () => {
     expect(fixture.stdout()).toContain('Marketing Site (x36t1ejdlz)');
   });
 
+  it('creates a project without linking the current directory', async () => {
+    await runCli(
+      ['project', 'create', '--name', 'Marketing Site'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(fixture.repoConfig.config).toBeUndefined();
+    expect(fixture.stdout()).toContain('EDGE_STORE_ACCESS_KEY=access_test');
+    expect(fixture.stdout()).toContain(
+      'You will not be able to view it again.',
+    );
+  });
+
+  it('requires explicit confirmation for non-interactive deletion', async () => {
+    fixture.runtime.io.inputIsTty = false;
+
+    const exitCode = await runCli(
+      ['project', 'delete', project.basePath],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.stderr()).toContain('--yes');
+  });
+
+  it('deletes the canonical project after typed confirmation', async () => {
+    await runCli(['project', 'delete', project.id], fixture.runtime, '0.0.0');
+
+    expect(fixture.confirmTyped).toHaveBeenCalledWith(
+      expect.stringContaining(project.basePath),
+      project.basePath,
+    );
+    expect(fixture.stdout()).toContain('Deleted project');
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -162,6 +199,7 @@ function createFixture() {
   const setCredential = vi.fn(async (token: string) => {
     credentialValue.value = token;
   });
+  const confirmTyped = vi.fn(async () => undefined);
   const credentials: CredentialStore = {
     get: vi.fn(async () => credentialValue.value),
     set: setCredential,
@@ -202,6 +240,23 @@ function createFixture() {
       projects: {
         list: vi.fn(async () => ({ projects: [project] })),
         get: vi.fn(async () => ({ project })),
+        create: vi.fn(async () => ({
+          project,
+          projectKey: {
+            key: {
+              id: 'key_123',
+              name: 'default',
+              accessKey: 'access_test',
+              projectId: project.id,
+              accountId: account.id,
+              createdAt: project.createdAt,
+              updatedAt: project.updatedAt,
+              revokedAt: null,
+            },
+            secretKey: 'secret_test',
+          },
+        })),
+        delete: vi.fn(async () => ({})),
       },
     },
   } as unknown as ManagementEdgeStoreSdk;
@@ -249,6 +304,7 @@ function createFixture() {
     credentials,
     prompts: {
       readToken,
+      confirmTyped,
     },
     sdkFactory: vi.fn(() => sdk),
   };
@@ -260,6 +316,7 @@ function createFixture() {
     credentials,
     setCredential,
     readToken,
+    confirmTyped,
     stdout: () => Buffer.concat(stdoutChunks).toString('utf8'),
     stderr: () => Buffer.concat(stderrChunks).toString('utf8'),
   };

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -157,6 +157,20 @@ describe('runCli', () => {
     expect(fixture.stdout()).toContain('Deleted project');
   });
 
+  it('deletes the supplied project reference when forced', async () => {
+    await runCli(
+      ['--plain', 'project', 'delete', project.id, '--yes'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(fixture.deleteProject).toHaveBeenCalledWith({
+      project: project.id,
+      signal: fixture.runtime.signal,
+    });
+    expect(fixture.stdout()).toBe(`${project.id}\n`);
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -314,6 +328,7 @@ function createFixture() {
       secretKey: 'secret_test',
     },
   }));
+  const deleteProject = vi.fn(async () => ({}));
   const sdk = {
     system: {
       health: vi.fn(async () => ({ status: 'ok' })),
@@ -344,7 +359,7 @@ function createFixture() {
         list: vi.fn(async () => ({ projects: [project] })),
         get: vi.fn(async () => ({ project })),
         create: createProject,
-        delete: vi.fn(async () => ({})),
+        delete: deleteProject,
       },
     },
   } as unknown as ManagementEdgeStoreSdk;
@@ -406,6 +421,7 @@ function createFixture() {
     readToken,
     confirmTyped,
     createProject,
+    deleteProject,
     stdout: () => Buffer.concat(stdoutChunks).toString('utf8'),
     stderr: () => Buffer.concat(stderrChunks).toString('utf8'),
   };

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -147,6 +147,18 @@ describe('runCli', () => {
     expect(fixture.stderr()).toContain('--yes');
   });
 
+  it('requires --yes for project deletion in plain mode', async () => {
+    const exitCode = await runCli(
+      ['--plain', 'project', 'delete', project.basePath],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.deleteProject).not.toHaveBeenCalled();
+    expect(fixture.stderr()).toContain('--yes');
+  });
+
   it('deletes the canonical project after typed confirmation', async () => {
     await runCli(['project', 'delete', project.id], fixture.runtime, '0.0.0');
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -100,6 +100,40 @@ describe('runCli', () => {
     );
   });
 
+  it('rejects plain project creation before creating a one-time key', async () => {
+    const exitCode = await runCli(
+      ['--plain', 'project', 'create', '--name', 'Marketing Site'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.createProject).not.toHaveBeenCalled();
+    expect(fixture.stdout()).toBe('');
+    expect(fixture.stderr()).toContain('--without-key');
+  });
+
+  it('supports plain project creation without an initial key', async () => {
+    const exitCode = await runCli(
+      [
+        '--plain',
+        'project',
+        'create',
+        '--name',
+        'Marketing Site',
+        '--without-key',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fixture.createProject).toHaveBeenCalledWith(
+      expect.objectContaining({ createKey: false }),
+    );
+    expect(fixture.stdout()).toBe(`${project.basePath}\n`);
+  });
+
   it('requires explicit confirmation for non-interactive deletion', async () => {
     fixture.runtime.io.inputIsTty = false;
 
@@ -264,6 +298,22 @@ function createFixture() {
     available: vi.fn(async () => true),
   };
 
+  const createProject = vi.fn(async () => ({
+    project,
+    projectKey: {
+      key: {
+        id: 'key_123',
+        name: 'default',
+        accessKey: 'access_test',
+        projectId: project.id,
+        accountId: account.id,
+        createdAt: project.createdAt,
+        updatedAt: project.updatedAt,
+        revokedAt: null,
+      },
+      secretKey: 'secret_test',
+    },
+  }));
   const sdk = {
     system: {
       health: vi.fn(async () => ({ status: 'ok' })),
@@ -293,22 +343,7 @@ function createFixture() {
       projects: {
         list: vi.fn(async () => ({ projects: [project] })),
         get: vi.fn(async () => ({ project })),
-        create: vi.fn(async () => ({
-          project,
-          projectKey: {
-            key: {
-              id: 'key_123',
-              name: 'default',
-              accessKey: 'access_test',
-              projectId: project.id,
-              accountId: account.id,
-              createdAt: project.createdAt,
-              updatedAt: project.updatedAt,
-              revokedAt: null,
-            },
-            secretKey: 'secret_test',
-          },
-        })),
+        create: createProject,
         delete: vi.fn(async () => ({})),
       },
     },
@@ -370,6 +405,7 @@ function createFixture() {
     setCredential,
     readToken,
     confirmTyped,
+    createProject,
     stdout: () => Buffer.concat(stdoutChunks).toString('utf8'),
     stderr: () => Buffer.concat(stderrChunks).toString('utf8'),
   };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,9 +7,12 @@ import {
 import { loginCommand, logoutCommand, whoamiCommand } from './commands/auth';
 import { doctorCommand } from './commands/doctor';
 import {
+  projectCreateCommand,
   projectCurrentCommand,
+  projectDeleteCommand,
   projectLinkCommand,
   projectListCommand,
+  projectShowCommand,
   projectUnlinkCommand,
 } from './commands/project';
 import { normalizeError } from './core/errors';
@@ -139,6 +142,43 @@ function createProgram(runtime: CliRuntime, version: string): Command {
     .description('Show the locally linked project')
     .action(async () => {
       await projectCurrentCommand(runtime, globalFlags(program));
+    });
+
+  project
+    .command('show [project]')
+    .description('Show a project by base path or ID')
+    .action(async (projectRef?: string) => {
+      await projectShowCommand(runtime, globalFlags(program), projectRef);
+    });
+
+  project
+    .command('create')
+    .description('Create a project')
+    .requiredOption('--name <name>', 'project name')
+    .option('--account <account-id>', 'override the active account')
+    .option('--without-key', 'create the project without an initial key')
+    .option('--allow-overage', 'allow billable project overage')
+    .action(
+      async (options: {
+        name: string;
+        account?: string;
+        withoutKey?: boolean;
+        allowOverage?: boolean;
+      }) => {
+        await projectCreateCommand(runtime, globalFlags(program), options);
+      },
+    );
+
+  project
+    .command('delete <project>')
+    .alias('rm')
+    .description('Delete a project')
+    .option('--yes', 'skip interactive confirmation')
+    .action(async (projectRef: string, options: { yes?: boolean }) => {
+      await projectDeleteCommand(runtime, globalFlags(program), {
+        project: projectRef,
+        ...options,
+      });
     });
 
   project

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -106,30 +106,34 @@ export async function projectDeleteCommand(
   flags: GlobalFlags,
   options: { project: string; yes?: boolean },
 ): Promise<void> {
-  const project = await getProject(runtime, flags, options.project);
+  let project;
   if (!options.yes) {
     if (!runtime.io.inputIsTty || flags.json) {
       throw usageError(
         'confirmation_required',
         'Project deletion requires confirmation.',
-        [`edgestore project delete ${project.basePath} --yes`],
+        [`edgestore project delete ${options.project} --yes`],
       );
     }
+    project = await getProject(runtime, flags, options.project);
     await runtime.prompts.confirmTyped(
       `Delete project "${project.name}"? Type ${project.basePath} to confirm`,
       project.basePath,
     );
   }
 
+  const projectRef = project?.basePath ?? options.project;
   const sdk = await sdkFor(runtime, flags);
   await sdk.management.projects.delete({
-    project: project.basePath,
+    project: projectRef,
     signal: runtime.signal,
   });
   outputFor(runtime, flags).result(
-    { deleted: true, project },
-    `Deleted project "${project.name}" (${project.basePath}).`,
-    project.basePath,
+    { deleted: true, project: projectRef },
+    project
+      ? `Deleted project "${project.name}" (${project.basePath}).`
+      : `Deleted project ${projectRef}.`,
+    projectRef,
   );
 }
 

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -59,6 +59,16 @@ export async function projectCreateCommand(
     allowOverage?: boolean;
   },
 ): Promise<void> {
+  if (flags.plain && !options.withoutKey) {
+    throw usageError(
+      'one_time_secret_delivery_required',
+      'Plain output cannot deliver the initial project key.',
+      [
+        'Use --without-key with --plain.',
+        'Use human or --json output to receive the one-time key.',
+      ],
+    );
+  }
   const account = await activeAccount(runtime, options.account);
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.projects.create({

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -108,7 +108,7 @@ export async function projectDeleteCommand(
 ): Promise<void> {
   let project;
   if (!options.yes) {
-    if (!runtime.io.inputIsTty || flags.json) {
+    if (!runtime.io.inputIsTty || flags.json || flags.plain) {
       throw usageError(
         'confirmation_required',
         'Project deletion requires confirmation.',

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -29,6 +29,100 @@ export async function projectListCommand(
   outputFor(runtime, flags).result(result, human);
 }
 
+export async function projectShowCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  projectRef?: string,
+): Promise<void> {
+  const project = await getProject(runtime, flags, projectRef);
+  outputFor(runtime, flags).result(
+    { project },
+    [
+      `Name: ${project.name}`,
+      `Base path: ${project.basePath}`,
+      `ID: ${project.id}`,
+      `Account: ${project.accountId}`,
+      `Usage: ${project.usageBytes} bytes`,
+      `Created: ${project.createdAt}`,
+    ].join('\n'),
+    project.basePath,
+  );
+}
+
+export async function projectCreateCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  options: {
+    account?: string;
+    name: string;
+    withoutKey?: boolean;
+    allowOverage?: boolean;
+  },
+): Promise<void> {
+  const account = await activeAccount(runtime, options.account);
+  const sdk = await sdkFor(runtime, flags);
+  const result = await sdk.management.projects.create({
+    account,
+    name: options.name,
+    createKey: !options.withoutKey,
+    allowOverage: Boolean(options.allowOverage),
+    signal: runtime.signal,
+  });
+  const keyLines = result.projectKey
+    ? [
+        '',
+        `EDGE_STORE_ACCESS_KEY=${result.projectKey.key.accessKey}`,
+        `EDGE_STORE_SECRET_KEY=${result.projectKey.secretKey}`,
+        '',
+        'Save this secret now. You will not be able to view it again.',
+      ]
+    : [];
+
+  outputFor(runtime, flags).result(
+    result,
+    [
+      `Created project "${result.project.name}" (${result.project.basePath}).`,
+      ...keyLines,
+      '',
+      'Link this directory:',
+      `  edgestore project link ${result.project.basePath}`,
+    ].join('\n'),
+    result.project.basePath,
+  );
+}
+
+export async function projectDeleteCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  options: { project: string; yes?: boolean },
+): Promise<void> {
+  const project = await getProject(runtime, flags, options.project);
+  if (!options.yes) {
+    if (!runtime.io.inputIsTty || flags.json) {
+      throw usageError(
+        'confirmation_required',
+        'Project deletion requires confirmation.',
+        [`edgestore project delete ${project.basePath} --yes`],
+      );
+    }
+    await runtime.prompts.confirmTyped(
+      `Delete project "${project.name}"? Type ${project.basePath} to confirm`,
+      project.basePath,
+    );
+  }
+
+  const sdk = await sdkFor(runtime, flags);
+  await sdk.management.projects.delete({
+    project: project.basePath,
+    signal: runtime.signal,
+  });
+  outputFor(runtime, flags).result(
+    { deleted: true, project },
+    `Deleted project "${project.name}" (${project.basePath}).`,
+    project.basePath,
+  );
+}
+
 export async function projectCurrentCommand(
   runtime: CliRuntime,
   flags: GlobalFlags,
@@ -95,7 +189,30 @@ export async function projectUnlinkCommand(
   );
 }
 
-function missingProjectError() {
+export async function resolvedProjectRef(
+  runtime: CliRuntime,
+  explicit?: string,
+): Promise<string> {
+  if (explicit) return explicit;
+  const located = await runtime.repoConfig.read();
+  if (!located) throw missingProjectError();
+  return located.config.project;
+}
+
+async function getProject(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  explicit?: string,
+) {
+  const sdk = await sdkFor(runtime, flags);
+  const result = await sdk.management.projects.get({
+    project: await resolvedProjectRef(runtime, explicit),
+    signal: runtime.signal,
+  });
+  return result.project;
+}
+
+export function missingProjectError() {
   return usageError(
     'project_context_required',
     'No project specified or linked.',

--- a/packages/cli/src/core/prompts.ts
+++ b/packages/cli/src/core/prompts.ts
@@ -1,8 +1,9 @@
-import { isCancel, password } from '@clack/prompts';
+import { isCancel, password, text } from '@clack/prompts';
 import { CliError, usageError } from './errors';
 
 export interface CliPrompts {
   readToken(input: NodeJS.ReadableStream, inputIsTty: boolean): Promise<string>;
+  confirmTyped(message: string, expected: string): Promise<void>;
 }
 
 export class DefaultCliPrompts implements CliPrompts {
@@ -28,6 +29,20 @@ export class DefaultCliPrompts implements CliPrompts {
       throw new CliError('interrupted', 'Login canceled.', { exitCode: 130 });
     }
     return validateToken(result);
+  }
+
+  async confirmTyped(message: string, expected: string): Promise<void> {
+    const result = await text({
+      message,
+      placeholder: expected,
+      validate: (value) =>
+        value === expected ? undefined : `Type ${expected} to confirm.`,
+    });
+    if (isCancel(result)) {
+      throw new CliError('interrupted', 'Operation canceled.', {
+        exitCode: 130,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Adds the first complete project-management workflow on top of the CLI foundation.

- adds `project show [project]`
- adds `project create --name <name>` with optional `--without-key` and `--allow-overage`
- shows the initial project key exactly once when one is created
- keeps repository linking explicit and prints the follow-up `project link` command
- adds confirmed `project delete <project>` with canonical base-path prompts and `--yes` automation support
- adds reusable project-context resolution and typed confirmation primitives

## User impact

Users can inspect, provision, and delete projects from the CLI. Creating a project in an arbitrary directory does not write local config or an env file; local linking remains an explicit action.

## Validation

- focused CLI lint, typecheck, test, and build
- 21 CLI tests across 4 files
- full repository formatting check
- `git diff --check`

## Stack

Depends on #168 (`[CLI 01] feat: add CLI foundation`).


## Stack changeset

This PR is part of the unreleased CLI stack. The stack intentionally uses one comprehensive changeset instead of one changeset per slice. It includes minor releases for `@edgestore/cli` and `@edgestore/sdk`. It is added by [[CLI 10] PR #177](https://github.com/edgestorejs/edgestore/pull/177) at `.changeset/calm-clouds-guide.md`.
