### PR TITLE
[CLI 03] feat: add project key management

### DIFF
--- a/.changeset/tidy-tools-turn.md
+++ b/.changeset/tidy-tools-turn.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/cli": minor
+---
+
+Add project key listing, creation, revocation, rotation, and secure secret delivery.

--- a/.changeset/tidy-tools-turn.md
+++ b/.changeset/tidy-tools-turn.md
@@ -1,5 +1,0 @@
----
-"@edgestore/cli": minor
----
-
-Add project key listing, creation, revocation, rotation, and secure secret delivery.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -253,6 +253,37 @@ describe('runCli', () => {
     ).resolves.toContain('EDGE_STORE_SECRET_KEY=secret_test');
   });
 
+  it('keeps only the replacement key ID on plain rotation stdout', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-key-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+
+    const exitCode = await runCli(
+      [
+        '--plain',
+        'project',
+        'key',
+        'rotate',
+        project.basePath,
+        projectKey.id,
+        '--name',
+        'replacement',
+        '--output',
+        '.env.local',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fixture.confirmTyped).toHaveBeenCalledWith(
+      expect.stringContaining(projectKey.id),
+      'saved',
+    );
+    expect(fixture.stdout()).toBe(`${projectKey.id}\n`);
+  });
+
   it('validates a rotation target before creating its replacement', async () => {
     temporaryDirectory = await mkdtemp(
       path.join(tmpdir(), 'edgestore-cli-key-'),

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -123,6 +123,30 @@ describe('runCli', () => {
     expect(fixture.stdout()).toContain('Deleted project');
   });
 
+  it('creates a project key and exposes its secret once', async () => {
+    await runCli(
+      ['project', 'key', 'create', project.basePath, '--name', 'production'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(fixture.stdout()).toContain('EDGE_STORE_ACCESS_KEY=access_test');
+    expect(fixture.stdout()).toContain('EDGE_STORE_SECRET_KEY=secret_test');
+  });
+
+  it('requires typed confirmation before revoking a project key', async () => {
+    await runCli(
+      ['project', 'key', 'revoke', project.basePath, 'key_123'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(fixture.confirmTyped).toHaveBeenCalledWith(
+      expect.stringContaining('last active key'),
+      'key_123',
+    );
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -257,6 +281,36 @@ function createFixture() {
           },
         })),
         delete: vi.fn(async () => ({})),
+      },
+      projectKeys: {
+        list: vi.fn(async () => ({
+          keys: [
+            {
+              id: 'key_123',
+              name: 'production',
+              accessKey: 'access_test',
+              projectId: project.id,
+              accountId: account.id,
+              createdAt: project.createdAt,
+              updatedAt: project.updatedAt,
+              revokedAt: null,
+            },
+          ],
+        })),
+        create: vi.fn(async () => ({
+          key: {
+            id: 'key_123',
+            name: 'production',
+            accessKey: 'access_test',
+            projectId: project.id,
+            accountId: account.id,
+            createdAt: project.createdAt,
+            updatedAt: project.updatedAt,
+            revokedAt: null,
+          },
+          secretKey: 'secret_test',
+        })),
+        revoke: vi.fn(async () => ({})),
       },
     },
   } as unknown as ManagementEdgeStoreSdk;

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -11,6 +11,7 @@ import type {
   RepoConfig,
 } from './core/config';
 import type { CredentialStore } from './core/credentials';
+import { CliError } from './core/errors';
 import type { CliRuntime } from './core/runtime';
 
 const account = {
@@ -294,6 +295,88 @@ describe('runCli', () => {
       'saved',
     );
     expect(fixture.stdout()).toBe(`${projectKey.id}\n`);
+  });
+
+  it('revokes the replacement key when interactive rotation is canceled', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-key-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.createProjectKey.mockResolvedValueOnce({
+      key: { ...projectKey, id: 'key_replacement' },
+      secretKey: 'secret_test',
+    });
+    fixture.confirmTyped.mockRejectedValueOnce(
+      new CliError('interrupted', 'Operation canceled.', { exitCode: 130 }),
+    );
+
+    const exitCode = await runCli(
+      [
+        '--plain',
+        'project',
+        'key',
+        'rotate',
+        project.basePath,
+        projectKey.id,
+        '--name',
+        'replacement',
+        '--output',
+        '.env.local',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(130);
+    expect(fixture.revokeProjectKey).toHaveBeenCalledWith({
+      project: project.basePath,
+      keyId: 'key_replacement',
+      signal: expect.objectContaining({ aborted: false }),
+    });
+    expect(fixture.stdout()).toBe('');
+    expect(fixture.stderr()).toContain(
+      'Operation canceled. The replacement project key was revoked.',
+    );
+  });
+
+  it('reports manual cleanup when canceled rotation rollback fails', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-key-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.createProjectKey.mockResolvedValueOnce({
+      key: { ...projectKey, id: 'key_replacement' },
+      secretKey: 'secret_test',
+    });
+    fixture.confirmTyped.mockRejectedValueOnce(
+      new CliError('interrupted', 'Operation canceled.', { exitCode: 130 }),
+    );
+    fixture.revokeProjectKey.mockRejectedValueOnce(
+      new Error('revocation unavailable'),
+    );
+
+    const exitCode = await runCli(
+      [
+        '--plain',
+        'project',
+        'key',
+        'rotate',
+        project.basePath,
+        projectKey.id,
+        '--name',
+        'replacement',
+        '--output',
+        '.env.local',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(130);
+    expect(fixture.stdout()).toBe('');
+    expect(fixture.stderr()).toContain(
+      `edgestore project key revoke ${project.basePath} key_replacement --yes`,
+    );
   });
 
   it('validates a rotation target before creating its replacement', async () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -442,6 +442,23 @@ describe('runCli', () => {
     );
   });
 
+  it('revokes a project key with revoke-only access when forced', async () => {
+    fixture.listProjectKeys.mockRejectedValueOnce(new Error('read denied'));
+
+    const exitCode = await runCli(
+      ['project', 'key', 'revoke', project.basePath, projectKey.id, '--yes'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fixture.revokeProjectKey).toHaveBeenCalledWith({
+      project: project.basePath,
+      keyId: projectKey.id,
+      signal: fixture.runtime.signal,
+    });
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,6 +1,9 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { PassThrough, Readable } from 'node:stream';
 import type { ManagementEdgeStoreSdk } from '@edgestore/sdk';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runCli } from './cli';
 import type {
   GlobalConfig,
@@ -36,11 +39,30 @@ const project = {
   updatedAt: '2026-01-01T00:00:00.000Z',
 };
 
+const projectKey = {
+  id: 'key_123',
+  name: 'production',
+  accessKey: 'access_test',
+  projectId: project.id,
+  accountId: account.id,
+  createdAt: project.createdAt,
+  updatedAt: project.updatedAt,
+  revokedAt: null as string | null,
+};
+
 describe('runCli', () => {
   let fixture: ReturnType<typeof createFixture>;
+  let temporaryDirectory: string | undefined;
 
   beforeEach(() => {
     fixture = createFixture();
+  });
+
+  afterEach(async () => {
+    if (temporaryDirectory) {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+      temporaryDirectory = undefined;
+    }
   });
 
   it('renders account lists and marks the active account', async () => {
@@ -166,6 +188,200 @@ describe('runCli', () => {
 
     expect(fixture.stdout()).toContain('EDGE_STORE_ACCESS_KEY=access_test');
     expect(fixture.stdout()).toContain('EDGE_STORE_SECRET_KEY=secret_test');
+  });
+
+  it('requires a destination for plain project-key creation', async () => {
+    const exitCode = await runCli(
+      [
+        '--plain',
+        'project',
+        'key',
+        'create',
+        project.basePath,
+        '--name',
+        'production',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.createProjectKey).not.toHaveBeenCalled();
+    expect(fixture.stderr()).toContain('--copy or --output');
+  });
+
+  it('keeps the key ID on plain stdout when the secret is delivered', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-key-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+
+    const exitCode = await runCli(
+      [
+        '--plain',
+        'project',
+        'key',
+        'create',
+        project.basePath,
+        '--name',
+        'production',
+        '--output',
+        '.env.local',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fixture.stdout()).toBe(`${projectKey.id}\n`);
+    await expect(
+      readFile(path.join(temporaryDirectory, '.env.local'), 'utf8'),
+    ).resolves.toContain('EDGE_STORE_SECRET_KEY=secret_test');
+  });
+
+  it('validates a rotation target before creating its replacement', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-key-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.listProjectKeys.mockResolvedValueOnce({ keys: [] });
+
+    const exitCode = await runCli(
+      [
+        'project',
+        'key',
+        'rotate',
+        project.basePath,
+        'missing',
+        '--name',
+        'replacement',
+        '--output',
+        '.env.local',
+        '--yes',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(fixture.createProjectKey).not.toHaveBeenCalled();
+    expect(fixture.stderr()).toContain('was not found');
+  });
+
+  it('does not rotate an already revoked project key', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-key-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.listProjectKeys.mockResolvedValueOnce({
+      keys: [{ ...projectKey, revokedAt: '2026-02-01T00:00:00.000Z' }],
+    });
+
+    const exitCode = await runCli(
+      [
+        'project',
+        'key',
+        'rotate',
+        project.basePath,
+        projectKey.id,
+        '--name',
+        'replacement',
+        '--output',
+        '.env.local',
+        '--yes',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(fixture.createProjectKey).not.toHaveBeenCalled();
+    expect(fixture.stderr()).toContain('already revoked');
+  });
+
+  it('revokes a key when delivery fails after preflight', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-key-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.createProjectKey.mockImplementationOnce(async () => {
+      await writeFile(
+        path.join(temporaryDirectory!, '.env.local'),
+        'EDGE_STORE_ACCESS_KEY=raced\n',
+      );
+      return { key: projectKey, secretKey: 'secret_test' };
+    });
+
+    const exitCode = await runCli(
+      [
+        '--json',
+        'project',
+        'key',
+        'create',
+        project.basePath,
+        '--name',
+        'production',
+        '--output',
+        '.env.local',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.stdout()).toBe('');
+    expect(fixture.revokeProjectKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: project.basePath,
+        keyId: projectKey.id,
+        signal: expect.objectContaining({ aborted: false }),
+      }),
+    );
+    expect(JSON.parse(fixture.stderr()).error.details.rollback).toEqual({
+      status: 'succeeded',
+      keyId: projectKey.id,
+    });
+  });
+
+  it('reports the recovery command when delivery rollback fails', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-key-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.createProjectKey.mockImplementationOnce(async () => {
+      await writeFile(
+        path.join(temporaryDirectory!, '.env.local'),
+        'EDGE_STORE_ACCESS_KEY=raced\n',
+      );
+      return { key: projectKey, secretKey: 'secret_test' };
+    });
+    fixture.revokeProjectKey.mockRejectedValueOnce(new Error('denied'));
+
+    const exitCode = await runCli(
+      [
+        '--json',
+        'project',
+        'key',
+        'create',
+        project.basePath,
+        '--name',
+        'production',
+        '--output',
+        '.env.local',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    const error = JSON.parse(fixture.stderr()).error;
+    expect(error.details.rollback).toMatchObject({
+      status: 'failed',
+      keyId: projectKey.id,
+    });
+    expect(error.suggestions).toContain(
+      `edgestore project key revoke ${project.basePath} ${projectKey.id} --yes`,
+    );
   });
 
   it('requires typed confirmation before revoking a project key', async () => {
@@ -338,6 +554,12 @@ function createFixture() {
       secretKey: 'secret_test',
     },
   }));
+  const listProjectKeys = vi.fn(async () => ({ keys: [projectKey] }));
+  const createProjectKey = vi.fn(async () => ({
+    key: projectKey,
+    secretKey: 'secret_test',
+  }));
+  const revokeProjectKey = vi.fn(async () => ({}));
   const sdk = {
     system: {
       health: vi.fn(async () => ({ status: 'ok' })),
@@ -371,34 +593,9 @@ function createFixture() {
         delete: vi.fn(async () => ({})),
       },
       projectKeys: {
-        list: vi.fn(async () => ({
-          keys: [
-            {
-              id: 'key_123',
-              name: 'production',
-              accessKey: 'access_test',
-              projectId: project.id,
-              accountId: account.id,
-              createdAt: project.createdAt,
-              updatedAt: project.updatedAt,
-              revokedAt: null,
-            },
-          ],
-        })),
-        create: vi.fn(async () => ({
-          key: {
-            id: 'key_123',
-            name: 'production',
-            accessKey: 'access_test',
-            projectId: project.id,
-            accountId: account.id,
-            createdAt: project.createdAt,
-            updatedAt: project.updatedAt,
-            revokedAt: null,
-          },
-          secretKey: 'secret_test',
-        })),
-        revoke: vi.fn(async () => ({})),
+        list: listProjectKeys,
+        create: createProjectKey,
+        revoke: revokeProjectKey,
       },
     },
   } as unknown as ManagementEdgeStoreSdk;
@@ -460,6 +657,9 @@ function createFixture() {
     readToken,
     confirmTyped,
     createProject,
+    listProjectKeys,
+    createProjectKey,
+    revokeProjectKey,
     stdout: () => Buffer.concat(stdoutChunks).toString('utf8'),
     stderr: () => Buffer.concat(stderrChunks).toString('utf8'),
   };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,12 @@ import {
   projectShowCommand,
   projectUnlinkCommand,
 } from './commands/project';
+import {
+  projectKeyCreateCommand,
+  projectKeyListCommand,
+  projectKeyRevokeCommand,
+  projectKeyRotateCommand,
+} from './commands/projectKey';
 import { normalizeError } from './core/errors';
 import { outputFor, type CliRuntime, type GlobalFlags } from './core/runtime';
 
@@ -193,6 +199,58 @@ function createProgram(runtime: CliRuntime, version: string): Command {
     .description('Remove the local project link')
     .action(async () => {
       await projectUnlinkCommand(runtime, globalFlags(program));
+    });
+
+  const projectKey = project.command('key').description('Manage project keys');
+
+  projectKey
+    .command('list <project>')
+    .alias('ls')
+    .description('List project key metadata')
+    .action(async (projectRef: string) => {
+      await projectKeyListCommand(runtime, globalFlags(program), projectRef);
+    });
+
+  projectKey
+    .command('create <project>')
+    .description('Create a named project key')
+    .requiredOption('--name <name>', 'key name')
+    .option('--copy', 'copy the key pair to the clipboard')
+    .option('--output <file>', 'write the key pair to an env file')
+    .option('--update', 'replace existing key values in the output file')
+    .action(async (projectRef: string, options) => {
+      await projectKeyCreateCommand(runtime, globalFlags(program), {
+        project: projectRef,
+        ...options,
+      });
+    });
+
+  projectKey
+    .command('revoke <project> <key-id>')
+    .description('Revoke a project key')
+    .option('--yes', 'skip interactive confirmation')
+    .action(async (projectRef: string, keyId: string, options) => {
+      await projectKeyRevokeCommand(runtime, globalFlags(program), {
+        project: projectRef,
+        keyId,
+        ...options,
+      });
+    });
+
+  projectKey
+    .command('rotate <project> <key-id>')
+    .description('Create a replacement key and revoke the old key')
+    .requiredOption('--name <name>', 'replacement key name')
+    .option('--copy', 'copy the replacement key pair to the clipboard')
+    .option('--output <file>', 'write the replacement key pair to an env file')
+    .option('--update', 'replace existing key values in the output file')
+    .option('--yes', 'confirm non-interactive rotation')
+    .action(async (projectRef: string, keyId: string, options) => {
+      await projectKeyRotateCommand(runtime, globalFlags(program), {
+        project: projectRef,
+        keyId,
+        ...options,
+      });
     });
 
   return program;

--- a/packages/cli/src/commands/projectKey.ts
+++ b/packages/cli/src/commands/projectKey.ts
@@ -1,9 +1,10 @@
-import { usageError } from '../core/errors';
+import { CliError, normalizeError, usageError } from '../core/errors';
 import { renderTable } from '../core/output';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { outputFor, sdkFor } from '../core/runtime';
 import {
   deliverEnvSecret,
+  preflightEnvSecret,
   type SecretDeliveryOptions,
 } from '../core/secretDelivery';
 
@@ -41,9 +42,11 @@ export async function projectKeyCreateCommand(
   flags: GlobalFlags,
   input: KeyOptions & { project: string },
 ): Promise<void> {
-  const result = await createKey(runtime, flags, input);
+  requirePlainSecretDelivery(flags, input);
+  await preflightKeyDelivery(runtime, input);
+  const sdk = await sdkFor(runtime, flags);
+  const { result, delivered } = await createAndDeliverKey(runtime, sdk, input);
   const values = keyValues(result.key.accessKey, result.secretKey);
-  const delivered = await deliverEnvSecret(runtime.cwd, values, input);
   outputFor(runtime, flags).result(
     result,
     [
@@ -113,9 +116,29 @@ export async function projectKeyRotateCommand(
     );
   }
 
-  const result = await createKey(runtime, flags, input);
+  requirePlainSecretDelivery(flags, input);
+  const sdk = await sdkFor(runtime, flags);
+  const listed = await sdk.management.projectKeys.list({
+    project: input.project,
+    signal: runtime.signal,
+  });
+  const target = listed.keys.find((key) => key.id === input.keyId);
+  if (!target) {
+    throw new CliError(
+      'project_key_not_found',
+      `Project key ${input.keyId} was not found in ${input.project}.`,
+    );
+  }
+  if (target.revokedAt) {
+    throw new CliError(
+      'project_key_revoked',
+      `Project key ${input.keyId} is already revoked.`,
+    );
+  }
+  await preflightKeyDelivery(runtime, input);
+
+  const { result, delivered } = await createAndDeliverKey(runtime, sdk, input);
   const values = keyValues(result.key.accessKey, result.secretKey);
-  const delivered = await deliverEnvSecret(runtime.cwd, values, input);
   const output = outputFor(runtime, flags);
   const secretMessage = [
     `Created replacement key "${result.key.name}".`,
@@ -131,7 +154,6 @@ export async function projectKeyRotateCommand(
       'saved',
     );
   }
-  const sdk = await sdkFor(runtime, flags);
   await sdk.management.projectKeys.revoke({
     project: input.project,
     keyId: input.keyId,
@@ -148,17 +170,115 @@ export async function projectKeyRotateCommand(
   );
 }
 
-async function createKey(
+async function createAndDeliverKey(
   runtime: CliRuntime,
-  flags: GlobalFlags,
-  input: { project: string; name: string },
+  sdk: Awaited<ReturnType<typeof sdkFor>>,
+  input: { project: string; name: string } & SecretDeliveryOptions,
 ) {
-  const sdk = await sdkFor(runtime, flags);
-  return sdk.management.projectKeys.create({
+  const result = await sdk.management.projectKeys.create({
     project: input.project,
     name: input.name,
     signal: runtime.signal,
   });
+  try {
+    const delivered = await deliverEnvSecret(
+      runtime.cwd,
+      keyValues(result.key.accessKey, result.secretKey),
+      input,
+    );
+    return { result, delivered };
+  } catch (error) {
+    throw await rollbackUndeliveredKey(sdk, {
+      project: input.project,
+      keyId: result.key.id,
+      deliveryError: error,
+    });
+  }
+}
+
+async function preflightKeyDelivery(
+  runtime: CliRuntime,
+  options: SecretDeliveryOptions,
+): Promise<void> {
+  await preflightEnvSecret(
+    runtime.cwd,
+    ['EDGE_STORE_ACCESS_KEY', 'EDGE_STORE_SECRET_KEY'],
+    options,
+  );
+}
+
+async function rollbackUndeliveredKey(
+  sdk: Awaited<ReturnType<typeof sdkFor>>,
+  input: { project: string; keyId: string; deliveryError: unknown },
+): Promise<CliError> {
+  const cause = normalizeError(input.deliveryError);
+  try {
+    await sdk.management.projectKeys.revoke({
+      project: input.project,
+      keyId: input.keyId,
+      signal: AbortSignal.timeout(10_000),
+    });
+    return new CliError(
+      'secret_delivery_failed',
+      `${cause.message} The new project key was revoked.`,
+      {
+        details: {
+          cause: errorDetails(cause),
+          rollback: { status: 'succeeded', keyId: input.keyId },
+        },
+        requestId: cause.options.requestId,
+        suggestions: cause.options.suggestions,
+        exitCode: cause.exitCode,
+      },
+    );
+  } catch (rollbackError) {
+    const rollback = normalizeError(rollbackError);
+    return new CliError(
+      'secret_delivery_failed',
+      `${cause.message} Automatic revocation of the new project key failed.`,
+      {
+        details: {
+          cause: errorDetails(cause),
+          rollback: {
+            status: 'failed',
+            keyId: input.keyId,
+            error: errorDetails(rollback),
+          },
+        },
+        requestId: cause.options.requestId,
+        suggestions: [
+          ...(cause.options.suggestions ?? []),
+          `edgestore project key revoke ${input.project} ${input.keyId} --yes`,
+        ],
+        exitCode: cause.exitCode,
+      },
+    );
+  }
+}
+
+function errorDetails(error: CliError) {
+  return {
+    code: error.code,
+    message: error.message,
+    ...(error.options.details === undefined
+      ? {}
+      : { details: error.options.details }),
+    ...(error.options.requestId === undefined
+      ? {}
+      : { requestId: error.options.requestId }),
+  };
+}
+
+function requirePlainSecretDelivery(
+  flags: GlobalFlags,
+  options: SecretDeliveryOptions,
+): void {
+  if (flags.plain && !options.copy && !options.output) {
+    throw usageError(
+      'secret_delivery_required',
+      'Plain output requires --copy or --output for the one-time key.',
+    );
+  }
 }
 
 function keyValues(accessKey: string, secretKey: string) {

--- a/packages/cli/src/commands/projectKey.ts
+++ b/packages/cli/src/commands/projectKey.ts
@@ -148,7 +148,7 @@ export async function projectKeyRotateCommand(
   ].join('\n');
 
   if (!input.yes) {
-    output.message(secretMessage);
+    if (output.options.mode === 'human') output.message(secretMessage);
     await runtime.prompts.confirmTyped(
       `Type saved to revoke ${input.keyId}`,
       'saved',

--- a/packages/cli/src/commands/projectKey.ts
+++ b/packages/cli/src/commands/projectKey.ts
@@ -65,12 +65,12 @@ export async function projectKeyRevokeCommand(
   input: { project: string; keyId: string; yes?: boolean },
 ): Promise<void> {
   const sdk = await sdkFor(runtime, flags);
-  const listed = await sdk.management.projectKeys.list({
-    project: input.project,
-    signal: runtime.signal,
-  });
-  const key = listed.keys.find((item) => item.id === input.keyId);
   if (!input.yes) {
+    const listed = await sdk.management.projectKeys.list({
+      project: input.project,
+      signal: runtime.signal,
+    });
+    const key = listed.keys.find((item) => item.id === input.keyId);
     requireInteractiveConfirmation(runtime, flags, [
       `edgestore project key revoke ${input.project} ${input.keyId} --yes`,
     ]);

--- a/packages/cli/src/commands/projectKey.ts
+++ b/packages/cli/src/commands/projectKey.ts
@@ -1,0 +1,187 @@
+import { usageError } from '../core/errors';
+import { renderTable } from '../core/output';
+import type { CliRuntime, GlobalFlags } from '../core/runtime';
+import { outputFor, sdkFor } from '../core/runtime';
+import {
+  deliverEnvSecret,
+  type SecretDeliveryOptions,
+} from '../core/secretDelivery';
+
+type KeyOptions = SecretDeliveryOptions & {
+  name: string;
+};
+
+export async function projectKeyListCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  project: string,
+): Promise<void> {
+  const sdk = await sdkFor(runtime, flags);
+  const result = await sdk.management.projectKeys.list({
+    project,
+    signal: runtime.signal,
+  });
+  const rows = result.keys.map((key) => [
+    key.id,
+    key.name,
+    key.accessKey,
+    key.revokedAt ? 'revoked' : 'active',
+    key.createdAt,
+  ]);
+  outputFor(runtime, flags).result(
+    result,
+    rows.length
+      ? renderTable(['ID', 'NAME', 'ACCESS KEY', 'STATUS', 'CREATED'], rows)
+      : 'No project keys found.',
+  );
+}
+
+export async function projectKeyCreateCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: KeyOptions & { project: string },
+): Promise<void> {
+  const result = await createKey(runtime, flags, input);
+  const values = keyValues(result.key.accessKey, result.secretKey);
+  const delivered = await deliverEnvSecret(runtime.cwd, values, input);
+  outputFor(runtime, flags).result(
+    result,
+    [
+      `Created project key "${result.key.name}".`,
+      ...(delivered.length ? ['', ...delivered] : ['', ...envLines(values)]),
+      '',
+      'Save this secret now. You will not be able to view it again.',
+    ].join('\n'),
+    result.key.id,
+  );
+}
+
+export async function projectKeyRevokeCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: { project: string; keyId: string; yes?: boolean },
+): Promise<void> {
+  const sdk = await sdkFor(runtime, flags);
+  const listed = await sdk.management.projectKeys.list({
+    project: input.project,
+    signal: runtime.signal,
+  });
+  const key = listed.keys.find((item) => item.id === input.keyId);
+  if (!input.yes) {
+    requireInteractiveConfirmation(runtime, flags, [
+      `edgestore project key revoke ${input.project} ${input.keyId} --yes`,
+    ]);
+    const activeCount = listed.keys.filter((item) => !item.revokedAt).length;
+    const warning =
+      key && !key.revokedAt && activeCount === 1
+        ? ' This is the last active key and runtime access will stop.'
+        : '';
+    await runtime.prompts.confirmTyped(
+      `Revoke project key ${input.keyId}?${warning} Type ${input.keyId} to confirm`,
+      input.keyId,
+    );
+  }
+  const result = await sdk.management.projectKeys.revoke({
+    project: input.project,
+    keyId: input.keyId,
+    signal: runtime.signal,
+  });
+  outputFor(runtime, flags).result(
+    result,
+    `Revoked project key ${input.keyId}.`,
+    input.keyId,
+  );
+}
+
+export async function projectKeyRotateCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: {
+    project: string;
+    keyId: string;
+    yes?: boolean;
+  } & KeyOptions,
+): Promise<void> {
+  if (!input.yes) {
+    requireInteractiveConfirmation(runtime, flags, [
+      `edgestore project key rotate ${input.project} ${input.keyId} --name ${input.name} --output .env.local --yes`,
+    ]);
+  } else if (!input.copy && !input.output) {
+    throw usageError(
+      'secret_delivery_required',
+      'Non-interactive rotation requires --copy or --output.',
+    );
+  }
+
+  const result = await createKey(runtime, flags, input);
+  const values = keyValues(result.key.accessKey, result.secretKey);
+  const delivered = await deliverEnvSecret(runtime.cwd, values, input);
+  const output = outputFor(runtime, flags);
+  const secretMessage = [
+    `Created replacement key "${result.key.name}".`,
+    ...(delivered.length ? ['', ...delivered] : ['', ...envLines(values)]),
+    '',
+    'Save this secret now. You will not be able to view it again.',
+  ].join('\n');
+
+  if (!input.yes) {
+    output.message(secretMessage);
+    await runtime.prompts.confirmTyped(
+      `Type saved to revoke ${input.keyId}`,
+      'saved',
+    );
+  }
+  const sdk = await sdkFor(runtime, flags);
+  await sdk.management.projectKeys.revoke({
+    project: input.project,
+    keyId: input.keyId,
+    signal: runtime.signal,
+  });
+  output.result(
+    { replacement: result, revokedKeyId: input.keyId },
+    input.yes
+      ? [secretMessage, '', `Revoked old project key ${input.keyId}.`].join(
+          '\n',
+        )
+      : `Revoked old project key ${input.keyId}.`,
+    result.key.id,
+  );
+}
+
+async function createKey(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: { project: string; name: string },
+) {
+  const sdk = await sdkFor(runtime, flags);
+  return sdk.management.projectKeys.create({
+    project: input.project,
+    name: input.name,
+    signal: runtime.signal,
+  });
+}
+
+function keyValues(accessKey: string, secretKey: string) {
+  return {
+    EDGE_STORE_ACCESS_KEY: accessKey,
+    EDGE_STORE_SECRET_KEY: secretKey,
+  };
+}
+
+function envLines(values: Record<string, string>): string[] {
+  return Object.entries(values).map(([name, value]) => `${name}=${value}`);
+}
+
+function requireInteractiveConfirmation(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  suggestions: string[],
+): void {
+  if (!runtime.io.inputIsTty || flags.json) {
+    throw usageError(
+      'confirmation_required',
+      'This operation requires confirmation.',
+      suggestions,
+    );
+  }
+}

--- a/packages/cli/src/commands/projectKey.ts
+++ b/packages/cli/src/commands/projectKey.ts
@@ -149,10 +149,21 @@ export async function projectKeyRotateCommand(
 
   if (!input.yes) {
     if (output.options.mode === 'human') output.message(secretMessage);
-    await runtime.prompts.confirmTyped(
-      `Type saved to revoke ${input.keyId}`,
-      'saved',
-    );
+    try {
+      await runtime.prompts.confirmTyped(
+        `Type saved to revoke ${input.keyId}`,
+        'saved',
+      );
+    } catch (error) {
+      throw await rollbackNewProjectKey(sdk, {
+        project: input.project,
+        keyId: result.key.id,
+        cause: error,
+        successMessage: 'The replacement project key was revoked.',
+        failureMessage:
+          'Automatic revocation of the replacement project key failed.',
+      });
+    }
   }
   await sdk.management.projectKeys.revoke({
     project: input.project,
@@ -188,10 +199,13 @@ async function createAndDeliverKey(
     );
     return { result, delivered };
   } catch (error) {
-    throw await rollbackUndeliveredKey(sdk, {
+    throw await rollbackNewProjectKey(sdk, {
       project: input.project,
       keyId: result.key.id,
-      deliveryError: error,
+      cause: error,
+      successMessage: 'The new project key was revoked.',
+      failureMessage: 'Automatic revocation of the new project key failed.',
+      code: 'secret_delivery_failed',
     });
   }
 }
@@ -207,11 +221,18 @@ async function preflightKeyDelivery(
   );
 }
 
-async function rollbackUndeliveredKey(
+async function rollbackNewProjectKey(
   sdk: Awaited<ReturnType<typeof sdkFor>>,
-  input: { project: string; keyId: string; deliveryError: unknown },
+  input: {
+    project: string;
+    keyId: string;
+    cause: unknown;
+    successMessage: string;
+    failureMessage: string;
+    code?: string;
+  },
 ): Promise<CliError> {
-  const cause = normalizeError(input.deliveryError);
+  const cause = normalizeError(input.cause);
   try {
     await sdk.management.projectKeys.revoke({
       project: input.project,
@@ -219,8 +240,8 @@ async function rollbackUndeliveredKey(
       signal: AbortSignal.timeout(10_000),
     });
     return new CliError(
-      'secret_delivery_failed',
-      `${cause.message} The new project key was revoked.`,
+      input.code ?? cause.code,
+      `${cause.message} ${input.successMessage}`,
       {
         details: {
           cause: errorDetails(cause),
@@ -234,8 +255,8 @@ async function rollbackUndeliveredKey(
   } catch (rollbackError) {
     const rollback = normalizeError(rollbackError);
     return new CliError(
-      'secret_delivery_failed',
-      `${cause.message} Automatic revocation of the new project key failed.`,
+      input.code ?? cause.code,
+      `${cause.message} ${input.failureMessage}`,
       {
         details: {
           cause: errorDetails(cause),

--- a/packages/cli/src/core/secretDelivery.test.ts
+++ b/packages/cli/src/core/secretDelivery.test.ts
@@ -1,0 +1,49 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { deliverEnvSecret } from './secretDelivery';
+
+describe('deliverEnvSecret', () => {
+  let directory: string | undefined;
+
+  afterEach(async () => {
+    if (directory) await rm(directory, { recursive: true, force: true });
+  });
+
+  it('creates an env file and refuses to overwrite values by default', async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'edgestore-secret-'));
+    const file = path.join(directory, '.env.local');
+
+    await deliverEnvSecret(
+      directory,
+      { EDGE_STORE_ACCESS_KEY: 'access' },
+      { output: '.env.local' },
+    );
+
+    expect(await readFile(file, 'utf8')).toBe('EDGE_STORE_ACCESS_KEY=access\n');
+    await expect(
+      deliverEnvSecret(
+        directory,
+        { EDGE_STORE_ACCESS_KEY: 'next' },
+        { output: '.env.local' },
+      ),
+    ).rejects.toMatchObject({ code: 'secret_output_exists' });
+  });
+
+  it('updates existing values and preserves unrelated lines', async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'edgestore-secret-'));
+    const file = path.join(directory, '.env.local');
+    await writeFile(file, 'OTHER=value\nEDGE_STORE_ACCESS_KEY=old\n');
+
+    await deliverEnvSecret(
+      directory,
+      { EDGE_STORE_ACCESS_KEY: 'next' },
+      { output: '.env.local', update: true },
+    );
+
+    expect(await readFile(file, 'utf8')).toBe(
+      'OTHER=value\nEDGE_STORE_ACCESS_KEY=next\n',
+    );
+  });
+});

--- a/packages/cli/src/core/secretDelivery.test.ts
+++ b/packages/cli/src/core/secretDelivery.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { deliverEnvSecret } from './secretDelivery';
+import { deliverEnvSecret, preflightEnvSecret } from './secretDelivery';
 
 describe('deliverEnvSecret', () => {
   let directory: string | undefined;
@@ -44,6 +44,54 @@ describe('deliverEnvSecret', () => {
 
     expect(await readFile(file, 'utf8')).toBe(
       'OTHER=value\nEDGE_STORE_ACCESS_KEY=next\n',
+    );
+  });
+
+  it('replaces every exact duplicate assignment with --update', async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'edgestore-secret-'));
+    const file = path.join(directory, '.env.local');
+    await writeFile(
+      file,
+      [
+        '# keys',
+        'EDGE_STORE_ACCESS_KEY=old-one',
+        'OTHER=value',
+        'EDGE_STORE_ACCESS_KEY=old-two',
+        'EDGE_STORE_ACCESS_KEY_SUFFIX=untouched',
+        '',
+      ].join('\n'),
+    );
+
+    await deliverEnvSecret(
+      directory,
+      { EDGE_STORE_ACCESS_KEY: 'next' },
+      { output: '.env.local', update: true },
+    );
+
+    expect(await readFile(file, 'utf8')).toBe(
+      [
+        '# keys',
+        'EDGE_STORE_ACCESS_KEY=next',
+        'OTHER=value',
+        'EDGE_STORE_ACCESS_KEY=next',
+        'EDGE_STORE_ACCESS_KEY_SUFFIX=untouched',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('preflights existing assignments without changing the file', async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'edgestore-secret-'));
+    const file = path.join(directory, '.env.local');
+    await writeFile(file, 'EDGE_STORE_ACCESS_KEY=old\n');
+
+    await expect(
+      preflightEnvSecret(directory, ['EDGE_STORE_ACCESS_KEY'], {
+        output: '.env.local',
+      }),
+    ).rejects.toMatchObject({ code: 'secret_output_exists' });
+    await expect(readFile(file, 'utf8')).resolves.toBe(
+      'EDGE_STORE_ACCESS_KEY=old\n',
     );
   });
 });

--- a/packages/cli/src/core/secretDelivery.ts
+++ b/packages/cli/src/core/secretDelivery.ts
@@ -35,10 +35,10 @@ export async function preflightEnvSecret(
       names,
       update: Boolean(options.update),
     });
-    await access(
-      existing.exists ? outputPath : path.dirname(outputPath),
-      constants.W_OK,
-    );
+    const directoryMode =
+      constants.W_OK | (process.platform === 'win32' ? 0 : constants.X_OK);
+    await access(path.dirname(outputPath), directoryMode);
+    if (existing.exists) await access(outputPath, constants.W_OK);
   }
 }
 

--- a/packages/cli/src/core/secretDelivery.ts
+++ b/packages/cli/src/core/secretDelivery.ts
@@ -97,7 +97,7 @@ async function copyToClipboard(value: string): Promise<void> {
   throw new CliError('clipboard_failed', 'Could not copy to the clipboard.');
 }
 
-async function resolveClipboardCommand(): Promise<string[]> {
+async function resolveClipboardCommand(): Promise<[string, ...string[]]> {
   for (const candidate of clipboardCandidates()) {
     if (await executableExists(candidate[0])) return candidate;
   }
@@ -107,7 +107,7 @@ async function resolveClipboardCommand(): Promise<string[]> {
   );
 }
 
-function clipboardCandidates(): string[][] {
+function clipboardCandidates(): [string, ...string[]][] {
   return process.platform === 'darwin'
     ? [['pbcopy']]
     : process.platform === 'win32'

--- a/packages/cli/src/core/secretDelivery.ts
+++ b/packages/cli/src/core/secretDelivery.ts
@@ -1,5 +1,14 @@
 import { spawn } from 'node:child_process';
-import { chmod, readFile, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { constants } from 'node:fs';
+import {
+  access,
+  chmod,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import path from 'node:path';
 import { CliError, usageError } from './errors';
 
@@ -8,6 +17,30 @@ export type SecretDeliveryOptions = {
   output?: string;
   update?: boolean;
 };
+
+export async function preflightEnvSecret(
+  cwd: string,
+  names: string[],
+  options: SecretDeliveryOptions,
+): Promise<void> {
+  if (options.copy) {
+    await resolveClipboardCommand();
+  }
+  if (options.output) {
+    const outputPath = path.resolve(cwd, options.output);
+    const existing = await readEnvFile(outputPath);
+    assertAssignmentsAvailable({
+      filePath: outputPath,
+      contents: existing.contents,
+      names,
+      update: Boolean(options.update),
+    });
+    await access(
+      existing.exists ? outputPath : path.dirname(outputPath),
+      constants.W_OK,
+    );
+  }
+}
 
 export async function deliverEnvSecret(
   cwd: string,
@@ -36,54 +69,77 @@ async function writeEnvFile(
   values: Record<string, string>,
   update: boolean,
 ): Promise<void> {
-  let existing = '';
-  try {
-    existing = await readFile(filePath, 'utf8');
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-  }
+  const existing = await readEnvFile(filePath);
 
   const names = Object.keys(values);
-  const present = names.filter((name) =>
-    new RegExp(`^${escapeRegExp(name)}=`, 'm').test(existing),
-  );
-  if (present.length && !update) {
-    throw usageError(
-      'secret_output_exists',
-      `${filePath} already contains ${present.join(', ')}.`,
-      ['Pass --update to replace the existing values.'],
-    );
+  assertAssignmentsAvailable({
+    filePath,
+    contents: existing.contents,
+    names,
+    update,
+  });
+  const next = updateAssignments(existing.contents, values);
+  const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporaryPath, next, { mode: 0o600 });
+    await chmod(temporaryPath, 0o600);
+    await rename(temporaryPath, filePath);
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
   }
-
-  let next = existing;
-  for (const [name, value] of Object.entries(values)) {
-    const line = `${name}=${value}`;
-    const pattern = new RegExp(`^${escapeRegExp(name)}=.*$`, 'm');
-    next = pattern.test(next)
-      ? next.replace(pattern, line)
-      : `${next}${next && !next.endsWith('\n') ? '\n' : ''}${line}\n`;
-  }
-  await writeFile(filePath, next, { mode: 0o600 });
-  await chmod(filePath, 0o600);
 }
 
 async function copyToClipboard(value: string): Promise<void> {
-  const candidates =
-    process.platform === 'darwin'
-      ? [['pbcopy']]
-      : process.platform === 'win32'
-        ? [['clip']]
-        : [['wl-copy'], ['xclip', '-selection', 'clipboard']];
+  const [command, ...args] = await resolveClipboardCommand();
+  const copied = await runClipboard(command, args, value);
+  if (copied) return;
+  throw new CliError('clipboard_failed', 'Could not copy to the clipboard.');
+}
 
-  for (const [command, ...args] of candidates) {
-    if (!command) continue;
-    const copied = await runClipboard(command, args, value);
-    if (copied) return;
+async function resolveClipboardCommand(): Promise<string[]> {
+  for (const candidate of clipboardCandidates()) {
+    if (await executableExists(candidate[0])) return candidate;
   }
   throw new CliError(
     'clipboard_unavailable',
     'No supported clipboard command is available.',
   );
+}
+
+function clipboardCandidates(): string[][] {
+  return process.platform === 'darwin'
+    ? [['pbcopy']]
+    : process.platform === 'win32'
+      ? [['clip']]
+      : [['wl-copy'], ['xclip', '-selection', 'clipboard']];
+}
+
+async function executableExists(command: string | undefined): Promise<boolean> {
+  if (!command) return false;
+  // Clipboard helpers are native executables, so detection must inspect PATH.
+  // eslint-disable-next-line turbo/no-undeclared-env-vars
+  const executableExtensions = process.env.PATHEXT;
+  // eslint-disable-next-line turbo/no-undeclared-env-vars
+  const executablePath = process.env.PATH;
+  const extensions =
+    process.platform === 'win32'
+      ? (executableExtensions ?? '.EXE;.CMD;.BAT;.COM').split(';')
+      : [''];
+  for (const directory of (executablePath ?? '').split(path.delimiter)) {
+    for (const extension of extensions) {
+      try {
+        await access(
+          path.join(directory, `${command}${extension}`),
+          process.platform === 'win32' ? constants.F_OK : constants.X_OK,
+        );
+        return true;
+      } catch {
+        // Keep searching PATH.
+      }
+    }
+  }
+  return false;
 }
 
 function runClipboard(
@@ -104,6 +160,64 @@ function runClipboard(
   });
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+async function readEnvFile(
+  filePath: string,
+): Promise<{ contents: string; exists: boolean }> {
+  try {
+    return { contents: await readFile(filePath, 'utf8'), exists: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { contents: '', exists: false };
+    }
+    throw error;
+  }
+}
+
+function assertAssignmentsAvailable(input: {
+  filePath: string;
+  contents: string;
+  names: string[];
+  update: boolean;
+}): void {
+  const present = input.names.filter((name) =>
+    hasAssignment(input.contents, name),
+  );
+  if (present.length && !input.update) {
+    throw usageError(
+      'secret_output_exists',
+      `${input.filePath} already contains ${present.join(', ')}.`,
+      ['Pass --update to replace the existing values.'],
+    );
+  }
+}
+
+function hasAssignment(contents: string, name: string): boolean {
+  return contents
+    .split('\n')
+    .some((line) => line.replace(/\r$/, '').startsWith(`${name}=`));
+}
+
+function updateAssignments(
+  contents: string,
+  values: Record<string, string>,
+): string {
+  const replaced = new Set<string>();
+  const lines = contents.split('\n').map((line) => {
+    const carriageReturn = line.endsWith('\r') ? '\r' : '';
+    const content = carriageReturn ? line.slice(0, -1) : line;
+    for (const [name, value] of Object.entries(values)) {
+      if (content.startsWith(`${name}=`)) {
+        replaced.add(name);
+        return `${name}=${value}${carriageReturn}`;
+      }
+    }
+    return line;
+  });
+  let next = lines.join('\n');
+  for (const [name, value] of Object.entries(values)) {
+    if (replaced.has(name)) continue;
+    if (next && !next.endsWith('\n')) next += '\n';
+    next += `${name}=${value}\n`;
+  }
+  return next;
 }

--- a/packages/cli/src/core/secretDelivery.ts
+++ b/packages/cli/src/core/secretDelivery.ts
@@ -1,0 +1,109 @@
+import { spawn } from 'node:child_process';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { CliError, usageError } from './errors';
+
+export type SecretDeliveryOptions = {
+  copy?: boolean;
+  output?: string;
+  update?: boolean;
+};
+
+export async function deliverEnvSecret(
+  cwd: string,
+  values: Record<string, string>,
+  options: SecretDeliveryOptions,
+): Promise<string[]> {
+  const text = Object.entries(values)
+    .map(([name, value]) => `${name}=${value}`)
+    .join('\n');
+  const destinations: string[] = [];
+
+  if (options.copy) {
+    await copyToClipboard(`${text}\n`);
+    destinations.push('Copied to clipboard.');
+  }
+  if (options.output) {
+    const outputPath = path.resolve(cwd, options.output);
+    await writeEnvFile(outputPath, values, Boolean(options.update));
+    destinations.push(`Saved to ${outputPath}.`);
+  }
+  return destinations;
+}
+
+async function writeEnvFile(
+  filePath: string,
+  values: Record<string, string>,
+  update: boolean,
+): Promise<void> {
+  let existing = '';
+  try {
+    existing = await readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+
+  const names = Object.keys(values);
+  const present = names.filter((name) =>
+    new RegExp(`^${escapeRegExp(name)}=`, 'm').test(existing),
+  );
+  if (present.length && !update) {
+    throw usageError(
+      'secret_output_exists',
+      `${filePath} already contains ${present.join(', ')}.`,
+      ['Pass --update to replace the existing values.'],
+    );
+  }
+
+  let next = existing;
+  for (const [name, value] of Object.entries(values)) {
+    const line = `${name}=${value}`;
+    const pattern = new RegExp(`^${escapeRegExp(name)}=.*$`, 'm');
+    next = pattern.test(next)
+      ? next.replace(pattern, line)
+      : `${next}${next && !next.endsWith('\n') ? '\n' : ''}${line}\n`;
+  }
+  await writeFile(filePath, next, { mode: 0o600 });
+  await chmod(filePath, 0o600);
+}
+
+async function copyToClipboard(value: string): Promise<void> {
+  const candidates =
+    process.platform === 'darwin'
+      ? [['pbcopy']]
+      : process.platform === 'win32'
+        ? [['clip']]
+        : [['wl-copy'], ['xclip', '-selection', 'clipboard']];
+
+  for (const [command, ...args] of candidates) {
+    if (!command) continue;
+    const copied = await runClipboard(command, args, value);
+    if (copied) return;
+  }
+  throw new CliError(
+    'clipboard_unavailable',
+    'No supported clipboard command is available.',
+  );
+}
+
+function runClipboard(
+  command: string,
+  args: string[],
+  value: string,
+): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['pipe', 'ignore', 'ignore'] });
+    child.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') resolve(false);
+      else reject(error);
+    });
+    child.on('exit', (code) => {
+      resolve(code === 0);
+    });
+    child.stdin.end(value);
+  });
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary

Adds complete project-key lifecycle management and reusable one-time secret delivery.

- adds `project key list/create/revoke/rotate`
- lists metadata without exposing past secrets
- supports `--copy`, `--output`, and protected `--update` env-file writes
- sends clipboard contents over stdin rather than process arguments
- warns and confirms when revoking the last active key
- creates and delivers a replacement before revoking the old key during rotation
- requires explicit delivery and `--yes` for non-interactive rotation
- preserves one valid JSON result in machine mode

## Validation

- focused CLI lint, typecheck, test, and build
- 25 CLI tests across 5 files
- full repository formatting check
- `git diff --check`

## Stack

Depends on #169 (`[CLI 02] feat: add project lifecycle commands`).


## Stack changeset

This PR is part of the unreleased CLI stack. The stack intentionally uses one comprehensive changeset instead of one changeset per slice. It includes minor releases for `@edgestore/cli` and `@edgestore/sdk`. It is added by [[CLI 10] PR #177](https://github.com/edgestorejs/edgestore/pull/177) at `.changeset/calm-clouds-guide.md`.
