### PR TITLE
[CLI 04] feat: add management token commands

### DIFF
--- a/.changeset/warm-tokens-work.md
+++ b/.changeset/warm-tokens-work.md
@@ -1,5 +1,0 @@
----
-"@edgestore/cli": minor
----
-
-Add account and user management token listing, creation, and revocation.

--- a/.changeset/warm-tokens-work.md
+++ b/.changeset/warm-tokens-work.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/cli": minor
+---
+
+Add account and user management token listing, creation, and revocation.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -147,6 +147,19 @@ describe('runCli', () => {
     );
   });
 
+  it('creates an account management token with one-time output', async () => {
+    await runCli(
+      ['token', 'create', '--name', 'deploy', '--preset', 'deploy'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(fixture.stdout()).toContain('EDGESTORE_TOKEN=mgmt_created');
+    expect(fixture.stdout()).toContain(
+      'You will not be able to view it again.',
+    );
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -310,6 +323,31 @@ function createFixture() {
           },
           secretKey: 'secret_test',
         })),
+        revoke: vi.fn(async () => ({})),
+      },
+      tokens: {
+        listAccount: vi.fn(async () => ({ tokens: [] })),
+        listUser: vi.fn(async () => ({ tokens: [] })),
+        createAccount: vi.fn(async () => ({
+          token: {
+            id: 'tok_created',
+            name: 'deploy',
+            kind: 'ACCOUNT',
+            tokenPrefix: 'edge_',
+            scopes: ['project:read'],
+            createdAt: project.createdAt,
+            updatedAt: project.updatedAt,
+            lastUsedAt: null,
+            revokedAt: null,
+            expiresAt: null,
+            accountId: account.id,
+            userId: null,
+          },
+          secret: 'mgmt_created',
+        })),
+        createUser: vi.fn(async () => {
+          throw new Error('not used');
+        }),
         revoke: vi.fn(async () => ({})),
       },
     },

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -158,6 +158,99 @@ describe('runCli', () => {
     expect(fixture.stdout()).toContain(
       'You will not be able to view it again.',
     );
+    const input = fixture.createAccountToken.mock.calls[0]?.[0];
+    expect(input).toMatchObject({
+      account: account.id,
+      name: 'deploy',
+      preset: 'deploy',
+    });
+    expect(input).not.toHaveProperty('scopes');
+  });
+
+  it('creates user-owned management tokens from presets', async () => {
+    await runCli(
+      [
+        'token',
+        'create',
+        '--name',
+        'read access',
+        '--user',
+        '--preset',
+        'read-only',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    const input = fixture.createUserToken.mock.calls[0]?.[0];
+    expect(input).toMatchObject({
+      name: 'read access',
+      preset: 'read-only',
+    });
+    expect(input).not.toHaveProperty('account');
+    expect(input).not.toHaveProperty('scopes');
+  });
+
+  it('forwards repeated explicit token scopes unchanged', async () => {
+    await runCli(
+      [
+        'token',
+        'create',
+        '--name',
+        'custom access',
+        '--scope',
+        'account:read',
+        '--scope',
+        'project:read',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    const input = fixture.createAccountToken.mock.calls[0]?.[0];
+    expect(input).toMatchObject({
+      account: account.id,
+      name: 'custom access',
+      scopes: ['account:read', 'project:read'],
+    });
+    expect(input).not.toHaveProperty('preset');
+  });
+
+  it('rejects conflicting token permission options', async () => {
+    const exitCode = await runCli(
+      [
+        'token',
+        'create',
+        '--name',
+        'conflicting',
+        '--preset',
+        'deploy',
+        '--scope',
+        'project:read',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.stderr()).toContain(
+      '--preset and --scope cannot be used together.',
+    );
+    expect(fixture.createAccountToken).not.toHaveBeenCalled();
+  });
+
+  it('requires token permissions', async () => {
+    const exitCode = await runCli(
+      ['token', 'create', '--name', 'missing permissions'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.stderr()).toContain(
+      'Token creation requires --preset or at least one --scope.',
+    );
+    expect(fixture.createAccountToken).not.toHaveBeenCalled();
   });
 
   it('validates a token before saving it', async () => {
@@ -248,6 +341,41 @@ function createFixture() {
     available: vi.fn(async () => true),
   };
 
+  const createAccountToken = vi.fn(async (_input: unknown) => ({
+    token: {
+      id: 'tok_created',
+      name: 'deploy',
+      kind: 'ACCOUNT' as const,
+      tokenPrefix: 'edge_',
+      scopes: ['project:read'],
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+      lastUsedAt: null,
+      revokedAt: null,
+      expiresAt: null,
+      accountId: account.id,
+      userId: null,
+    },
+    secret: 'mgmt_created',
+  }));
+  const createUserToken = vi.fn(async (_input: unknown) => ({
+    token: {
+      id: 'tok_user_created',
+      name: 'read access',
+      kind: 'USER' as const,
+      tokenPrefix: 'edge_',
+      scopes: ['account:read'],
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+      lastUsedAt: null,
+      revokedAt: null,
+      expiresAt: null,
+      accountId: null,
+      userId: 'user_123',
+    },
+    secret: 'mgmt_user_created',
+  }));
+
   const sdk = {
     system: {
       health: vi.fn(async () => ({ status: 'ok' })),
@@ -328,26 +456,8 @@ function createFixture() {
       tokens: {
         listAccount: vi.fn(async () => ({ tokens: [] })),
         listUser: vi.fn(async () => ({ tokens: [] })),
-        createAccount: vi.fn(async () => ({
-          token: {
-            id: 'tok_created',
-            name: 'deploy',
-            kind: 'ACCOUNT',
-            tokenPrefix: 'edge_',
-            scopes: ['project:read'],
-            createdAt: project.createdAt,
-            updatedAt: project.updatedAt,
-            lastUsedAt: null,
-            revokedAt: null,
-            expiresAt: null,
-            accountId: account.id,
-            userId: null,
-          },
-          secret: 'mgmt_created',
-        })),
-        createUser: vi.fn(async () => {
-          throw new Error('not used');
-        }),
+        createAccount: createAccountToken,
+        createUser: createUserToken,
         revoke: vi.fn(async () => ({})),
       },
     },
@@ -409,6 +519,8 @@ function createFixture() {
     setCredential,
     readToken,
     confirmTyped,
+    createAccountToken,
+    createUserToken,
     stdout: () => Buffer.concat(stdoutChunks).toString('utf8'),
     stderr: () => Buffer.concat(stderrChunks).toString('utf8'),
   };

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -50,6 +50,21 @@ const projectKey = {
   revokedAt: null as string | null,
 };
 
+const accountToken = {
+  id: 'tok_created',
+  name: 'deploy',
+  kind: 'ACCOUNT' as const,
+  tokenPrefix: 'edge_',
+  scopes: ['project:read'],
+  createdAt: project.createdAt,
+  updatedAt: project.updatedAt,
+  lastUsedAt: null,
+  revokedAt: null as string | null,
+  expiresAt: null as string | null,
+  accountId: account.id,
+  userId: null,
+};
+
 describe('runCli', () => {
   let fixture: ReturnType<typeof createFixture>;
   let temporaryDirectory: string | undefined;
@@ -59,6 +74,7 @@ describe('runCli', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     if (temporaryDirectory) {
       await rm(temporaryDirectory, { recursive: true, force: true });
       temporaryDirectory = undefined;
@@ -339,7 +355,7 @@ describe('runCli', () => {
     );
     expect(JSON.parse(fixture.stderr()).error.details.rollback).toEqual({
       status: 'succeeded',
-      keyId: projectKey.id,
+      credentialId: projectKey.id,
     });
   });
 
@@ -377,7 +393,7 @@ describe('runCli', () => {
     const error = JSON.parse(fixture.stderr()).error;
     expect(error.details.rollback).toMatchObject({
       status: 'failed',
-      keyId: projectKey.id,
+      credentialId: projectKey.id,
     });
     expect(error.suggestions).toContain(
       `edgestore project key revoke ${project.basePath} ${projectKey.id} --yes`,
@@ -415,6 +431,119 @@ describe('runCli', () => {
       preset: 'deploy',
     });
     expect(input).not.toHaveProperty('scopes');
+  });
+
+  it('requires a destination for plain token creation', async () => {
+    const exitCode = await runCli(
+      ['--plain', 'token', 'create', '--name', 'deploy', '--preset', 'deploy'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.createAccountToken).not.toHaveBeenCalled();
+    expect(fixture.stderr()).toContain('--copy or --output');
+  });
+
+  it('preflights token output before creating the token', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-token-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    await writeFile(
+      path.join(temporaryDirectory, '.env.local'),
+      'EDGESTORE_TOKEN=existing\n',
+    );
+
+    const exitCode = await runCli(
+      [
+        'token',
+        'create',
+        '--name',
+        'deploy',
+        '--preset',
+        'deploy',
+        '--output',
+        '.env.local',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.createAccountToken).not.toHaveBeenCalled();
+  });
+
+  it('reports a privileged recovery path when token rollback fails', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-token-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.createAccountToken.mockImplementationOnce(async () => {
+      await writeFile(
+        path.join(temporaryDirectory!, '.env.local'),
+        'EDGESTORE_TOKEN=raced\n',
+      );
+      return { token: accountToken, secret: 'mgmt_created' };
+    });
+    fixture.revokeToken.mockRejectedValueOnce(new Error('forbidden'));
+
+    const exitCode = await runCli(
+      [
+        '--json',
+        'token',
+        'create',
+        '--name',
+        'deploy',
+        '--preset',
+        'deploy',
+        '--output',
+        '.env.local',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    const error = JSON.parse(fixture.stderr()).error;
+    expect(error.details.rollback).toMatchObject({
+      status: 'failed',
+      credentialId: accountToken.id,
+    });
+    expect(error.suggestions).toEqual(
+      expect.arrayContaining([
+        `edgestore token revoke ${accountToken.id} --yes`,
+        expect.stringContaining('token:revoke'),
+      ]),
+    );
+  });
+
+  it('renders revoked, expired, and active token status deterministically', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-02T00:00:00.000Z'));
+    fixture.listAccountTokens.mockResolvedValueOnce({
+      tokens: [
+        {
+          ...accountToken,
+          id: 'tok_revoked',
+          revokedAt: '2026-07-01T00:00:00.000Z',
+          expiresAt: '2026-06-01T00:00:00.000Z',
+        },
+        {
+          ...accountToken,
+          id: 'tok_expired',
+          expiresAt: '2026-08-01T00:00:00.000Z',
+        },
+        { ...accountToken, id: 'tok_active' },
+      ],
+    });
+
+    await runCli(['token', 'list'], fixture.runtime, '0.0.0');
+
+    expect(fixture.stdout()).toContain('tok_revoked');
+    expect(fixture.stdout()).toMatch(/tok_revoked.*revoked/);
+    expect(fixture.stdout()).toMatch(/tok_expired.*expired/);
+    expect(fixture.stdout()).toMatch(/tok_active.*active/);
   });
 
   it('creates user-owned management tokens from presets', async () => {
@@ -645,20 +774,7 @@ function createFixture() {
   };
 
   const createAccountToken = vi.fn(async (_input: unknown) => ({
-    token: {
-      id: 'tok_created',
-      name: 'deploy',
-      kind: 'ACCOUNT' as const,
-      tokenPrefix: 'edge_',
-      scopes: ['project:read'],
-      createdAt: project.createdAt,
-      updatedAt: project.updatedAt,
-      lastUsedAt: null,
-      revokedAt: null,
-      expiresAt: null,
-      accountId: account.id,
-      userId: null,
-    },
+    token: accountToken,
     secret: 'mgmt_created',
   }));
   const createUserToken = vi.fn(async (_input: unknown) => ({
@@ -700,6 +816,10 @@ function createFixture() {
     secretKey: 'secret_test',
   }));
   const revokeProjectKey = vi.fn(async () => ({}));
+  const listAccountTokens = vi.fn(async () => ({
+    tokens: [] as (typeof accountToken)[],
+  }));
+  const revokeToken = vi.fn(async () => ({}));
   const sdk = {
     system: {
       health: vi.fn(async () => ({ status: 'ok' })),
@@ -738,11 +858,11 @@ function createFixture() {
         revoke: revokeProjectKey,
       },
       tokens: {
-        listAccount: vi.fn(async () => ({ tokens: [] })),
+        listAccount: listAccountTokens,
         listUser: vi.fn(async () => ({ tokens: [] })),
         createAccount: createAccountToken,
         createUser: createUserToken,
-        revoke: vi.fn(async () => ({})),
+        revoke: revokeToken,
       },
     },
   } as unknown as ManagementEdgeStoreSdk;
@@ -805,6 +925,8 @@ function createFixture() {
     confirmTyped,
     createAccountToken,
     createUserToken,
+    listAccountTokens,
+    revokeToken,
     createProject,
     listProjectKeys,
     createProjectKey,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,6 +21,11 @@ import {
   projectKeyRevokeCommand,
   projectKeyRotateCommand,
 } from './commands/projectKey';
+import {
+  tokenCreateCommand,
+  tokenListCommand,
+  tokenRevokeCommand,
+} from './commands/token';
 import { normalizeError } from './core/errors';
 import { outputFor, type CliRuntime, type GlobalFlags } from './core/runtime';
 
@@ -253,7 +258,70 @@ function createProgram(runtime: CliRuntime, version: string): Command {
       });
     });
 
+  const token = program
+    .command('token')
+    .description('Manage account and user management tokens');
+
+  token
+    .command('list')
+    .alias('ls')
+    .description('List management token metadata')
+    .option('--user', 'list user-owned tokens')
+    .option('--account <account-id>', 'override the active account')
+    .option('--page <number>', 'page number', parsePositiveInteger)
+    .option('--limit <number>', 'page size', parsePositiveInteger)
+    .option('--all', 'fetch every page')
+    .action(async (options) => {
+      await tokenListCommand(runtime, globalFlags(program), options);
+    });
+
+  token
+    .command('create')
+    .description('Create a management token')
+    .requiredOption('--name <name>', 'token name')
+    .option('--user', 'create a user-owned token')
+    .option('--account <account-id>', 'override the active account')
+    .option(
+      '--preset <preset>',
+      'permission preset: deploy, read-only, or full-access',
+    )
+    .option('--scope <scope>', 'explicit permission scope', collectValue, [])
+    .option('--expires-at <timestamp>', 'ISO 8601 expiration timestamp')
+    .option('--copy', 'copy the token to the clipboard')
+    .option('--output <file>', 'write the token to an env file')
+    .option('--update', 'replace an existing token in the output file')
+    .action(async (options) => {
+      await tokenCreateCommand(runtime, globalFlags(program), options);
+    });
+
+  token
+    .command('revoke <token-id>')
+    .description('Revoke a management token')
+    .option('--yes', 'skip interactive confirmation')
+    .action(async (tokenId: string, options) => {
+      await tokenRevokeCommand(runtime, globalFlags(program), {
+        tokenId,
+        ...options,
+      });
+    });
+
   return program;
+}
+
+function collectValue(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+function parsePositiveInteger(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new CommanderError(
+      2,
+      'invalid_number',
+      'Expected a positive integer.',
+    );
+  }
+  return parsed;
 }
 
 function globalFlags(program: Command): GlobalFlags {

--- a/packages/cli/src/commands/projectKey.ts
+++ b/packages/cli/src/commands/projectKey.ts
@@ -1,9 +1,9 @@
-import { CliError, normalizeError, usageError } from '../core/errors';
+import { CliError, usageError } from '../core/errors';
 import { renderTable } from '../core/output';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { outputFor, sdkFor } from '../core/runtime';
 import {
-  deliverEnvSecret,
+  deliverEnvSecretWithRollback,
   preflightEnvSecret,
   type SecretDeliveryOptions,
 } from '../core/secretDelivery';
@@ -180,20 +180,21 @@ async function createAndDeliverKey(
     name: input.name,
     signal: runtime.signal,
   });
-  try {
-    const delivered = await deliverEnvSecret(
-      runtime.cwd,
-      keyValues(result.key.accessKey, result.secretKey),
-      input,
-    );
-    return { result, delivered };
-  } catch (error) {
-    throw await rollbackUndeliveredKey(sdk, {
-      project: input.project,
-      keyId: result.key.id,
-      deliveryError: error,
-    });
-  }
+  const delivered = await deliverEnvSecretWithRollback({
+    cwd: runtime.cwd,
+    values: keyValues(result.key.accessKey, result.secretKey),
+    options: input,
+    credential: { label: 'project key', id: result.key.id },
+    rollback: async (signal) => {
+      await sdk.management.projectKeys.revoke({
+        project: input.project,
+        keyId: result.key.id,
+        signal,
+      });
+    },
+    manualRollbackCommand: `edgestore project key revoke ${input.project} ${result.key.id} --yes`,
+  });
+  return { result, delivered };
 }
 
 async function preflightKeyDelivery(
@@ -205,68 +206,6 @@ async function preflightKeyDelivery(
     ['EDGE_STORE_ACCESS_KEY', 'EDGE_STORE_SECRET_KEY'],
     options,
   );
-}
-
-async function rollbackUndeliveredKey(
-  sdk: Awaited<ReturnType<typeof sdkFor>>,
-  input: { project: string; keyId: string; deliveryError: unknown },
-): Promise<CliError> {
-  const cause = normalizeError(input.deliveryError);
-  try {
-    await sdk.management.projectKeys.revoke({
-      project: input.project,
-      keyId: input.keyId,
-      signal: AbortSignal.timeout(10_000),
-    });
-    return new CliError(
-      'secret_delivery_failed',
-      `${cause.message} The new project key was revoked.`,
-      {
-        details: {
-          cause: errorDetails(cause),
-          rollback: { status: 'succeeded', keyId: input.keyId },
-        },
-        requestId: cause.options.requestId,
-        suggestions: cause.options.suggestions,
-        exitCode: cause.exitCode,
-      },
-    );
-  } catch (rollbackError) {
-    const rollback = normalizeError(rollbackError);
-    return new CliError(
-      'secret_delivery_failed',
-      `${cause.message} Automatic revocation of the new project key failed.`,
-      {
-        details: {
-          cause: errorDetails(cause),
-          rollback: {
-            status: 'failed',
-            keyId: input.keyId,
-            error: errorDetails(rollback),
-          },
-        },
-        requestId: cause.options.requestId,
-        suggestions: [
-          ...(cause.options.suggestions ?? []),
-          `edgestore project key revoke ${input.project} ${input.keyId} --yes`,
-        ],
-        exitCode: cause.exitCode,
-      },
-    );
-  }
-}
-
-function errorDetails(error: CliError) {
-  return {
-    code: error.code,
-    message: error.message,
-    ...(error.options.details === undefined
-      ? {}
-      : { details: error.options.details }),
-    ...(error.options.requestId === undefined
-      ? {}
-      : { requestId: error.options.requestId }),
-  };
 }
 
 function requirePlainSecretDelivery(

--- a/packages/cli/src/commands/token.ts
+++ b/packages/cli/src/commands/token.ts
@@ -1,0 +1,180 @@
+import { usageError } from '../core/errors';
+import { renderTable } from '../core/output';
+import type { CliRuntime, GlobalFlags } from '../core/runtime';
+import { outputFor, sdkFor } from '../core/runtime';
+import {
+  deliverEnvSecret,
+  type SecretDeliveryOptions,
+} from '../core/secretDelivery';
+import { activeAccount } from './account';
+
+const tokenScopes = [
+  'account:read',
+  'project:read',
+  'project:create',
+  'project:delete',
+  'bucket:read',
+  'bucket:write',
+  'file:read',
+  'file:write',
+  'project-key:read',
+  'project-key:create',
+  'project-key:revoke',
+  'member:read',
+  'member:write',
+  'token:read',
+  'token:create',
+  'token:revoke',
+] as const;
+type TokenScope = (typeof tokenScopes)[number];
+
+export async function tokenListCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  options: {
+    user?: boolean;
+    account?: string;
+    page?: number;
+    limit?: number;
+    all?: boolean;
+  },
+): Promise<void> {
+  const sdk = await sdkFor(runtime, flags);
+  const pageSize = options.limit ?? 50;
+  const account = options.user
+    ? undefined
+    : await activeAccount(runtime, options.account);
+  const tokens = [];
+  let page = options.page ?? 1;
+
+  do {
+    const result = options.user
+      ? await sdk.management.tokens.listUser({
+          page,
+          pageSize,
+          signal: runtime.signal,
+        })
+      : await sdk.management.tokens.listAccount({
+          account: account!,
+          page,
+          pageSize,
+          signal: runtime.signal,
+        });
+    tokens.push(...result.tokens);
+    if (!options.all || result.tokens.length < pageSize) break;
+    page += 1;
+  } while (true);
+
+  const rows = tokens.map((token) => [
+    token.id,
+    token.name,
+    token.kind.toLowerCase(),
+    token.scopes.join(','),
+    token.lastUsedAt ?? 'never',
+    token.revokedAt ? 'revoked' : 'active',
+  ]);
+  outputFor(runtime, flags).result(
+    { tokens },
+    rows.length
+      ? renderTable(
+          ['ID', 'NAME', 'TYPE', 'SCOPES', 'LAST USED', 'STATUS'],
+          rows,
+        )
+      : 'No management tokens found.',
+  );
+}
+
+export async function tokenCreateCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  options: {
+    user?: boolean;
+    account?: string;
+    name: string;
+    preset?: 'deploy' | 'read-only' | 'full-access';
+    scope?: string[];
+    expiresAt?: string;
+  } & SecretDeliveryOptions,
+): Promise<void> {
+  if (options.preset && options.scope?.length) {
+    throw usageError(
+      'conflicting_token_permissions',
+      '--preset and --scope cannot be used together.',
+    );
+  }
+  if (!options.preset && !options.scope?.length) {
+    throw usageError(
+      'token_permissions_required',
+      'Token creation requires --preset or at least one --scope.',
+    );
+  }
+  const scopes = options.scope?.map(validateScope);
+  const sdk = await sdkFor(runtime, flags);
+  const body = {
+    name: options.name,
+    preset: options.preset,
+    scopes,
+    expiresAt: options.expiresAt,
+    signal: runtime.signal,
+  };
+  const result = options.user
+    ? await sdk.management.tokens.createUser(body)
+    : await sdk.management.tokens.createAccount({
+        account: await activeAccount(runtime, options.account),
+        ...body,
+      });
+  const delivered = await deliverEnvSecret(
+    runtime.cwd,
+    { EDGESTORE_TOKEN: result.secret },
+    options,
+  );
+  outputFor(runtime, flags).result(
+    result,
+    [
+      `Created ${result.token.kind.toLowerCase()} token "${result.token.name}".`,
+      ...(delivered.length
+        ? ['', ...delivered]
+        : ['', `EDGESTORE_TOKEN=${result.secret}`]),
+      '',
+      'Save this token now. You will not be able to view it again.',
+    ].join('\n'),
+    result.token.id,
+  );
+}
+
+export async function tokenRevokeCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: { tokenId: string; yes?: boolean },
+): Promise<void> {
+  if (!input.yes) {
+    if (!runtime.io.inputIsTty || flags.json) {
+      throw usageError(
+        'confirmation_required',
+        'Token revocation requires confirmation.',
+        [`edgestore token revoke ${input.tokenId} --yes`],
+      );
+    }
+    await runtime.prompts.confirmTyped(
+      `Type ${input.tokenId} to revoke this token`,
+      input.tokenId,
+    );
+  }
+  const sdk = await sdkFor(runtime, flags);
+  const result = await sdk.management.tokens.revoke({
+    tokenId: input.tokenId,
+    signal: runtime.signal,
+  });
+  outputFor(runtime, flags).result(
+    result,
+    `Revoked management token ${input.tokenId}.`,
+    input.tokenId,
+  );
+}
+
+function validateScope(value: string): TokenScope {
+  if ((tokenScopes as readonly string[]).includes(value)) {
+    return value as TokenScope;
+  }
+  throw usageError('invalid_token_scope', `Unsupported token scope: ${value}.`);
+}

--- a/packages/cli/src/commands/token.ts
+++ b/packages/cli/src/commands/token.ts
@@ -4,7 +4,8 @@ import { renderTable } from '../core/output';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { outputFor, sdkFor } from '../core/runtime';
 import {
-  deliverEnvSecret,
+  deliverEnvSecretWithRollback,
+  preflightEnvSecret,
   type SecretDeliveryOptions,
 } from '../core/secretDelivery';
 import { activeAccount } from './account';
@@ -52,13 +53,18 @@ export async function tokenListCommand(
     page += 1;
   } while (true);
 
+  const now = Date.now();
   const rows = tokens.map((token) => [
     token.id,
     token.name,
     token.kind.toLowerCase(),
     token.scopes.join(','),
     token.lastUsedAt ?? 'never',
-    token.revokedAt ? 'revoked' : 'active',
+    token.revokedAt
+      ? 'revoked'
+      : token.expiresAt && Date.parse(token.expiresAt) <= now
+        ? 'expired'
+        : 'active',
   ]);
   outputFor(runtime, flags).result(
     { tokens },
@@ -95,6 +101,13 @@ export async function tokenCreateCommand(
       'Token creation requires --preset or at least one --scope.',
     );
   }
+  if (flags.plain && !options.copy && !options.output) {
+    throw usageError(
+      'secret_delivery_required',
+      'Plain output requires --copy or --output for the one-time token.',
+    );
+  }
+  await preflightEnvSecret(runtime.cwd, ['EDGESTORE_TOKEN'], options);
   const sdk = await sdkFor(runtime, flags);
   const permissions = options.preset
     ? { preset: options.preset }
@@ -111,11 +124,22 @@ export async function tokenCreateCommand(
         account: await activeAccount(runtime, options.account),
         ...body,
       });
-  const delivered = await deliverEnvSecret(
-    runtime.cwd,
-    { EDGESTORE_TOKEN: result.secret },
+  const delivered = await deliverEnvSecretWithRollback({
+    cwd: runtime.cwd,
+    values: { EDGESTORE_TOKEN: result.secret },
     options,
-  );
+    credential: { label: 'management token', id: result.token.id },
+    rollback: async (signal) => {
+      await sdk.management.tokens.revoke({
+        tokenId: result.token.id,
+        signal,
+      });
+    },
+    manualRollbackCommand: `edgestore token revoke ${result.token.id} --yes`,
+    recoverySuggestions: [
+      'Use a credential with token:revoke access or revoke the token in the dashboard.',
+    ],
+  });
   outputFor(runtime, flags).result(
     result,
     [

--- a/packages/cli/src/commands/token.ts
+++ b/packages/cli/src/commands/token.ts
@@ -1,3 +1,4 @@
+import type { ManagementEdgeStoreSdk } from '@edgestore/sdk';
 import { usageError } from '../core/errors';
 import { renderTable } from '../core/output';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
@@ -8,25 +9,11 @@ import {
 } from '../core/secretDelivery';
 import { activeAccount } from './account';
 
-const tokenScopes = [
-  'account:read',
-  'project:read',
-  'project:create',
-  'project:delete',
-  'bucket:read',
-  'bucket:write',
-  'file:read',
-  'file:write',
-  'project-key:read',
-  'project-key:create',
-  'project-key:revoke',
-  'member:read',
-  'member:write',
-  'token:read',
-  'token:create',
-  'token:revoke',
-] as const;
-type TokenScope = (typeof tokenScopes)[number];
+type TokenScope = NonNullable<
+  Parameters<
+    ManagementEdgeStoreSdk['management']['tokens']['createUser']
+  >[0]['scopes']
+>[number];
 
 export async function tokenListCommand(
   runtime: CliRuntime,
@@ -108,13 +95,14 @@ export async function tokenCreateCommand(
       'Token creation requires --preset or at least one --scope.',
     );
   }
-  const scopes = options.scope?.map(validateScope);
   const sdk = await sdkFor(runtime, flags);
+  const permissions = options.preset
+    ? { preset: options.preset }
+    : { scopes: options.scope as TokenScope[] };
   const body = {
     name: options.name,
-    preset: options.preset,
-    scopes,
-    expiresAt: options.expiresAt,
+    ...permissions,
+    ...(options.expiresAt ? { expiresAt: options.expiresAt } : {}),
     signal: runtime.signal,
   };
   const result = options.user
@@ -170,11 +158,4 @@ export async function tokenRevokeCommand(
     `Revoked management token ${input.tokenId}.`,
     input.tokenId,
   );
-}
-
-function validateScope(value: string): TokenScope {
-  if ((tokenScopes as readonly string[]).includes(value)) {
-    return value as TokenScope;
-  }
-  throw usageError('invalid_token_scope', `Unsupported token scope: ${value}.`);
 }

--- a/packages/cli/src/core/secretDelivery.ts
+++ b/packages/cli/src/core/secretDelivery.ts
@@ -10,13 +10,71 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import path from 'node:path';
-import { CliError, usageError } from './errors';
+import { CliError, normalizeError, usageError } from './errors';
 
 export type SecretDeliveryOptions = {
   copy?: boolean;
   output?: string;
   update?: boolean;
 };
+
+export async function deliverEnvSecretWithRollback(input: {
+  cwd: string;
+  values: Record<string, string>;
+  options: SecretDeliveryOptions;
+  credential: { label: string; id: string };
+  rollback(signal: AbortSignal): Promise<void>;
+  manualRollbackCommand: string;
+  recoverySuggestions?: string[];
+}): Promise<string[]> {
+  try {
+    return await deliverEnvSecret(input.cwd, input.values, input.options);
+  } catch (deliveryError) {
+    const cause = normalizeError(deliveryError);
+    try {
+      await input.rollback(AbortSignal.timeout(10_000));
+    } catch (rollbackError) {
+      const rollback = normalizeError(rollbackError);
+      throw new CliError(
+        'secret_delivery_failed',
+        `${cause.message} Automatic revocation of the new ${input.credential.label} failed.`,
+        {
+          details: {
+            cause: errorDetails(cause),
+            rollback: {
+              status: 'failed',
+              credentialId: input.credential.id,
+              error: errorDetails(rollback),
+            },
+          },
+          requestId: cause.options.requestId,
+          suggestions: [
+            ...(cause.options.suggestions ?? []),
+            input.manualRollbackCommand,
+            ...(input.recoverySuggestions ?? []),
+          ],
+          exitCode: cause.exitCode,
+        },
+      );
+    }
+    throw new CliError(
+      'secret_delivery_failed',
+      `${cause.message} The new ${input.credential.label} was revoked.`,
+      {
+        details: {
+          cause: errorDetails(cause),
+          rollback: {
+            status: 'succeeded',
+            credentialId: input.credential.id,
+          },
+        },
+        requestId: cause.options.requestId,
+        suggestions: cause.options.suggestions,
+        exitCode: cause.exitCode,
+      },
+    );
+  }
+}
 
 export async function preflightEnvSecret(
   cwd: string,
@@ -220,4 +278,17 @@ function updateAssignments(
     next += `${name}=${value}\n`;
   }
   return next;
+}
+
+function errorDetails(error: CliError) {
+  return {
+    code: error.code,
+    message: error.message,
+    ...(error.options.details === undefined
+      ? {}
+      : { details: error.options.details }),
+    ...(error.options.requestId === undefined
+      ? {}
+      : { requestId: error.options.requestId }),
+  };
 }

--- a/packages/cli/src/core/secretDelivery.ts
+++ b/packages/cli/src/core/secretDelivery.ts
@@ -30,13 +30,13 @@ export async function deliverEnvSecretWithRollback(input: {
   try {
     return await deliverEnvSecret(input.cwd, input.values, input.options);
   } catch (deliveryError) {
-    await rollbackCredentialAfterFailure({
+    return rollbackCredentialAfterFailure({
       cause: deliveryError,
       code: 'secret_delivery_failed',
       successMessage: `The new ${input.credential.label} was revoked.`,
       failureMessage: `Automatic revocation of the new ${input.credential.label} failed.`,
       credential: input.credential,
-      rollback: input.rollback,
+      rollback: (signal) => input.rollback(signal),
       manualRollbackCommand: input.manualRollbackCommand,
       recoverySuggestions: input.recoverySuggestions,
     });


### PR DESCRIPTION
## Summary

Adds account-owned and user-owned management-token workflows.

- adds `token list/create/revoke`
- defaults to the active account and requires `--user` for user-owned credentials
- supports presets, explicit repeated scopes, and expiration
- supports page selection, page size, and explicit `--all` traversal
- lists token metadata without exposing historical secrets
- delivers new `EDGESTORE_TOKEN` values once through terminal, clipboard, or protected env-file output
- requires confirmation for revocation and `--yes` in automation

## Validation

- focused CLI lint, typecheck, test, and build
- 26 CLI tests across 5 files
- full repository formatting check
- `git diff --check`

## Stack

Depends on #170 (`[CLI 03] feat: add project key management`).


## Stack changeset

This PR is part of the unreleased CLI stack. The stack intentionally uses one comprehensive changeset instead of one changeset per slice. It includes minor releases for `@edgestore/cli` and `@edgestore/sdk`. It is added by [[CLI 10] PR #177](https://github.com/edgestorejs/edgestore/pull/177) at `.changeset/calm-clouds-guide.md`.
