### PR TITLE
[CLI 06] feat: add asynchronous bucket emptying

### DIFF
--- a/.changeset/slow-jobs-empty.md
+++ b/.changeset/slow-jobs-empty.md
@@ -1,5 +1,0 @@
----
-"@edgestore/cli": minor
----
-
-Add asynchronous bucket emptying, status, retry, and bounded wait workflows.

--- a/.changeset/slow-jobs-empty.md
+++ b/.changeset/slow-jobs-empty.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/cli": minor
+---
+
+Add asynchronous bucket emptying, status, retry, and bounded wait workflows.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -270,6 +270,22 @@ describe('runCli', () => {
     );
   });
 
+  it('starts an empty-bucket job and prints its status command', async () => {
+    fixture.repoConfig.config = {
+      account: account.id,
+      project: project.basePath,
+    };
+
+    await runCli(
+      ['bucket', 'empty', 'publicFiles', '--yes'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(fixture.stdout()).toContain('Job: job_123');
+    expect(fixture.stdout()).toContain('empty-status publicFiles');
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -506,6 +522,16 @@ function createFixture() {
           },
         })),
         delete: vi.fn(async () => ({})),
+        empty: vi.fn(async () => ({
+          jobId: 'job_123',
+          bucketId: 'bucket_123',
+          status: 'QUEUED',
+        })),
+        emptyJobs: {
+          latest: vi.fn(),
+          get: vi.fn(),
+          retry: vi.fn(),
+        },
       },
     },
   } as unknown as ManagementEdgeStoreSdk;

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -286,6 +286,28 @@ describe('runCli', () => {
     expect(fixture.stdout()).toContain('empty-status publicFiles');
   });
 
