### PR TITLE
[SDK 11] chore: sync API v2 management contract

### DIFF
--- a/.changeset/sync-v2-management-contract.md
+++ b/.changeset/sync-v2-management-contract.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/sdk": minor
+---
+
+Sync the API v2 destructive bucket scopes and nullable latest empty-job result.

--- a/packages/sdk/src/generated/api-v2.ts
+++ b/packages/sdk/src/generated/api-v2.ts
@@ -233,7 +233,7 @@ export type paths = {
         };
         /**
          * Get the latest empty-bucket job
-         * @description Returns the most recently created empty-bucket job for the selected bucket.
+         * @description Returns the most recently created empty-bucket job for the selected bucket, or null when no job exists.
          */
         get: operations["v2.management.buckets.emptyJobs.latest"];
         put?: never;
@@ -1941,7 +1941,7 @@ export interface operations {
                                 /** @description Owning account ID. */
                                 accountId: string;
                                 /** @description Effective management permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                             } | {
                                 /**
                                  * @description User-owned management-token principal.
@@ -1951,7 +1951,7 @@ export interface operations {
                                 /** @description Authenticated token ID. */
                                 tokenId: string;
                                 /** @description Effective management permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                                 /** @description Authenticated user identity. */
                                 user: {
                                     /** @description Unique EdgeStore user ID. */
@@ -3428,7 +3428,6 @@ export interface operations {
                     "application/json": {
                         /** @description Successful response payload. */
                         data: {
-                            /** @description Progress and results for an asynchronous bucket cleanup. */
                             job: {
                                 /** @description Unique empty-bucket job ID. */
                                 id: string;
@@ -3478,7 +3477,7 @@ export interface operations {
                                 createdAt: string;
                                 /** @description ISO 8601 last-update timestamp. */
                                 updatedAt: string;
-                            };
+                            } | null;
                         };
                     };
                 };
@@ -3520,7 +3519,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ProjectNotFoundError"] | components["schemas"]["BucketNotFoundError"] | components["schemas"]["EmptyBucketJobNotFoundError"];
+                    "application/json": components["schemas"]["ProjectNotFoundError"] | components["schemas"]["BucketNotFoundError"];
                 };
             };
             /** @description 413 */
