### PR TITLE
ci: add RC prerelease handoff

### DIFF
--- a/.github/workflows/promote-next.yml
+++ b/.github/workflows/promote-next.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           git fetch origin main
           git merge-base --is-ancestor origin/main HEAD
-          jq -e '.mode == "pre" and .tag == "next"' .changeset/pre.json
+          jq -e \
+            '.mode == "pre" and (.tag == "next" or .tag == "rc")' \
+            .changeset/pre.json
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Generate stable versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,9 @@ jobs:
         shell: bash
         run: |
           if [[ "$GITHUB_REF_NAME" == "next" ]]; then
-            jq -e '.mode == "pre" and .tag == "next"' .changeset/pre.json
+            jq -e \
+              '.mode == "pre" and (.tag == "next" or .tag == "rc")' \
+              .changeset/pre.json
           elif [[ -f .changeset/pre.json ]]; then
             echo 'main must not contain a Changesets prerelease state'
             exit 1

--- a/.github/workflows/start-rc.yml
+++ b/.github/workflows/start-rc.yml
@@ -1,0 +1,84 @@
+name: Start RC cycle
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: start-rc-cycle
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Prepare RC handoff PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout next
+        uses: actions/checkout@v7
+        with:
+          ref: next
+          fetch-depth: 0
+
+      - name: Validate next prerelease state
+        id: source
+        shell: bash
+        run: |
+          jq -e '.mode == "pre" and .tag == "next"' .changeset/pre.json
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare RC prerelease state
+        shell: bash
+        run: |
+          temp_file="$(mktemp)"
+          jq '.tag = "rc"' .changeset/pre.json > "$temp_file"
+          mv "$temp_file" .changeset/pre.json
+
+          jq -e '.mode == "pre" and .tag == "rc"' .changeset/pre.json
+          test "$(git diff --name-only)" = '.changeset/pre.json'
+
+      - name: Open RC handoff PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT_SHA: ${{ steps.source.outputs.sha }}
+          PR_BODY: |
+            Starts the RC prerelease phase on `next`.
+
+            - Keeps Changesets in prerelease mode.
+            - Changes the prerelease tag from `next` to `rc`.
+            - Allows Changesets to create **Version Packages (rc)**.
+            - Continues the existing numeric prerelease counter.
+
+            No package versions are changed by this PR.
+        shell: bash
+        run: |
+          branch="release/start-rc-$NEXT_SHA"
+          existing_url="$(gh pr list \
+            --base next \
+            --head "$branch" \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')"
+
+          if [[ -n "$existing_url" ]]; then
+            echo "RC handoff PR already exists: $existing_url"
+            exit 0
+          fi
+
+          git switch -c "$branch"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .changeset/pre.json
+          git diff --cached --check
+          git commit -m 'chore: start rc release cycle'
+          git push -u origin "$branch"
+
+          gh pr create \
+            --base next \
+            --head "$branch" \
+            --title 'chore: start RC release cycle' \
+            --body "$PR_BODY"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,12 +6,12 @@ package publication does not change the documentation deployment model.
 
 ## Choose the target branch
 
-| Change                                 | Target branch | npm tag    |
-| -------------------------------------- | ------------- | ---------- |
-| Stable fix or release infrastructure   | `main`        | `latest`   |
-| Work for the upcoming breaking release | `next`        | `next`     |
+| Change                                 | Target branch | npm tag          |
+| -------------------------------------- | ------------- | ---------------- |
+| Stable fix or release infrastructure   | `main`        | `latest`         |
+| Work for the upcoming breaking release | `next`        | `next` or `rc`   |
 | Backport for a supported major         | `<major>.x`   | `legacy-v<major>` |
-| Temporary snapshot from a PR branch    | PR branch     | `canary`   |
+| Temporary snapshot from a PR branch    | PR branch     | `canary`         |
 
 Forward-merge stable fixes from `main` into `next`. Do not routinely merge
 `next` into `main`. A forward merge does not need an immediate prerelease; a