+  it('reports when a bucket has no empty-bucket job', async () => {
+    fixture.repoConfig.config = {
+      account: account.id,
+      project: project.basePath,
+    };
+
+    const exitCode = await runCli(
+      ['--json', 'bucket', 'empty-status', 'publicFiles'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(fixture.stderr())).toEqual({
+      error: {
+        code: 'bucket_empty_job_not_found',
+        message: 'No empty-bucket job found for publicFiles.',
+        suggestions: ['edgestore bucket empty publicFiles'],
+      },
+    });
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -528,7 +550,7 @@ function createFixture() {
           status: 'QUEUED',
         })),
         emptyJobs: {
-          latest: vi.fn(),
+          latest: vi.fn(async () => ({ job: null })),
           get: vi.fn(),
           retry: vi.fn(),
         },

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -65,6 +65,30 @@ const accountToken = {
   userId: null,
 };
 
+const failedEmptyJob = {
+  id: 'job_123',
+  bucketId: 'bucket_123',
+  projectId: project.id,
+  accountId: account.id,
+  status: 'FAILED' as const,
+  phase: 'DELETING_FILES' as const,
+  totalCount: 5,
+  totalBytes: 500,
+  processedCount: 2,
+  freedBytes: 200,
+  pendingS3CleanupCount: 1,
+  canceledUploadCount: 0,
+  orphanObjectCount: 1,
+  orphanBytes: 20,
+  cloudFrontInvalidationId: null,
+  error: 'storage unavailable',
+  heartbeatAt: project.updatedAt,
+  startedAt: project.createdAt,
+  completedAt: project.updatedAt,
+  createdAt: project.createdAt,
+  updatedAt: project.updatedAt,
+};
+
 describe('runCli', () => {
   let fixture: ReturnType<typeof createFixture>;
   let temporaryDirectory: string | undefined;
@@ -656,13 +680,87 @@ describe('runCli', () => {
     };
 
     await runCli(
-      ['bucket', 'empty', 'publicFiles', '--yes'],
+      [
+        '--api-url',
+        'https://api-dev.edgestore.dev',
+        'bucket',
+        'empty',
+        'publicFiles',
+        '--project',
+        project.basePath,
+        '--yes',
+      ],
       fixture.runtime,
       '0.0.0',
     );
 
     expect(fixture.stdout()).toContain('Job: job_123');
-    expect(fixture.stdout()).toContain('empty-status publicFiles');
+    expect(fixture.stdout()).toContain(
+      `edgestore --api-url https://api-dev.edgestore.dev bucket empty-status publicFiles --job job_123 --project ${project.basePath}`,
+    );
+  });
+
+  it('preserves applicable options in confirmation follow-ups', async () => {
+    fixture.runtime.io.inputIsTty = false;
+
+    const exitCode = await runCli(
+      [
+        '--json',
+        '--api-url',
+        'https://api-dev.edgestore.dev',
+        'bucket',
+        'empty',
+        'publicFiles',
+        '--project',
+        project.basePath,
+        '--retry',
+        'job_old',
+        '--wait',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(fixture.stderr()).error.suggestions).toEqual([
+      `edgestore --json --api-url https://api-dev.edgestore.dev bucket empty publicFiles --retry job_old --wait --yes --project ${project.basePath}`,
+    ]);
+    expect(fixture.emptyBucket).not.toHaveBeenCalled();
+  });
+
+  it('emits one structured error when a waited empty job fails', async () => {
+    fixture.getEmptyJob.mockResolvedValueOnce({ job: failedEmptyJob });
+
+    const exitCode = await runCli(
+      [
+        '--json',
+        '--api-url',
+        'https://api-dev.edgestore.dev',
+        'bucket',
+        'empty',
+        'publicFiles',
+        '--project',
+        project.basePath,
+        '--wait',
+        '--yes',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(fixture.stdout()).toBe('');
+    expect(JSON.parse(fixture.stderr())).toEqual({
+      error: {
+        code: 'bucket_empty_failed',
+        message:
+          'Bucket empty job job_123 failed after 2/5 files: storage unavailable.',
+        details: { job: failedEmptyJob },
+        suggestions: [
+          `edgestore --json --api-url https://api-dev.edgestore.dev bucket empty publicFiles --retry job_123 --wait --yes --project ${project.basePath}`,
+        ],
+      },
+    });
   });
 
   it('reports when a bucket has no empty-bucket job', async () => {
@@ -682,7 +780,9 @@ describe('runCli', () => {
       error: {
         code: 'bucket_empty_job_not_found',
         message: 'No empty-bucket job found for publicFiles.',
-        suggestions: ['edgestore bucket empty publicFiles'],
+        suggestions: [
+          `edgestore bucket empty publicFiles --project ${project.basePath}`,
+        ],
       },
     });
   });
@@ -905,6 +1005,14 @@ function createFixture() {
       updatedAt: project.updatedAt,
     },
   }));
+  const emptyBucket = vi.fn(async () => ({
+    jobId: 'job_123',
+    bucketId: 'bucket_123',
+    status: 'QUEUED' as const,
+  }));
+  const latestEmptyJob = vi.fn(async () => ({ job: null }));
+  const getEmptyJob = vi.fn();
+  const retryEmptyJob = vi.fn();
   const sdk = {
     system: {
       health: vi.fn(async () => ({ status: 'ok' })),
@@ -966,15 +1074,11 @@ function createFixture() {
         })),
         create: createBucket,
         delete: vi.fn(async () => ({})),
-        empty: vi.fn(async () => ({
-          jobId: 'job_123',
-          bucketId: 'bucket_123',
-          status: 'QUEUED',
-        })),
+        empty: emptyBucket,
         emptyJobs: {
-          latest: vi.fn(async () => ({ job: null })),
-          get: vi.fn(),
-          retry: vi.fn(),
+          latest: latestEmptyJob,
+          get: getEmptyJob,
+          retry: retryEmptyJob,
         },
       },
     },