@@ -6162,7 +6161,7 @@ export interface operations {
                                 /** @description Non-secret token prefix used to identify the credential. */
                                 tokenPrefix: string;
                                 /** @description Granted permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                                 /** @description ISO 8601 creation timestamp. */
                                 createdAt: string;
                                 /** @description ISO 8601 last-update timestamp. */
@@ -6264,7 +6263,7 @@ export interface operations {
                      */
                     preset?: "deploy" | "read-only" | "full-access";
                     /** @description Explicit permissions. Mutually exclusive with preset. */
-                    scopes?: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                    scopes?: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                     /** @description ISO 8601 expiration timestamp, or null for no expiration. */
                     expiresAt?: string | null;
                 };
@@ -6295,7 +6294,7 @@ export interface operations {
                                 /** @description Non-secret token prefix used to identify the credential. */
                                 tokenPrefix: string;
                                 /** @description Granted permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                                 /** @description ISO 8601 creation timestamp. */
                                 createdAt: string;
                                 /** @description ISO 8601 last-update timestamp. */
@@ -6414,7 +6413,7 @@ export interface operations {
                                 /** @description Non-secret token prefix used to identify the credential. */
                                 tokenPrefix: string;
                                 /** @description Granted permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                                 /** @description ISO 8601 creation timestamp. */
                                 createdAt: string;
                                 /** @description ISO 8601 last-update timestamp. */
@@ -6504,7 +6503,7 @@ export interface operations {
                      */
                     preset?: "deploy" | "read-only" | "full-access";
                     /** @description Explicit permissions. Mutually exclusive with preset. */
-                    scopes?: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                    scopes?: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                     /** @description ISO 8601 expiration timestamp, or null for no expiration. */
                     expiresAt?: string | null;
                 };
@@ -6535,7 +6534,7 @@ export interface operations {
                                 /** @description Non-secret token prefix used to identify the credential. */
                                 tokenPrefix: string;
                                 /** @description Granted permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                                 /** @description ISO 8601 creation timestamp. */
                                 createdAt: string;
                                 /** @description ISO 8601 last-update timestamp. */

--- a/packages/sdk/src/generated/openapi-v2.json
+++ b/packages/sdk/src/generated/openapi-v2.json
@@ -1844,6 +1844,8 @@
                                       "project:delete",
                                       "bucket:read",
                                       "bucket:write",
+                                      "bucket:delete",
+                                      "bucket:empty",
                                       "file:read",
                                       "file:write",
                                       "project-key:read",
@@ -1888,6 +1890,8 @@
                                       "project:delete",
                                       "bucket:read",
                                       "bucket:write",
+                                      "bucket:delete",
+                                      "bucket:empty",
                                       "file:read",
                                       "file:write",
                                       "project-key:read",
@@ -4948,7 +4952,7 @@
       "get": {
         "operationId": "v2.management.buckets.emptyJobs.latest",
         "summary": "Get the latest empty-bucket job",
-        "description": "Returns the most recently created empty-bucket job for the selected bucket.",
+        "description": "Returns the most recently created empty-bucket job for the selected bucket, or null when no job exists.",
         "tags": [
           "management",
           "buckets"
@@ -4990,180 +4994,187 @@
                       "type": "object",
                       "properties": {
                         "job": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "description": "Unique empty-bucket job ID."
-                            },
-                            "bucketId": {
-                              "type": "string",
-                              "description": "ID of the bucket being emptied."
-                            },
-                            "projectId": {
-                              "type": "string",
-                              "description": "ID of the bucket's project."
-                            },
-                            "accountId": {
-                              "type": "string",
-                              "description": "ID of the project's account."
-                            },
-                            "status": {
-                              "enum": [
-                                "QUEUED",
-                                "RUNNING",
-                                "SUCCEEDED",
-                                "FAILED"
-                              ],
-                              "type": "string",
-                              "description": "Current job lifecycle state."
-                            },
-                            "phase": {
-                              "enum": [
-                                "DELETING_FILES",
-                                "ABORTING_UPLOADS",
-                                "RECONCILING_STORAGE",
-                                "INVALIDATING_CACHE"
-                              ],
-                              "type": "string",
-                              "description": "Current cleanup phase."
-                            },
-                            "totalCount": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 9007199254740991,
-                              "description": "Number of file records selected for cleanup."
-                            },
-                            "totalBytes": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 9007199254740991,
-                              "description": "Total bytes represented by selected file records."
-                            },
-                            "processedCount": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 9007199254740991,
-                              "description": "Number of file records processed so far."
-                            },
-                            "freedBytes": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 9007199254740991,
-                              "description": "Storage bytes accounted as freed so far."
-                            },
-                            "pendingS3CleanupCount": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 9007199254740991,
-                              "description": "Stored objects still pending deletion."
-                            },
-                            "canceledUploadCount": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 9007199254740991,
-                              "description": "Incomplete uploads canceled by the job."
-                            },
-                            "orphanObjectCount": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 9007199254740991,
-                              "description": "Stored objects found without matching active file records."
-                            },
-                            "orphanBytes": {
-                              "type": "integer",
-                              "minimum": 0,
-                              "maximum": 9007199254740991,
-                              "description": "Total bytes of orphaned stored objects found."
-                            },
-                            "cloudFrontInvalidationId": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "Unique empty-bucket job ID."
                                 },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "description": "Cache invalidation ID, or null until one is created."
-                            },
-                            "error": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
+                                "bucketId": {
+                                  "type": "string",
+                                  "description": "ID of the bucket being emptied."
                                 },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "description": "Failure message, or null when the job has not failed."
-                            },
-                            "heartbeatAt": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
+                                "projectId": {
+                                  "type": "string",
+                                  "description": "ID of the bucket's project."
                                 },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "description": "ISO 8601 timestamp of the latest worker heartbeat."
-                            },
-                            "startedAt": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
+                                "accountId": {
+                                  "type": "string",
+                                  "description": "ID of the project's account."
                                 },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "description": "ISO 8601 timestamp when processing started."
-                            },
-                            "completedAt": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
+                                "status": {
+                                  "enum": [
+                                    "QUEUED",
+                                    "RUNNING",
+                                    "SUCCEEDED",
+                                    "FAILED"
+                                  ],
+                                  "type": "string",
+                                  "description": "Current job lifecycle state."
                                 },
