### PR TITLE
[CLI 07] feat: add file management commands

### DIFF
--- a/.changeset/bright-files-flow.md
+++ b/.changeset/bright-files-flow.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/cli": minor
+---
+
+Add cursor-paginated file listing, metadata lookup, downloads, and chunked deletion.

--- a/.changeset/bright-files-flow.md
+++ b/.changeset/bright-files-flow.md
@@ -1,5 +1,0 @@
----
-"@edgestore/cli": minor
----
-
-Add cursor-paginated file listing, metadata lookup, downloads, and chunked deletion.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -308,6 +308,22 @@ describe('runCli', () => {
     });
   });
 
+  it('lists files only within the required bucket', async () => {
+    fixture.repoConfig.config = {
+      account: account.id,
+      project: project.basePath,
+    };
+
+    await runCli(
+      ['file', 'list', '--bucket', 'publicFiles'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(fixture.stdout()).toContain('file_123');
+    expect(fixture.stdout()).toContain('logo.png');
+  });
+
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
 
@@ -554,6 +570,36 @@ function createFixture() {
           get: vi.fn(),
           retry: vi.fn(),
         },
+      },
+      files: {
+        list: vi.fn(async () => ({
+          files: [
+            {
+              id: 'file_123',
+              url: 'https://files.example/logo.png',
+              key: 'publicFiles/_public/logo.png',
+              thumbnailUrl: null,
+              thumbnailKey: null,
+              bucketId: 'bucket_123',
+              bucketName: 'publicFiles',
+              projectId: project.id,
+              accountId: account.id,
+              name: 'logo.png',
+              path: {},
+              metadata: {},
+              sizeBytes: 10,
+              mimeType: 'image/png',
+              state: 'uploaded',
+              temporary: false,
+              uploadedAt: project.createdAt,
+              updatedAt: project.updatedAt,
+            },
+          ],
+          pagination: { limit: 50, nextCursor: null, hasMore: false },
+        })),
+        lookup: vi.fn(),
+        createDownloadUrls: vi.fn(),
+        delete: vi.fn(),
       },
     },
   } as unknown as ManagementEdgeStoreSdk;

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1075,6 +1075,42 @@ describe('runCli', () => {
     });
   });
 
+  it('identifies per-file deletion failures in human output', async () => {
+    fixture.deleteFiles.mockResolvedValueOnce({
+      results: [
+        { fileRef: { id: 'file_ok' }, success: true },
+        {
+          fileRef: { id: 'file_failed' },
+          success: false,
+          error: {
+            code: 'FILE_NOT_DELETABLE',
+            message: 'File is already deleted.',
+          },
+        },
+      ],
+      successCount: 1,
+      failureCount: 1,
+    });
+
+    const exitCode = await runCli(
+      [
+        'file',
+        'delete',
+        'file_ok',
+        'file_failed',
+        '--project',
+        project.basePath,
+        '--yes',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(fixture.stdout()).toContain('Deleted 1 file(s); 1 failed.');
+    expect(fixture.stdout()).toContain('file_failed: File is already deleted.');
+  });
+
   it('rejects unsupported bucket types before calling the SDK', async () => {
     fixture.repoConfig.config = {
       account: account.id,

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -968,6 +968,48 @@ describe('runCli', () => {
     expect(fixture.stdout()).toContain('logo.png');
   });
 
+  it('treats URL-shaped references as paths when --bucket is supplied', async () => {
+    fixture.lookupFile.mockResolvedValueOnce({
+      file: {
+        id: 'file_123',
+        bucketName: 'publicFiles',
+        key: 'https://example.com/logo.png',
+        path: {},
+        metadata: {},
+        sizeBytes: 10,
+        mimeType: 'image/png',
+        state: 'uploaded',
+        temporary: false,
+        url: 'https://files.example/logo.png',
+        uploadedAt: project.createdAt,
+        updatedAt: project.updatedAt,
+      },
+    });
+
+    await runCli(
+      [
+        'file',
+        'info',
+        'https://example.com/logo.png',
+        '--bucket',
+        'publicFiles',
+        '--project',
+        project.basePath,
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(fixture.lookupFile).toHaveBeenCalledWith({
+      project: project.basePath,
+      file: {
+        bucketName: 'publicFiles',
+        path: 'https://example.com/logo.png',
+      },
+      signal: fixture.runtime.signal,
+    });
+  });
+
   it('streams downloads through a restrictive temporary file', async () => {
     temporaryDirectory = await mkdtemp(
       path.join(tmpdir(), 'edgestore-cli-download-'),
@@ -1494,6 +1536,7 @@ function createFixture() {
       },
     ],
   }));
+  const lookupFile = vi.fn();
   type DeleteFilesInput = Parameters<
     ManagementEdgeStoreSdk['management']['files']['delete']
   >[0];
@@ -1590,7 +1633,7 @@ function createFixture() {
           ],
           pagination: { limit: 50, nextCursor: null, hasMore: false },
         })),
-        lookup: vi.fn(),
+        lookup: lookupFile,
         generateAccessUrls,
         delete: deleteFiles,
       },
@@ -1667,6 +1710,7 @@ function createFixture() {
     getEmptyJob,
     retryEmptyJob,
     generateAccessUrls,
+    lookupFile,
     deleteFiles,
     createProject,
     listProjectKeys,

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -960,6 +960,8 @@ describe('runCli', () => {
           fileRef,
           success: true as const,
         })),
+        successCount: input.files.length,
+        failureCount: 0,
       };
     });
 