@@ -1041,6 +1145,10 @@ function createFixture() {
     listAccountTokens,
     revokeToken,
     createBucket,
+    emptyBucket,
+    latestEmptyJob,
+    getEmptyJob,
+    retryEmptyJob,
     createProject,
     listProjectKeys,
     createProjectKey,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,6 +8,8 @@ import { loginCommand, logoutCommand, whoamiCommand } from './commands/auth';
 import {
   bucketCreateCommand,
   bucketDeleteCommand,
+  bucketEmptyCommand,
+  bucketEmptyStatusCommand,
   bucketListCommand,
   bucketShowCommand,
 } from './commands/bucket';
@@ -357,6 +359,32 @@ function createProgram(runtime: CliRuntime, version: string): Command {
     .option('--yes', 'skip interactive confirmation')
     .action(async (bucketName: string, options) => {
       await bucketDeleteCommand(runtime, globalFlags(program), {
+        bucket: bucketName,
+        ...options,
+      });
+    });
+
+  bucket
+    .command('empty <bucket>')
+    .description('Asynchronously delete every file in a bucket')
+    .option('--project <project>', 'override the linked project')
+    .option('--retry <job-id>', 'retry the latest failed job')
+    .option('--wait', 'wait for the job to finish')
+    .option('--yes', 'skip interactive confirmation')
+    .action(async (bucketName: string, options) => {
+      await bucketEmptyCommand(runtime, globalFlags(program), {
+        bucket: bucketName,
+        ...options,
+      });
+    });
+
+  bucket
+    .command('empty-status <bucket>')
+    .description('Show empty-bucket job status')
+    .option('--project <project>', 'override the linked project')
+    .option('--job <job-id>', 'inspect a specific job')
+    .action(async (bucketName: string, options) => {
+      await bucketEmptyStatusCommand(runtime, globalFlags(program), {
         bucket: bucketName,
         ...options,
       });

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -1,4 +1,4 @@
-import { usageError } from '../core/errors';
+import { CliError, usageError } from '../core/errors';
 import { renderTable } from '../core/output';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { outputFor, sdkFor } from '../core/runtime';
@@ -118,6 +118,100 @@ export async function bucketDeleteCommand(
   );
 }
 
+export async function bucketEmptyCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: {
+    bucket: string;
+    project?: string;
+    retry?: string;
+    wait?: boolean;
+    yes?: boolean;
+  },
+): Promise<void> {
+  const project = await resolvedProjectRef(runtime, input.project);
+  if (!input.yes) {
+    if (!runtime.io.inputIsTty || flags.json) {
+      throw usageError(
+        'confirmation_required',
+        'Emptying a bucket requires confirmation.',
+        [`edgestore bucket empty ${input.bucket} --yes`],
+      );
+    }
+    await runtime.prompts.confirmTyped(
+      `Type ${input.bucket} to asynchronously delete all files`,
+      input.bucket,
+    );
+  }
+  const sdk = await sdkFor(runtime, flags);
+  const started = input.retry
+    ? await sdk.management.buckets.emptyJobs.retry({
+        project,
+        bucket: input.bucket,
+        jobId: input.retry,
+        signal: runtime.signal,
+      })
+    : await sdk.management.buckets.empty({
+        project,
+        bucket: input.bucket,
+        signal: runtime.signal,
+      });
+  if (input.wait) {
+    const job = await waitForEmptyJob(runtime, flags, {
+      project,
+      bucket: input.bucket,
+      jobId: started.jobId,
+    });
+    renderEmptyJob(runtime, flags, job);
+    if (job.status === 'FAILED') {
+      throw new CliError(
+        'bucket_empty_failed',
+        'The bucket empty job failed.',
+        {
+          details: { jobId: job.id, error: job.error },
+          suggestions: [
+            `edgestore bucket empty ${input.bucket} --retry ${job.id}`,
+          ],
+        },
+      );
+    }
+    return;
+  }
+  outputFor(runtime, flags).result(
+    started,
+    [
+      'Started empty bucket job.',
+      `Job: ${started.jobId}`,
+      '',
+      'Check status:',
+      `  edgestore bucket empty-status ${input.bucket} --job ${started.jobId}`,
+    ].join('\n'),
+    started.jobId,
+  );
+}
+
+export async function bucketEmptyStatusCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: { bucket: string; project?: string; job?: string },
+): Promise<void> {
+  const project = await resolvedProjectRef(runtime, input.project);
+  const sdk = await sdkFor(runtime, flags);
+  const result = input.job
+    ? await sdk.management.buckets.emptyJobs.get({
+        project,
+        bucket: input.bucket,
+        jobId: input.job,
+        signal: runtime.signal,
+      })
+    : await sdk.management.buckets.emptyJobs.latest({
+        project,
+        bucket: input.bucket,
+        signal: runtime.signal,
+      });
+  renderEmptyJob(runtime, flags, result.job);
+}
+
 async function getBucket(
   runtime: CliRuntime,
   flags: GlobalFlags,
@@ -138,4 +232,79 @@ function validateBucketName(name: string): void {
       'Bucket names must begin with a letter or number and contain only letters, numbers, underscores, or hyphens.',
     );
   }
+}
+
+type EmptyJob = Awaited<
+  ReturnType<
+    Awaited<
+      ReturnType<typeof sdkFor>
+    >['management']['buckets']['emptyJobs']['get']
+  >
+>['job'];
+
+async function waitForEmptyJob(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  target: { project: string; bucket: string; jobId: string },
+): Promise<EmptyJob> {
+  const sdk = await sdkFor(runtime, flags);
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    const result = await sdk.management.buckets.emptyJobs.get({
+      project: target.project,
+      bucket: target.bucket,
+      jobId: target.jobId,
+      signal: runtime.signal,
+    });
+    if (result.job.status === 'SUCCEEDED' || result.job.status === 'FAILED') {
+      return result.job;
+    }
+    await delay(Math.min(1_000 + attempt * 250, 5_000), runtime.signal);
+  }
+  throw new CliError(
+    'bucket_empty_timeout',
+    'Timed out waiting for the bucket empty job.',
+    {
+      details: { jobId: target.jobId },
+      suggestions: [
+        `edgestore bucket empty-status ${target.bucket} --job ${target.jobId}`,
+      ],
+    },
+  );
+}
+
+function renderEmptyJob(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  job: EmptyJob,
+): void {
+  outputFor(runtime, flags).result(
+    { job },
+    [
+      `Job: ${job.id}`,
+      `Status: ${job.status.toLowerCase()}`,
+      `Phase: ${job.phase.toLowerCase()}`,
+      `Progress: ${job.processedCount}/${job.totalCount}`,
+      `Freed: ${job.freedBytes} bytes`,
+      `Canceled uploads: ${job.canceledUploadCount}`,
+      `Orphan objects: ${job.orphanObjectCount}`,
+      ...(job.error ? [`Failure: ${job.error}`] : []),
+    ].join('\n'),
+    job.status.toLowerCase(),
+  );
+}
+
+function delay(milliseconds: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(resolve, milliseconds);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeout);
+        reject(
+          new CliError('interrupted', 'Operation canceled.', { exitCode: 130 }),
+        );
+      },
+      { once: true },
+    );
+  });
 }

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -1,3 +1,4 @@
+import { renderCliCommand } from '../core/command';
 import { CliError, usageError } from '../core/errors';
 import { renderTable } from '../core/output';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