-                                {
-                                  "type": "null"
+                                "phase": {
+                                  "enum": [
+                                    "DELETING_FILES",
+                                    "ABORTING_UPLOADS",
+                                    "RECONCILING_STORAGE",
+                                    "INVALIDATING_CACHE"
+                                  ],
+                                  "type": "string",
+                                  "description": "Current cleanup phase."
+                                },
+                                "totalCount": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "Number of file records selected for cleanup."
+                                },
+                                "totalBytes": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "Total bytes represented by selected file records."
+                                },
+                                "processedCount": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "Number of file records processed so far."
+                                },
+                                "freedBytes": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "Storage bytes accounted as freed so far."
+                                },
+                                "pendingS3CleanupCount": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "Stored objects still pending deletion."
+                                },
+                                "canceledUploadCount": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "Incomplete uploads canceled by the job."
+                                },
+                                "orphanObjectCount": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "Stored objects found without matching active file records."
+                                },
+                                "orphanBytes": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "Total bytes of orphaned stored objects found."
+                                },
+                                "cloudFrontInvalidationId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "description": "Cache invalidation ID, or null until one is created."
+                                },
+                                "error": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "description": "Failure message, or null when the job has not failed."
+                                },
+                                "heartbeatAt": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "description": "ISO 8601 timestamp of the latest worker heartbeat."
+                                },
+                                "startedAt": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "description": "ISO 8601 timestamp when processing started."
+                                },
+                                "completedAt": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "description": "ISO 8601 timestamp when processing finished."
+                                },
+                                "createdAt": {
+                                  "type": "string",
+                                  "description": "ISO 8601 creation timestamp."
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                  "description": "ISO 8601 last-update timestamp."
                                 }
+                              },
+                              "required": [
+                                "id",
+                                "bucketId",
+                                "projectId",
+                                "accountId",
+                                "status",
+                                "phase",
+                                "totalCount",
+                                "totalBytes",
+                                "processedCount",
+                                "freedBytes",
+                                "pendingS3CleanupCount",
+                                "canceledUploadCount",
+                                "orphanObjectCount",
+                                "orphanBytes",
+                                "cloudFrontInvalidationId",
+                                "error",
+                                "heartbeatAt",
+                                "startedAt",
+                                "completedAt",
+                                "createdAt",
+                                "updatedAt"
                               ],
-                              "description": "ISO 8601 timestamp when processing finished."
+                              "description": "Progress and results for an asynchronous bucket cleanup."
                             },
-                            "createdAt": {
-                              "type": "string",
-                              "description": "ISO 8601 creation timestamp."
-                            },
-                            "updatedAt": {
-                              "type": "string",
-                              "description": "ISO 8601 last-update timestamp."
+                            {
+                              "type": "null"
                             }
-                          },
-                          "required": [
-                            "id",
-                            "bucketId",
-                            "projectId",
-                            "accountId",
-                            "status",
-                            "phase",
-                            "totalCount",
-                            "totalBytes",
-                            "processedCount",
-                            "freedBytes",
-                            "pendingS3CleanupCount",
-                            "canceledUploadCount",
-                            "orphanObjectCount",
-                            "orphanBytes",
-                            "cloudFrontInvalidationId",
-                            "error",
-                            "heartbeatAt",
-                            "startedAt",
-                            "completedAt",
-                            "createdAt",
-                            "updatedAt"
-                          ],
-                          "description": "Progress and results for an asynchronous bucket cleanup."
+                          ]
                         }
                       },
                       "required": [
@@ -5254,9 +5265,6 @@
                     },
                     {
                       "$ref": "#/components/schemas/BucketNotFoundError"
-                    },
-                    {
-                      "$ref": "#/components/schemas/EmptyBucketJobNotFoundError"
                     }
                   ]
                 }
@@ -11361,6 +11369,8 @@
                                     "project:delete",
                                     "bucket:read",
                                     "bucket:write",
+                                    "bucket:delete",
+                                    "bucket:empty",
                                     "file:read",
                                     "file:write",
                                     "project-key:read",
@@ -11642,6 +11652,8 @@
                         "project:delete",
                         "bucket:read",
                         "bucket:write",
+                        "bucket:delete",
+                        "bucket:empty",
                         "file:read",
                         "file:write",
                         "project-key:read",
@@ -11723,6 +11735,8 @@
                                   "project:delete",
                                   "bucket:read",
                                   "bucket:write",
+                                  "bucket:delete",
+                                  "bucket:empty",
                                   "file:read",
                                   "file:write",
                                   "project-key:read",