@@ -21,8 +21,8 @@ All published `@edgestore/*` behavior and public API changes require a
 Changeset. Use `patch` for fixes, `minor` for backward-compatible features, and
 `major` for breaking changes.
 
-Version and promotion PRs opened by GitHub Actions may require a maintainer to
-select **Approve workflows to run** before CI starts.
+Version, RC handoff, and promotion PRs opened by GitHub Actions may require a
+maintainer to select **Approve workflows to run** before CI starts.
 
 ## Stable releases
 
@@ -70,11 +70,46 @@ pnpm release
 
 Do not run `changeset pre exit` directly on `next`.
 
+## Start the RC phase
+
+RC releases stay on `next`; they are the final prerelease phase, not a stable
+promotion. Run the **Start RC cycle** workflow from GitHub Actions. It opens a
+PR into `next` that changes only `.changeset/pre.json`:
+
+```diff
+-  "tag": "next",
++  "tag": "rc",
+```
+
+The PR keeps `"mode": "pre"`. Do not run `changeset pre exit` when starting
+RC. After the PR is merged, pending Changesets produce a **Version Packages
+(rc)** PR. If no Changesets are pending, the release PR is created after the
+next Changeset reaches `next`.
+
+Changesets preserves the numeric prerelease counter when the tag changes. For
+example, `1.0.0-next.0` is followed by `1.0.0-rc.1`; subsequent releases use
+`rc.2`, `rc.3`, and so on. Merging the version PR publishes the generated
+version to npm's `rc` tag.
+
+Optionally move npm's `next` tag to the published RC so existing `@next`
+consumers follow the RC phase:
+
+```sh
+for package_dir in server react shared; do
+  package_name="@edgestore/$package_dir"
+  rc_version="$(pnpm view "$package_name" dist-tags.rc)"
+  npm dist-tag add "$package_name@$rc_version" next
+done
+```
+
+Run the dist-tag verification commands below after moving the aliases.
+
 ## Promote `next` to stable
 
 Run the **Promote next** workflow from GitHub Actions. The workflow:
 
-1. Verifies that `main` is contained in `next`.
+1. Verifies that `main` is contained in `next` and that `next` is in the
+   `next` or `rc` prerelease phase.
 2. Runs `changeset pre exit` and the repository version command.
 3. Opens a promotion PR into `main`.
 
@@ -156,8 +191,9 @@ pnpm view @edgestore/react dist-tags --json
 pnpm view @edgestore/shared dist-tags --json
 ```
 
-Expected tags are `latest` for stable, `next` for prereleases,
-`legacy-v<major>` for maintenance, and `canary` for snapshots.
+Expected tags are `latest` for stable, `next` or `rc` for prereleases,
+`legacy-v<major>` for maintenance, and `canary` for snapshots. During the RC
+phase, `next` may intentionally point to the same version as `rc`.
 
 ## Recover from a wrong dist-tag
 


### PR DESCRIPTION
## Summary

- allow `next` release and stable-promotion workflows to accept Changesets prerelease tags `next` or `rc`
- add a manually dispatched **Start RC cycle** workflow that opens a tag-only PR into `next`
- document RC releases, continuous prerelease numbering, optional `next` dist-tag aliasing, and stable promotion from RC

## Behavior

The handoff PR keeps `.changeset/pre.json` in `mode: pre` and changes only `tag: next` to `tag: rc`. Changesets therefore continues the existing counter, for example `1.0.0-next.0` to `1.0.0-rc.1`.

If Changesets are pending when the handoff merges, the release workflow creates **Version Packages (rc)**. Otherwise it waits until the next Changeset reaches `next`. Merging an RC version PR publishes to npm’s `rc` tag. Stable promotion continues to use the existing **Promote next** workflow and `changeset pre exit`.

## Validation

- parsed all three affected workflows as YAML
- validated every embedded Bash block with `bash -n`
- simulated the `next` to `rc` transformation and confirmed only `.changeset/pre.json`’s tag changes
- `git diff --check`