@@ -141,7 +142,20 @@ export async function bucketEmptyCommand(
       throw usageError(
         'confirmation_required',
         'Emptying a bucket requires confirmation.',
-        [`edgestore bucket empty ${input.bucket} --yes`],
+        [
+          renderCliCommand(
+            flags,
+            [
+              'bucket',
+              'empty',
+              input.bucket,
+              ...(input.retry ? ['--retry', input.retry] : []),
+              ...(input.wait ? ['--wait'] : []),
+              '--yes',
+            ],
+            { project },
+          ),
+        ],
       );
     }
     await runtime.prompts.confirmTyped(
@@ -168,19 +182,31 @@ export async function bucketEmptyCommand(
       bucket: input.bucket,
       jobId: started.jobId,
     });
-    renderEmptyJob(runtime, flags, job);
     if (job.status === 'FAILED') {
       throw new CliError(
         'bucket_empty_failed',
-        'The bucket empty job failed.',
+        `Bucket empty job ${job.id} failed after ${job.processedCount}/${job.totalCount} files: ${job.error ?? 'unknown failure'}.`,
         {
-          details: { jobId: job.id, error: job.error },
+          details: { job },
           suggestions: [
-            `edgestore bucket empty ${input.bucket} --retry ${job.id}`,
+            renderCliCommand(
+              flags,
+              [
+                'bucket',
+                'empty',
+                input.bucket,
+                '--retry',
+                job.id,
+                '--wait',
+                ...(input.yes ? ['--yes'] : []),
+              ],
+              { project },
+            ),
           ],
         },
       );
     }
