### PR TITLE
ci: allow canaries from prerelease branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,11 @@ jobs:
 
       - name: Create snapshot versions
         run: |
+          if [[ -f .changeset/pre.json ]] &&
+             jq -e '.mode == "pre"' .changeset/pre.json >/dev/null; then
+            pnpm changeset pre exit
+          fi
+
           pnpm changeset version --snapshot canary
           pnpm -s sync-versions
         env:


### PR DESCRIPTION
## Summary

- detect Changesets prerelease mode before creating canary snapshots
- temporarily run `changeset pre exit` in the ephemeral workflow checkout
- preserve the committed prerelease state on `next` and PR branches

## Root cause

PR branches based on `next` inherit `.changeset/pre.json` with `mode: pre`. Changesets rejects `version --snapshot` in that state, so the SDK canary run failed before build and publish.

The canary job already discards all generated version changes. Marking prerelease mode for exit inside that checkout lets Changesets calculate an isolated snapshot without committing or pushing the altered `pre.json`. Publishing remains restricted to the `canary` npm tag and creates no Git tag.

## Validation

- parsed `.github/workflows/release.yml` successfully as YAML
- validated the multiline Bash guard with `bash -n`
- confirmed the guard detects the repository’s current prerelease state
- `git diff --check`

After this merges, the SDK tip must incorporate the workflow commit before retrying the manual canary run.