### PR TITLE
[CLI 05] feat: add bucket management commands

### DIFF
--- a/.changeset/brisk-buckets-build.md
+++ b/.changeset/brisk-buckets-build.md
@@ -1,5 +1,0 @@
----
-"@edgestore/cli": minor
----
-
-Add bucket listing, inspection, creation, and confirmed deletion.

--- a/.changeset/brisk-buckets-build.md
+++ b/.changeset/brisk-buckets-build.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/cli": minor
+---
+
+Add bucket listing, inspection, creation, and confirmed deletion.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -649,6 +649,23 @@ describe('runCli', () => {
     );
   });
 
+  it('rejects unsupported bucket types before calling the SDK', async () => {
+    fixture.repoConfig.config = {
+      account: account.id,
+      project: project.basePath,
+    };
+
+    const exitCode = await runCli(
+      ['bucket', 'create', 'archives', '--type', 'video', '--protected'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.createBucket).not.toHaveBeenCalled();
+    expect(fixture.stderr()).toContain('file or image');
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -837,6 +854,19 @@ function createFixture() {
     tokens: [] as (typeof accountToken)[],
   }));
   const revokeToken = vi.fn(async () => ({}));
+  const createBucket = vi.fn(async () => ({
+    bucket: {
+      id: 'bucket_123',
+      name: 'publicFiles',
+      projectId: project.id,
+      accountId: account.id,
+      type: 'file' as const,
+      visibility: 'public' as const,
+      usageBytes: 0,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+    },
+  }));
   const sdk = {
     system: {
       health: vi.fn(async () => ({ status: 'ok' })),
@@ -896,19 +926,7 @@ function createFixture() {
             updatedAt: project.updatedAt,
           },
         })),
-        create: vi.fn(async () => ({
-          bucket: {
-            id: 'bucket_123',
-            name: 'publicFiles',
-            projectId: project.id,
-            accountId: account.id,
-            type: 'file',
-            visibility: 'public',
-            usageBytes: 0,
-            createdAt: project.createdAt,
-            updatedAt: project.updatedAt,
-          },
-        })),
+        create: createBucket,
         delete: vi.fn(async () => ({})),
       },
     },