+    renderEmptyJob(runtime, flags, job);
     return;
   }
   outputFor(runtime, flags).result(
@@ -190,7 +216,11 @@ export async function bucketEmptyCommand(
       `Job: ${started.jobId}`,
       '',
       'Check status:',
-      `  edgestore bucket empty-status ${input.bucket} --job ${started.jobId}`,
+      `  ${renderCliCommand(
+        flags,
+        ['bucket', 'empty-status', input.bucket, '--job', started.jobId],
+        { project },
+      )}`,
     ].join('\n'),
     started.jobId,
   );
@@ -219,7 +249,14 @@ export async function bucketEmptyStatusCommand(
     throw new CliError(
       'bucket_empty_job_not_found',
       `No empty-bucket job found for ${input.bucket}.`,
-      { suggestions: [`edgestore bucket empty ${input.bucket}`] },
+      {
+        suggestions: [
+          renderCliCommand(flags, ['bucket', 'empty', input.bucket], {
+            project,
+            preserveOutputMode: false,
+          }),
+        ],
+      },
     );
   }
   renderEmptyJob(runtime, flags, result.job);
@@ -279,7 +316,11 @@ async function waitForEmptyJob(
     {
       details: { jobId: target.jobId },
       suggestions: [
-        `edgestore bucket empty-status ${target.bucket} --job ${target.jobId}`,
+        renderCliCommand(
+          flags,
+          ['bucket', 'empty-status', target.bucket, '--job', target.jobId],
+          { project: target.project },
+        ),
       ],
     },
   );

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -209,6 +209,13 @@ export async function bucketEmptyStatusCommand(
         bucket: input.bucket,
         signal: runtime.signal,
       });
+  if (!result.job) {
+    throw new CliError(
+      'bucket_empty_job_not_found',
+      `No empty-bucket job found for ${input.bucket}.`,
+      { suggestions: [`edgestore bucket empty ${input.bucket}`] },
+    );
+  }
   renderEmptyJob(runtime, flags, result.job);
 }
 

--- a/packages/cli/src/core/command.test.ts
+++ b/packages/cli/src/core/command.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderCliCommand } from './command';
 
