### PR TITLE
ci: use packageManager pnpm version for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.26.2
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -117,8 +115,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.26.2
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -198,8 +194,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.26.2
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- remove the hardcoded pnpm 10.26.2 version from stable/prerelease, maintenance, and canary setup
- let pnpm/action-setup use pnpm 11.15.1 from the repository packageManager field

## Root cause

Upgrade 15 moved the repository to pnpm 11.15.1, but the release workflow continued requesting pnpm 10.26.2. pnpm/action-setup rejects those conflicting declarations, so the release runs after Upgrade 15 and Upgrade 16 failed before Changesets could refresh #181.

Merging this PR into next triggers the corrected release workflow, allowing Changesets to regenerate the Version Packages PR from the latest next state.

## Validation

- parsed .github/workflows/release.yml successfully as YAML
- git diff --check
- confirmed no hardcoded pnpm 10.26.2 versions remain in GitHub workflows