@@ -974,6 +992,7 @@ function createFixture() {
     createUserToken,
     listAccountTokens,
     revokeToken,
+    createBucket,
     createProject,
     listProjectKeys,
     createProjectKey,

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -253,6 +253,23 @@ describe('runCli', () => {
     expect(fixture.createAccountToken).not.toHaveBeenCalled();
   });
 
+  it('creates a bucket in the linked project', async () => {
+    fixture.repoConfig.config = {
+      account: account.id,
+      project: project.basePath,
+    };
+
+    await runCli(
+      ['bucket', 'create', 'publicFiles', '--type', 'file', '--public'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(fixture.stdout()).toContain(
+      'Created public file bucket publicFiles.',
+    );
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -459,6 +476,36 @@ function createFixture() {
         createAccount: createAccountToken,
         createUser: createUserToken,
         revoke: vi.fn(async () => ({})),
+      },
+      buckets: {
+        list: vi.fn(async () => ({ buckets: [] })),
+        get: vi.fn(async () => ({
+          bucket: {
+            id: 'bucket_123',
+            name: 'publicFiles',
+            projectId: project.id,
+            accountId: account.id,
+            type: 'file',
+            visibility: 'public',
+            usageBytes: 0,
+            createdAt: project.createdAt,
+            updatedAt: project.updatedAt,
+          },
+        })),
+        create: vi.fn(async () => ({
+          bucket: {
+            id: 'bucket_123',
+            name: 'publicFiles',
+            projectId: project.id,
+            accountId: account.id,
+            type: 'file',
+            visibility: 'public',
+            usageBytes: 0,
+            createdAt: project.createdAt,
+            updatedAt: project.updatedAt,
+          },
+        })),
+        delete: vi.fn(async () => ({})),
       },
     },
   } as unknown as ManagementEdgeStoreSdk;

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -728,6 +728,27 @@ describe('runCli', () => {
     expect(fixture.stderr()).toContain('file or image');
   });
 
+  it('deletes a bucket with delete-only access when forced', async () => {
+    fixture.repoConfig.config = {
+      account: account.id,
+      project: project.basePath,
+    };
+    fixture.getBucket.mockRejectedValueOnce(new Error('read denied'));
+
+    const exitCode = await runCli(
+      ['bucket', 'delete', 'publicFiles', '--yes'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fixture.deleteBucket).toHaveBeenCalledWith({
+      project: project.basePath,
+      bucket: 'publicFiles',
+      signal: fixture.runtime.signal,
+    });
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -945,6 +966,20 @@ function createFixture() {
       updatedAt: project.updatedAt,
     },
   }));
+  const getBucket = vi.fn(async () => ({
+    bucket: {
+      id: 'bucket_123',
+      name: 'publicFiles',
+      projectId: project.id,
+      accountId: account.id,
+      type: 'file' as const,
+      visibility: 'public' as const,
+      usageBytes: 0,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+    },
+  }));
+  const deleteBucket = vi.fn(async () => ({}));
   const deleteProject = vi.fn(async () => ({}));
   const sdk = {
     system: {
@@ -992,21 +1027,9 @@ function createFixture() {
       },
       buckets: {
         list: vi.fn(async () => ({ buckets: [] })),
-        get: vi.fn(async () => ({
-          bucket: {
-            id: 'bucket_123',
-            name: 'publicFiles',
-            projectId: project.id,
-            accountId: account.id,
-            type: 'file',
-            visibility: 'public',
-            usageBytes: 0,
-            createdAt: project.createdAt,
-            updatedAt: project.updatedAt,
-          },
-        })),
+        get: getBucket,
         create: createBucket,
-        delete: vi.fn(async () => ({})),
+        delete: deleteBucket,
       },
     },
   } as unknown as ManagementEdgeStoreSdk;
@@ -1072,6 +1095,8 @@ function createFixture() {
     listAccountTokens,
     revokeToken,
     createBucket,
+    getBucket,
+    deleteBucket,
     createProject,
     listProjectKeys,
     createProjectKey,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,6 +5,12 @@ import {
   accountSwitchCommand,
 } from './commands/account';
 import { loginCommand, logoutCommand, whoamiCommand } from './commands/auth';
+import {
+  bucketCreateCommand,
+  bucketDeleteCommand,
+  bucketListCommand,
+  bucketShowCommand,
+} from './commands/bucket';
 import { doctorCommand } from './commands/doctor';
 import {
   projectCreateCommand,
@@ -301,6 +307,57 @@ function createProgram(runtime: CliRuntime, version: string): Command {
     .action(async (tokenId: string, options) => {
       await tokenRevokeCommand(runtime, globalFlags(program), {
         tokenId,
+        ...options,
+      });
+    });
+
+  const bucket = program
+    .command('bucket')
+    .description('Manage project buckets');
+
+  bucket
+    .command('list')
+    .alias('ls')
+    .description('List buckets in a project')
+    .option('--project <project>', 'override the linked project')
+    .action(async (options: { project?: string }) => {
+      await bucketListCommand(runtime, globalFlags(program), options.project);
+    });
+
+  bucket
+    .command('show <bucket>')
+    .description('Show bucket details')
+    .option('--project <project>', 'override the linked project')
+    .action(async (bucketName: string, options: { project?: string }) => {
+      await bucketShowCommand(runtime, globalFlags(program), {
+        bucket: bucketName,
+        ...options,
+      });
+    });
+
+  bucket
+    .command('create <bucket>')
+    .description('Create a bucket')
+    .requiredOption('--type <type>', 'bucket type: file or image')
+    .option('--project <project>', 'override the linked project')
+    .option('--public', 'allow public reads')
+    .option('--protected', 'require signed reads')
+    .action(async (bucketName: string, options) => {
+      await bucketCreateCommand(runtime, globalFlags(program), {
+        bucket: bucketName,
+        ...options,
+      });
+    });
+
+  bucket
+    .command('delete <bucket>')
+    .alias('rm')
+    .description('Delete an empty bucket')
+    .option('--project <project>', 'override the linked project')
+    .option('--yes', 'skip interactive confirmation')
+    .action(async (bucketName: string, options) => {
+      await bucketDeleteCommand(runtime, globalFlags(program), {
+        bucket: bucketName,
         ...options,
       });
     });

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -93,11 +93,9 @@ export async function bucketDeleteCommand(
   flags: GlobalFlags,
   input: { bucket: string; project?: string; yes?: boolean },
 ): Promise<void> {
+  validateBucketName(input.bucket);
   const project = await resolvedProjectRef(runtime, input.project);
-  const current = await getBucket(runtime, flags, {
-    project,
-    bucket: input.bucket,
-  });
+  let bucket = input.bucket;
   if (!input.yes) {
     if (!runtime.io.inputIsTty || flags.json) {
       throw usageError(
@@ -106,22 +104,23 @@ export async function bucketDeleteCommand(
         [`edgestore bucket delete ${input.bucket} --yes`],
       );
     }
+    const current = await getBucket(runtime, flags, {
+      project,
+      bucket: input.bucket,
+    });
+    bucket = current.bucket.name;
     await runtime.prompts.confirmTyped(
-      `Type ${current.bucket.name} to delete this bucket`,
-      current.bucket.name,
+      `Type ${bucket} to delete this bucket`,
+      bucket,
     );
   }
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.buckets.delete({
     project,
-    bucket: current.bucket.name,
+    bucket,
     signal: runtime.signal,
   });
-  outputFor(runtime, flags).result(
-    result,
-    `Deleted bucket ${current.bucket.name}.`,
-    current.bucket.name,
-  );
+  outputFor(runtime, flags).result(result, `Deleted bucket ${bucket}.`, bucket);
 }
 
 async function getBucket(

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -1,0 +1,141 @@
+import { usageError } from '../core/errors';
+import { renderTable } from '../core/output';
+import type { CliRuntime, GlobalFlags } from '../core/runtime';
+import { outputFor, sdkFor } from '../core/runtime';
+import { resolvedProjectRef } from './project';
+
+export async function bucketListCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  project?: string,
+): Promise<void> {
+  const projectRef = await resolvedProjectRef(runtime, project);
+  const sdk = await sdkFor(runtime, flags);
+  const result = await sdk.management.buckets.list({
+    project: projectRef,
+    signal: runtime.signal,
+  });
+  const rows = result.buckets.map((bucket) => [
+    bucket.name,
+    bucket.type,
+    bucket.visibility,
+    bucket.usageBytes,
+    bucket.id,
+  ]);
+  outputFor(runtime, flags).result(
+    result,
+    rows.length
+      ? renderTable(['NAME', 'TYPE', 'VISIBILITY', 'BYTES', 'ID'], rows)
+      : 'No buckets found.',
+  );
+}
+
+export async function bucketShowCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: { bucket: string; project?: string },
+): Promise<void> {
+  const result = await getBucket(runtime, flags, input);
+  outputFor(runtime, flags).result(
+    result,
+    [
+      `Name: ${result.bucket.name}`,
+      `Type: ${result.bucket.type}`,
+      `Visibility: ${result.bucket.visibility}`,
+      `Usage: ${result.bucket.usageBytes} bytes`,
+      `ID: ${result.bucket.id}`,
+    ].join('\n'),
+    result.bucket.name,
+  );
+}
+
+export async function bucketCreateCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: {
+    bucket: string;
+    project?: string;
+    type: 'file' | 'image';
+    public?: boolean;
+    protected?: boolean;
+  },
+): Promise<void> {
+  validateBucketName(input.bucket);
+  if (Boolean(input.public) === Boolean(input.protected)) {
+    throw usageError(
+      'bucket_visibility_required',
+      'Choose exactly one of --public or --protected.',
+    );
+  }
+  const sdk = await sdkFor(runtime, flags);
+  const result = await sdk.management.buckets.create({
+    project: await resolvedProjectRef(runtime, input.project),
+    name: input.bucket,
+    type: input.type,
+    visibility: input.public ? 'public' : 'protected',
+    signal: runtime.signal,
+  });
+  outputFor(runtime, flags).result(
+    result,
+    `Created ${result.bucket.visibility} ${result.bucket.type} bucket ${result.bucket.name}.`,
+    result.bucket.name,
+  );
+}
+
+export async function bucketDeleteCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: { bucket: string; project?: string; yes?: boolean },
+): Promise<void> {
+  const project = await resolvedProjectRef(runtime, input.project);
+  const current = await getBucket(runtime, flags, {
+    project,
+    bucket: input.bucket,
+  });
+  if (!input.yes) {
+    if (!runtime.io.inputIsTty || flags.json) {
+      throw usageError(
+        'confirmation_required',
+        'Bucket deletion requires confirmation.',
+        [`edgestore bucket delete ${input.bucket} --yes`],
+      );
+    }
+    await runtime.prompts.confirmTyped(
+      `Type ${current.bucket.name} to delete this bucket`,
+      current.bucket.name,
+    );
+  }
+  const sdk = await sdkFor(runtime, flags);
+  const result = await sdk.management.buckets.delete({
+    project,
+    bucket: current.bucket.name,
+    signal: runtime.signal,
+  });
+  outputFor(runtime, flags).result(
+    result,
+    `Deleted bucket ${current.bucket.name}.`,
+    current.bucket.name,
+  );
+}
+
+async function getBucket(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: { bucket: string; project?: string },
+) {
+  const sdk = await sdkFor(runtime, flags);
+  return sdk.management.buckets.get({
+    project: await resolvedProjectRef(runtime, input.project),
+    bucket: input.bucket,
+    signal: runtime.signal,
+  });
+}
+
+function validateBucketName(name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,254}$/.test(name)) {
+    throw usageError(
+      'invalid_bucket_name',
+      'Bucket names must begin with a letter or number and contain only letters, numbers, underscores, or hyphens.',
+    );
+  }
+}

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -55,12 +55,13 @@ export async function bucketCreateCommand(
   input: {
     bucket: string;
     project?: string;
-    type: 'file' | 'image';
+    type: string;
     public?: boolean;
     protected?: boolean;
   },
 ): Promise<void> {
   validateBucketName(input.bucket);
+  const type = parseBucketType(input.type);
   if (Boolean(input.public) === Boolean(input.protected)) {
     throw usageError(
       'bucket_visibility_required',
@@ -71,7 +72,7 @@ export async function bucketCreateCommand(
   const result = await sdk.management.buckets.create({
     project: await resolvedProjectRef(runtime, input.project),
     name: input.bucket,
-    type: input.type,
+    type,
     visibility: input.public ? 'public' : 'protected',
     signal: runtime.signal,
   });
@@ -80,6 +81,11 @@ export async function bucketCreateCommand(
     `Created ${result.bucket.visibility} ${result.bucket.type} bucket ${result.bucket.name}.`,
     result.bucket.name,
   );
+}
+
+export function parseBucketType(value: string | undefined): 'file' | 'image' {
+  if (value === 'file' || value === 'image') return value;
+  throw usageError('invalid_bucket_type', 'Bucket type must be file or image.');
 }
 
 export async function bucketDeleteCommand(


### PR DESCRIPTION
## Summary

Adds synchronous bucket management within explicit or locally linked project context.

- adds `bucket list/show/create/delete`
- validates canonical bucket names before mutations
- requires file/image type and exactly one visibility choice
- resolves buckets by exact name and project context
- requires typed deletion confirmation or `--yes` for automation
- leaves non-empty-bucket behavior to the API and existing structured remediation

## Validation

- focused CLI lint, typecheck, test, and build
- 27 CLI tests across 5 files
- full repository formatting check
- `git diff --check`

## Stack

Depends on #171 (`[CLI 04] feat: add management token commands`).


## Stack changeset

This PR is part of the unreleased CLI stack. The stack intentionally uses one comprehensive changeset instead of one changeset per slice. It includes minor releases for `@edgestore/cli` and `@edgestore/sdk`. It is added by [[CLI 10] PR #177](https://github.com/edgestorejs/edgestore/pull/177) at `.changeset/calm-clouds-guide.md`.