+const flags = {
+  apiUrl: 'http://[::1]:3000',
+  color: false,
+  progress: false,
+};
+
 describe('renderCliCommand', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('preserves output, API, and project context', () => {
     expect(
       renderCliCommand(
@@ -27,5 +37,25 @@ describe('renderCliCommand', () => {
         "project's name",
       ]),
     ).toBe(`edgestore project show 'project'"'"'s name'`);
+  });
+
+  it('quotes follow-up arguments for POSIX shells', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+
+    expect(
+      renderCliCommand(flags, ['bucket', 'empty-status', 'my files']),
+    ).toBe(
+      "edgestore --api-url 'http://[::1]:3000' bucket empty-status 'my files'",
+    );
+  });
+
+  it('quotes follow-up arguments for Windows shells', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+
+    expect(
+      renderCliCommand(flags, ['bucket', 'empty-status', 'my files']),
+    ).toBe(
+      'edgestore --api-url "http://[::1]:3000" bucket empty-status "my files"',
+    );
   });
 });

--- a/packages/cli/src/core/command.test.ts
+++ b/packages/cli/src/core/command.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { renderCliCommand } from './command';
+
+describe('renderCliCommand', () => {
+  it('preserves output, API, and project context', () => {
+    expect(
+      renderCliCommand(
+        {
+          json: true,
+          apiUrl: 'https://api-dev.edgestore.dev',
+          color: false,
+          progress: false,
+        },
+        ['bucket', 'empty-status', 'publicFiles', '--job', 'job_123'],
+        { project: 'x36t1ejdlz' },
+      ),
+    ).toBe(
+      'edgestore --json --api-url https://api-dev.edgestore.dev bucket empty-status publicFiles --job job_123 --project x36t1ejdlz',
+    );
+  });
+
+  it('quotes unsafe argument values', () => {
+    expect(
+      renderCliCommand({ color: false, progress: false }, [
+        'project',
+        'show',
+        "project's name",
+      ]),
+    ).toBe(`edgestore project show 'project'"'"'s name'`);
+  });
+});

--- a/packages/cli/src/core/command.ts
+++ b/packages/cli/src/core/command.ts
@@ -1,0 +1,25 @@
+import type { GlobalFlags } from './runtime';
+
+export function renderCliCommand(
+  flags: GlobalFlags,
+  command: string[],
+  options: {
+    project?: string;
+    preserveOutputMode?: boolean;
+  } = {},
+): string {
+  const args = ['edgestore'];
+  if (options.preserveOutputMode !== false) {
+    if (flags.json) args.push('--json');
+    if (flags.plain) args.push('--plain');
+  }
+  if (flags.apiUrl) args.push('--api-url', flags.apiUrl);
+  args.push(...command);
+  if (options.project) args.push('--project', options.project);
+  return args.map(quoteShellArgument).join(' ');
+}
+
+function quoteShellArgument(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}

--- a/packages/cli/src/core/command.ts
+++ b/packages/cli/src/core/command.ts
@@ -21,5 +21,8 @@ export function renderCliCommand(
 
 function quoteShellArgument(value: string): string {
   if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
+  if (process.platform === 'win32') {
+    return `"${value.replaceAll('"', '\\"')}"`;
+  }
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }


### PR DESCRIPTION
## Summary

Adds bucket-scoped asynchronous cleanup workflows.

- adds `bucket empty` and `bucket empty-status`
- supports exact historical jobs through `--job`
- supports retrying failed jobs through `--retry`
- returns immediately by default and prints the exact status command
- supports `--wait` with bounded polling of the returned job ID
- reports phase, counts, bytes freed, canceled uploads, orphan cleanup, and failure text
- preserves failed job IDs and prints exact retry remediation
- requires typed confirmation or `--yes` for automation

## Validation

- focused CLI lint, typecheck, test, and build
- 28 CLI tests across 5 files
- full repository formatting check
- `git diff --check`

## Stack

Depends on #172 (`[CLI 05] feat: add bucket management commands`).


## Stack changeset

This PR is part of the unreleased CLI stack. The stack intentionally uses one comprehensive changeset instead of one changeset per slice. It includes minor releases for `@edgestore/cli` and `@edgestore/sdk`. It is added by [[CLI 10] PR #177](https://github.com/edgestorejs/edgestore/pull/177) at `.changeset/calm-clouds-guide.md`.