@@ -12038,6 +12052,8 @@
                                     "project:delete",
                                     "bucket:read",
                                     "bucket:write",
+                                    "bucket:delete",
+                                    "bucket:empty",
                                     "file:read",
                                     "file:write",
                                     "project-key:read",
@@ -12291,6 +12307,8 @@
                         "project:delete",
                         "bucket:read",
                         "bucket:write",
+                        "bucket:delete",
+                        "bucket:empty",
                         "file:read",
                         "file:write",
                         "project-key:read",
@@ -12372,6 +12390,8 @@
                                   "project:delete",
                                   "bucket:read",
                                   "bucket:write",
+                                  "bucket:delete",
+                                  "bucket:empty",
                                   "file:read",
                                   "file:write",
                                   "project-key:read",

--- a/packages/sdk/src/generated/source.ts
+++ b/packages/sdk/src/generated/source.ts
@@ -2,7 +2,7 @@ export const API_V2_SOURCE_REPOSITORY =
   'https://github.com/edgestorejs/edge-store-app' as const;
 
 export const API_V2_SOURCE_COMMIT =
-  '40cd041ed09d6e2f81cdf59d6983944d969b4be5' as const;
+  '70f0dab08e9181fbbe1f4a0e8b9fa4966003bec8' as const;
 
 export const API_V2_SCHEMA_SHA256 =
-  '23098c8a37a5e2c845d4db223de355b2e2cecdef988091e74bfa7ec3835f0ac2' as const;
+  'fd0b03eaf0bce45b704cbb5d7f042809df9ee16213d52a9da97eea003f1bb6c8' as const;

--- a/packages/sdk/src/managementAccessContract.test.ts
+++ b/packages/sdk/src/managementAccessContract.test.ts
@@ -130,11 +130,14 @@ describe('management access request mappings', () => {
           sdk.management.tokens.createAccount({
             account,
             name: 'CI token',
-            scopes: ['project:read'],
+            scopes: ['bucket:delete', 'bucket:empty'],
           }),
         method: 'POST',
         path: `/v2/management/accounts/${account}/tokens`,
-        body: { name: 'CI token', scopes: ['project:read'] },
+        body: {
+          name: 'CI token',
+          scopes: ['bucket:delete', 'bucket:empty'],
+        },
       },
       'v2.management.tokens.listUser': {
         invoke: () => sdk.management.tokens.listUser({ page: 2, pageSize: 10 }),

--- a/packages/sdk/src/managementResources.test.ts
+++ b/packages/sdk/src/managementResources.test.ts
@@ -84,4 +84,23 @@ describe('management resources', () => {
       sdk.management.projects.delete({ project: 'project-id' }),
     ).resolves.toEqual({});
   });
+
+  it('returns null when a bucket has no empty-bucket job', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      expect(request.url).toBe(
+        'https://example.com/v2/management/projects/project-id/buckets/documents/empty-job',
+      );
+      return Response.json({ data: { job: null } });
+    });
+    const sdk = createManagementSdk(fetch);
+
+    const result = await sdk.management.buckets.emptyJobs.latest({
+      project: 'project-id',
+      bucket: 'documents',
+    });
+
+    expect(result).toEqual({ job: null });
+    expectTypeOf<null>().toMatchTypeOf<typeof result.job>();
+  });
 });

--- a/packages/sdk/src/managementResources.ts
+++ b/packages/sdk/src/managementResources.ts
@@ -85,7 +85,7 @@ export type ManagementResourceClient = {
       input: BucketInput & CallOptions,
     ): Promise<Result<'v2.management.buckets.empty'>>;
     emptyJobs: {
-      /** Gets the latest empty-bucket job. */
+      /** Gets the latest empty-bucket job, or `null` when no job exists. */
       latest(
         input: BucketInput & CallOptions,
       ): Promise<Result<'v2.management.buckets.emptyJobs.latest'>>;


### PR DESCRIPTION
## Summary

- pin the SDK contract to edge-store-app PR 252 at commit 70f0dab08e9181fbbe1f4a0e8b9fa4966003bec8
- regenerate the OpenAPI schema, TypeScript contract, and generated TSDoc
- add the bucket delete/empty scopes and nullable latest empty-job response to contract coverage

## Verification

- SDK codegen check, typecheck, tests, lint, and build
- full stack build, tests, type tests, lint, format check, and docs build

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