@@ -1230,9 +1232,16 @@ function createFixture() {
   type DeleteFilesInput = Parameters<
     ManagementEdgeStoreSdk['management']['files']['delete']
   >[0];
-  const deleteFiles = vi.fn(async (_input: DeleteFilesInput) => ({
-    results: [],
-  }));
+  type DeleteFilesResult = Awaited<
+    ReturnType<ManagementEdgeStoreSdk['management']['files']['delete']>
+  >;
+  const deleteFiles = vi.fn(
+    async (_input: DeleteFilesInput): Promise<DeleteFilesResult> => ({
+      results: [],
+      successCount: 0,
+      failureCount: 0,
+    }),
+  );
   const sdk = {
     system: {
       health: vi.fn(async () => ({ status: 'ok' })),

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { PassThrough, Readable } from 'node:stream';
@@ -99,6 +106,7 @@ describe('runCli', () => {
 
   afterEach(async () => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     if (temporaryDirectory) {
       await rm(temporaryDirectory, { recursive: true, force: true });
       temporaryDirectory = undefined;
@@ -803,6 +811,186 @@ describe('runCli', () => {
     expect(fixture.stdout()).toContain('logo.png');
   });
 
+  it('streams downloads through a restrictive temporary file', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-download-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode('first '));
+                controller.enqueue(new TextEncoder().encode('second'));
+                controller.close();
+              },
+            }),
+          ),
+      ),
+    );
+
+    const exitCode = await runCli(
+      [
+        'file',
+        'download',
+        'file_123',
+        '--output',
+        'download.txt',
+        '--project',
+        project.basePath,
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    const outputPath = path.join(temporaryDirectory, 'download.txt');
+    expect(exitCode).toBe(0);
+    await expect(readFile(outputPath, 'utf8')).resolves.toBe('first second');
+    expect((await stat(outputPath)).mode & 0o777).toBe(0o600);
+    await expect(readdir(temporaryDirectory)).resolves.toEqual([
+      'download.txt',
+    ]);
+  });
+
+  it('preserves an existing download after a mid-stream failure', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-download-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    const outputPath = path.join(temporaryDirectory, 'download.txt');
+    await writeFile(outputPath, 'original');
+    let pullCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              pull(controller) {
+                pullCount += 1;
+                if (pullCount === 1) {
+                  controller.enqueue(new TextEncoder().encode('partial'));
+                } else {
+                  controller.error(new Error('stream failed'));
+                }
+              },
+            }),
+          ),
+      ),
+    );
+
+    const exitCode = await runCli(
+      [
+        'file',
+        'download',
+        'file_123',
+        '--output',
+        'download.txt',
+        '--project',
+        project.basePath,
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(1);
+    await expect(readFile(outputPath, 'utf8')).resolves.toBe('original');
+    await expect(readdir(temporaryDirectory)).resolves.toEqual([
+      'download.txt',
+    ]);
+  });
+
+  it('removes a partial download after cancellation', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-download-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    const outputPath = path.join(temporaryDirectory, 'download.txt');
+    await writeFile(outputPath, 'original');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode('partial'));
+                fixture.abortController.abort();
+              },
+            }),
+          ),
+      ),
+    );
+
+    const exitCode = await runCli(
+      [
+        'file',
+        'download',
+        'file_123',
+        '--output',
+        'download.txt',
+        '--project',
+        project.basePath,
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(130);
+    await expect(readFile(outputPath, 'utf8')).resolves.toBe('original');
+    await expect(readdir(temporaryDirectory)).resolves.toEqual([
+      'download.txt',
+    ]);
+  });
+
+  it('reports exact partial state when a later delete batch fails', async () => {
+    const references = Array.from(
+      { length: 201 },
+      (_, index) => `file_${index + 1}`,
+    );
+    let requestCount = 0;
+    fixture.deleteFiles.mockImplementation(async (input) => {
+      requestCount += 1;
+      if (requestCount === 2) throw new Error('second batch failed');
+      return {
+        results: input.files.map((fileRef) => ({
+          fileRef,
+          success: true as const,
+        })),
+      };
+    });
+
+    const exitCode = await runCli(
+      [
+        '--json',
+        'file',
+        'delete',
+        ...references,
+        '--project',
+        project.basePath,
+        '--yes',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(fixture.stdout()).toBe('');
+    expect(fixture.deleteFiles).toHaveBeenCalledTimes(2);
+    const details = JSON.parse(fixture.stderr()).error.details;
+    expect(details.completed.successCount).toBe(100);
+    expect(details.completed.results).toHaveLength(100);
+    expect(details.uncertainReferences).toEqual(references.slice(100, 200));
+    expect(details.notAttemptedReferences).toEqual(references.slice(200));
+    expect(details.cause).toMatchObject({
+      code: 'unexpected_error',
+      message: 'second batch failed',
+    });
+  });
+
   it('rejects unsupported bucket types before calling the SDK', async () => {
     fixture.repoConfig.config = {
       account: account.id,
@@ -1029,6 +1217,22 @@ function createFixture() {
   const latestEmptyJob = vi.fn(async () => ({ job: null }));
   const getEmptyJob = vi.fn();
   const retryEmptyJob = vi.fn();
+  const generateAccessUrls = vi.fn(async () => ({
+    accessUrls: [
+      {
+        fileRef: { id: 'file_123' },
+        url: 'https://files.example/download',
+        expiresAt: null,
+        expiresIn: null,
+      },
+    ],
+  }));
+  type DeleteFilesInput = Parameters<
+    ManagementEdgeStoreSdk['management']['files']['delete']
+  >[0];
+  const deleteFiles = vi.fn(async (_input: DeleteFilesInput) => ({
+    results: [],
+  }));
   const sdk = {
     system: {
       health: vi.fn(async () => ({ status: 'ok' })),
@@ -1124,12 +1328,13 @@ function createFixture() {
           pagination: { limit: 50, nextCursor: null, hasMore: false },
         })),
         lookup: vi.fn(),
-        generateAccessUrls: vi.fn(),
-        delete: vi.fn(),
+        generateAccessUrls,
+        delete: deleteFiles,
       },
     },
   } as unknown as ManagementEdgeStoreSdk;
 
+  const abortController = new AbortController();
   const runtime: CliRuntime = {
     exitCode: 0,
     cwd: '/repo',
@@ -1141,7 +1346,7 @@ function createFixture() {
       inputIsTty: true,
       outputIsTty: false,
     },
-    signal: new AbortController().signal,
+    signal: abortController.signal,
     globalConfig: {
       path: '/config/edgestore/config.json',
       read: vi.fn(async () => ({ ...globalConfig })),
@@ -1180,6 +1385,7 @@ function createFixture() {
 
   return {
     runtime,
+    abortController,
     globalConfig,
     repoConfig,
     credentials,
@@ -1195,6 +1401,8 @@ function createFixture() {
     latestEmptyJob,
     getEmptyJob,
     retryEmptyJob,
+    generateAccessUrls,
+    deleteFiles,
     createProject,
     listProjectKeys,
     createProjectKey,

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -991,6 +991,26 @@ describe('runCli', () => {
     ]);
   });
 
+  it('rejects plain file deletion before deleting files', async () => {
+    const exitCode = await runCli(
+      [
+        '--plain',
+        'file',
+        'delete',
+        'file_123',
+        '--project',
+        project.basePath,
+        '--yes',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.deleteFiles).not.toHaveBeenCalled();
+    expect(fixture.stderr()).toContain('--json');
+  });
+
   it('reports exact partial state when a later delete batch fails', async () => {
     const references = Array.from(
       { length: 201 },

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -598,7 +598,7 @@ function createFixture() {
           pagination: { limit: 50, nextCursor: null, hasMore: false },
         })),
         lookup: vi.fn(),
-        createDownloadUrls: vi.fn(),
+        generateAccessUrls: vi.fn(),
         delete: vi.fn(),
       },
     },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,12 @@ import {
 } from './commands/bucket';
 import { doctorCommand } from './commands/doctor';
 import {
+  fileDeleteCommand,
+  fileDownloadCommand,
+  fileInfoCommand,
+  fileListCommand,
+} from './commands/file';
+import {
   projectCreateCommand,
   projectCurrentCommand,
   projectDeleteCommand,
@@ -324,6 +330,60 @@ function createProgram(runtime: CliRuntime, version: string): Command {
     .option('--project <project>', 'override the linked project')
     .action(async (options: { project?: string }) => {
       await bucketListCommand(runtime, globalFlags(program), options.project);
+    });
+
+  const file = program.command('file').description('Manage project files');
+
+  file
+    .command('list')
+    .alias('ls')
+    .description('List files in one bucket')
+    .requiredOption('--bucket <bucket>', 'bucket name')
+    .option('--project <project>', 'override the linked project')
+    .option('--limit <number>', 'page size', parsePositiveInteger)
+    .option('--cursor <cursor>', 'opaque continuation cursor')
+    .option('--all', 'fetch every page')
+    .action(async (options) => {
+      await fileListCommand(runtime, globalFlags(program), options);
+    });
+
+  file
+    .command('info <file>')
+    .description('Show file metadata')
+    .option('--project <project>', 'override the linked project')
+    .option('--bucket <bucket>', 'treat the file argument as a bucket path')
+    .action(async (reference: string, options) => {
+      await fileInfoCommand(runtime, globalFlags(program), {
+        reference,
+        ...options,
+      });
+    });
+
+  file
+    .command('download <file>')
+    .description('Download a file')
+    .requiredOption('--output <path>', 'local output path')
+    .option('--project <project>', 'override the linked project')
+    .option('--bucket <bucket>', 'treat the file argument as a bucket path')
+    .action(async (reference: string, options) => {
+      await fileDownloadCommand(runtime, globalFlags(program), {
+        reference,
+        ...options,
+      });
+    });
+
+  file
+    .command('delete <file...>')
+    .alias('rm')
+    .description('Delete one or more files')
+    .option('--project <project>', 'override the linked project')
+    .option('--bucket <bucket>', 'treat file arguments as bucket paths')
+    .option('--yes', 'skip interactive confirmation')
+    .action(async (references: string[], options) => {
+      await fileDeleteCommand(runtime, globalFlags(program), {
+        references,
+        ...options,
+      });
     });
 
   bucket

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -277,8 +277,8 @@ function renderIncompleteDeletion(input: {
 }
 
 function fileReference(value: string, bucket?: string): FileRef {
-  if (/^https?:\/\//i.test(value)) return { url: value };
   if (bucket) return { bucketName: bucket, path: value };
+  if (/^https?:\/\//i.test(value)) return { url: value };
   return { id: value };
 }
 

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -163,6 +163,13 @@ export async function fileDeleteCommand(
     yes?: boolean;
   },
 ): Promise<void> {
+  if (flags.plain) {
+    throw usageError(
+      'plain_output_unavailable',
+      'File deletion does not have a single plain-text result.',
+      ['Use --json to inspect every file result.'],
+    );
+  }
   if (!input.yes) {
     if (!runtime.io.inputIsTty || flags.json) {
       throw usageError(

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -103,12 +103,12 @@ export async function fileDownloadCommand(
   },
 ): Promise<void> {
   const sdk = await sdkFor(runtime, flags);
-  const result = await sdk.management.files.createDownloadUrls({
+  const result = await sdk.management.files.generateAccessUrls({
     project: await resolvedProjectRef(runtime, input.project),
     files: [fileReference(input.reference, input.bucket)],
     signal: runtime.signal,
   });
-  const download = result.downloadUrls[0];
+  const download = result.accessUrls[0];
   if (!download) {
     throw usageError('download_url_missing', 'No download URL was returned.');
   }

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -234,9 +234,18 @@ export async function fileDeleteCommand(
   }
   const successCount = results.filter((result) => result.success).length;
   const failureCount = results.length - successCount;
+  const human = [
+    `Deleted ${successCount} file(s); ${failureCount} failed.`,
+    ...results
+      .filter((result) => !result.success)
+      .map(
+        (result) =>
+          `  ${fileReferenceLabel(result.fileRef)}: ${result.error.message}`,
+      ),
+  ].join('\n');
   outputFor(runtime, flags).result(
     { results, successCount, failureCount },
-    `Deleted ${successCount} file(s); ${failureCount} failed.`,
+    human,
   );
   if (failureCount) runtime.exitCode = 1;
 }
@@ -271,4 +280,11 @@ function fileReference(value: string, bucket?: string): FileRef {
   if (/^https?:\/\//i.test(value)) return { url: value };
   if (bucket) return { bucketName: bucket, path: value };
   return { id: value };
+}
+
+function fileReferenceLabel(reference: FileRef): string {
+  if ('id' in reference) return reference.id;
+  if ('key' in reference) return reference.key;
+  if ('url' in reference) return reference.url;
+  return `${reference.bucketName}/${reference.path}`;
 }

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -1,0 +1,180 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { usageError } from '../core/errors';
+import { renderTable } from '../core/output';
+import type { CliRuntime, GlobalFlags } from '../core/runtime';
+import { outputFor, sdkFor } from '../core/runtime';
+import { resolvedProjectRef } from './project';
+
+type FileRef =
+  { id: string } | { url: string } | { bucketName: string; path: string };
+
+export async function fileListCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: {
+    bucket: string;
+    project?: string;
+    limit?: number;
+    cursor?: string;
+    all?: boolean;
+  },
+): Promise<void> {
+  if (input.all && input.cursor) {
+    throw usageError(
+      'conflicting_pagination',
+      '--all and --cursor cannot be used together.',
+    );
+  }
+  const project = await resolvedProjectRef(runtime, input.project);
+  const sdk = await sdkFor(runtime, flags);
+  const files = [];
+  let cursor = input.cursor;
+  let pagination;
+  do {
+    const result = await sdk.management.files.list({
+      project,
+      bucket: input.bucket,
+      limit: input.limit,
+      cursor,
+      signal: runtime.signal,
+    });
+    files.push(...result.files);
+    pagination = result.pagination;
+    cursor = result.pagination.nextCursor ?? undefined;
+  } while (input.all && pagination.hasMore && cursor);
+
+  const rows = files.map((file) => [
+    file.id,
+    file.key,
+    file.sizeBytes,
+    file.mimeType ?? '',
+    file.uploadedAt,
+  ]);
+  const continuation =
+    !input.all && pagination?.nextCursor
+      ? `\n\nNext cursor: ${pagination.nextCursor}`
+      : '';
+  outputFor(runtime, flags).result(
+    { files, pagination },
+    `${
+      rows.length
+        ? renderTable(['ID', 'PATH', 'BYTES', 'TYPE', 'UPLOADED'], rows)
+        : 'No files found.'
+    }${continuation}`,
+  );
+}
+
+export async function fileInfoCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: { reference: string; bucket?: string; project?: string },
+): Promise<void> {
+  const sdk = await sdkFor(runtime, flags);
+  const result = await sdk.management.files.lookup({
+    project: await resolvedProjectRef(runtime, input.project),
+    file: fileReference(input.reference, input.bucket),
+    signal: runtime.signal,
+  });
+  outputFor(runtime, flags).result(
+    result,
+    [
+      `ID: ${result.file.id}`,
+      `Bucket: ${result.file.bucketName}`,
+      `Key: ${result.file.key}`,
+      `Path fields: ${JSON.stringify(result.file.path)}`,
+      `Size: ${result.file.sizeBytes} bytes`,
+      `Type: ${result.file.mimeType ?? 'unknown'}`,
+      `URL: ${result.file.url}`,
+      `Uploaded: ${result.file.uploadedAt}`,
+    ].join('\n'),
+    result.file.id,
+  );
+}
+
+export async function fileDownloadCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: {
+    reference: string;
+    output: string;
+    bucket?: string;
+    project?: string;
+  },
+): Promise<void> {
+  const sdk = await sdkFor(runtime, flags);
+  const result = await sdk.management.files.createDownloadUrls({
+    project: await resolvedProjectRef(runtime, input.project),
+    files: [fileReference(input.reference, input.bucket)],
+    signal: runtime.signal,
+  });
+  const download = result.downloadUrls[0];
+  if (!download) {
+    throw usageError('download_url_missing', 'No download URL was returned.');
+  }
+  const response = await fetch(download.url, { signal: runtime.signal });
+  if (!response.ok) {
+    throw new Error(`Download failed with HTTP ${response.status}.`);
+  }
+  const outputPath = path.resolve(runtime.cwd, input.output);
+  await writeFile(outputPath, Buffer.from(await response.arrayBuffer()), {
+    mode: 0o600,
+  });
+  outputFor(runtime, flags).result(
+    { output: outputPath, download },
+    `Downloaded file to ${outputPath}.`,
+    outputPath,
+  );
+}
+
+export async function fileDeleteCommand(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: {
+    references: string[];
+    bucket?: string;
+    project?: string;
+    yes?: boolean;
+  },
+): Promise<void> {
+  if (!input.yes) {
+    if (!runtime.io.inputIsTty || flags.json) {
+      throw usageError(
+        'confirmation_required',
+        'File deletion requires confirmation.',
+        ['Repeat the command with --yes.'],
+      );
+    }
+    await runtime.prompts.confirmTyped(
+      `Type delete to remove ${input.references.length} file(s)`,
+      'delete',
+    );
+  }
+  const project = await resolvedProjectRef(runtime, input.project);
+  const sdk = await sdkFor(runtime, flags);
+  const refs = input.references.map((value) =>
+    fileReference(value, input.bucket),
+  );
+  const results = [];
+  for (let index = 0; index < refs.length; index += 100) {
+    const result = await sdk.management.files.delete({
+      project,
+      files: refs.slice(index, index + 100),
+      signal: runtime.signal,
+    });
+    results.push(...result.results);
+  }
+  const successCount = results.filter((result) => result.success).length;
+  const failureCount = results.length - successCount;
+  outputFor(runtime, flags).result(
+    { results, successCount, failureCount },
+    `Deleted ${successCount} file(s); ${failureCount} failed.`,
+  );
+  if (failureCount) runtime.exitCode = 1;
+}
+
+function fileReference(value: string, bucket?: string): FileRef {
+  if (/^https?:\/\//i.test(value)) return { url: value };
+  if (bucket) return { bucketName: bucket, path: value };
+  return { id: value };
+}

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -1,13 +1,21 @@
-import { writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { rename, rm } from 'node:fs/promises';
 import path from 'node:path';
-import { usageError } from '../core/errors';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import type { ReadableStream } from 'node:stream/web';
+import { CliError, normalizeError, usageError } from '../core/errors';
 import { renderTable } from '../core/output';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { outputFor, sdkFor } from '../core/runtime';
 import { resolvedProjectRef } from './project';
 
 type FileRef =
-  { id: string } | { url: string } | { bucketName: string; path: string };
+  | { id: string }
+  | { key: string }
+  | { url: string }
+  | { bucketName: string; path: string };
 
 export async function fileListCommand(
   runtime: CliRuntime,
@@ -114,12 +122,30 @@ export async function fileDownloadCommand(
   }
   const response = await fetch(download.url, { signal: runtime.signal });
   if (!response.ok) {
-    throw new Error(`Download failed with HTTP ${response.status}.`);
+    throw new CliError(
+      'download_failed',
+      `Download failed with HTTP ${response.status}.`,
+    );
+  }
+  if (!response.body) {
+    throw new CliError(
+      'download_body_missing',
+      'The download response did not contain a body.',
+    );
   }
   const outputPath = path.resolve(runtime.cwd, input.output);
-  await writeFile(outputPath, Buffer.from(await response.arrayBuffer()), {
-    mode: 0o600,
-  });
+  const temporaryPath = `${outputPath}.${randomUUID()}.tmp`;
+  try {
+    await pipeline(
+      Readable.fromWeb(response.body as ReadableStream<Uint8Array>),
+      createWriteStream(temporaryPath, { flags: 'wx', mode: 0o600 }),
+      { signal: runtime.signal },
+    );
+    await rename(temporaryPath, outputPath);
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
   outputFor(runtime, flags).result(
     { output: outputPath, download },
     `Downloaded file to ${outputPath}.`,
@@ -157,12 +183,47 @@ export async function fileDeleteCommand(
   );
   const results = [];
   for (let index = 0; index < refs.length; index += 100) {
-    const result = await sdk.management.files.delete({
-      project,
-      files: refs.slice(index, index + 100),
-      signal: runtime.signal,
-    });
-    results.push(...result.results);
+    try {
+      const result = await sdk.management.files.delete({
+        project,
+        files: refs.slice(index, index + 100),
+        signal: runtime.signal,
+      });
+      results.push(...result.results);
+    } catch (error) {
+      const cause = normalizeError(error);
+      const successCount = results.filter((result) => result.success).length;
+      const failureCount = results.length - successCount;
+      const uncertainReferences = input.references.slice(index, index + 100);
+      const notAttemptedReferences = input.references.slice(index + 100);
+      throw new CliError(
+        'file_delete_incomplete',
+        renderIncompleteDeletion({
+          results,
+          successCount,
+          failureCount,
+          uncertainReferences,
+          notAttemptedReferences,
+          cause,
+        }),
+        {
+          details: {
+            completed: { results, successCount, failureCount },
+            uncertainReferences,
+            notAttemptedReferences,
+            cause: {
+              code: cause.code,
+              message: cause.message,
+              ...(cause.options.details === undefined
+                ? {}
+                : { details: cause.options.details }),
+            },
+          },
+          requestId: cause.options.requestId,
+          exitCode: cause.exitCode,
+        },
+      );
+    }
   }
   const successCount = results.filter((result) => result.success).length;
   const failureCount = results.length - successCount;
@@ -171,6 +232,32 @@ export async function fileDeleteCommand(
     `Deleted ${successCount} file(s); ${failureCount} failed.`,
   );
   if (failureCount) runtime.exitCode = 1;
+}
+
+function renderIncompleteDeletion(input: {
+  results: {
+    fileRef: FileRef;
+    success: boolean;
+    error?: { message: string };
+  }[];
+  successCount: number;
+  failureCount: number;
+  uncertainReferences: string[];
+  notAttemptedReferences: string[];
+  cause: CliError;
+}): string {
+  return [
+    `File deletion stopped: ${input.cause.message}`,
+    `Completed: ${input.successCount} succeeded, ${input.failureCount} failed.`,
+    ...input.results.map(
+      (result) =>
+        `  ${JSON.stringify(result.fileRef)}: ${result.success ? 'deleted' : `failed: ${result.error?.message ?? 'unknown failure'}`}`,
+    ),
+    `Uncertain (${input.uncertainReferences.length}):`,
+    ...input.uncertainReferences.map((reference) => `  ${reference}`),
+    `Not attempted (${input.notAttemptedReferences.length}):`,
+    ...input.notAttemptedReferences.map((reference) => `  ${reference}`),
+  ].join('\n');
 }
 
 function fileReference(value: string, bucket?: string): FileRef {


### PR DESCRIPTION
## Summary

Adds administrative file browsing and mutation workflows.

- adds bucket-required `file list` with cursor, limit, and explicit `--all` traversal
- adds `file info` for IDs, URLs, and bucket-contextual paths
- adds `file download` using public or temporary signed read URLs
- adds confirmed `file delete` with per-item results
- chunks deletions at the API’s 100-reference limit
- reports partial deletion failures through output and exit status

## Validation

- focused CLI lint, typecheck, test, and build
- 29 CLI tests across 5 files
- full repository formatting check
- `git diff --check`

## Stack

Depends on #173 (`[CLI 06] feat: add asynchronous bucket emptying`).


## Stack changeset

This PR is part of the unreleased CLI stack. The stack intentionally uses one comprehensive changeset instead of one changeset per slice. It includes minor releases for `@edgestore/cli` and `@edgestore/sdk`. It is added by [[CLI 10] PR #177](https://github.com/edgestorejs/edgestore/pull/177) at `.changeset/calm-clouds-guide.md`.
