### PR TITLE
[SDK 12] refactor: clarify SDK Bearer configuration

### DIFF
--- a/.changeset/clarify-sdk-bearer-configuration.md
+++ b/.changeset/clarify-sdk-bearer-configuration.md
@@ -1,0 +1,5 @@
+---
+"@edgestore/sdk": major
+---
+
+Rename management credentials to Bearer credentials and use `apiUrl` for API configuration.

--- a/packages/sdk/src/credentials.test.ts
+++ b/packages/sdk/src/credentials.test.ts
@@ -14,7 +14,7 @@ describe('getAuthorizationHeader', () => {
     ).toBe('Basic cHJvamVjdDpzZWNyZXQ=');
   });
 
-  it('encodes management credentials as Bearer authentication', () => {
+  it('encodes Bearer credentials as Bearer authentication', () => {
     expect(
       getAuthorizationHeader(
         classifyCredentials({ token: 'management-token' }),

--- a/packages/sdk/src/credentials.ts
+++ b/packages/sdk/src/credentials.ts
@@ -7,20 +7,20 @@ export type ProjectCredentials = {
   token?: never;
 };
 
-/** Management token used by administrative API clients. */
-export type ManagementCredentials = {
-  /** Account- or user-owned management token. */
+/** Bearer token used by management API clients. */
+export type BearerCredentials = {
+  /** Account- or user-owned EdgeStore management token. */
   token: string;
   accessKey?: never;
   secretKey?: never;
 };
 
 /** Credentials accepted by {@link createEdgeStoreSdk}. */
-export type EdgeStoreCredentials = ProjectCredentials | ManagementCredentials;
+export type EdgeStoreCredentials = ProjectCredentials | BearerCredentials;
 
 export type ClassifiedCredentials =
   | ({ kind: 'project' } & ProjectCredentials)
-  | ({ kind: 'management' } & ManagementCredentials);
+  | ({ kind: 'bearer' } & BearerCredentials);
 
 export function classifyCredentials(
   credentials: EdgeStoreCredentials,
@@ -33,11 +33,11 @@ export function classifyCredentials(
   if (token !== undefined) {
     if (accessKey !== undefined || secretKey !== undefined) {
       throw new TypeError(
-        'EdgeStore credentials cannot contain both a management token and project keys.',
+        'EdgeStore credentials cannot contain both a Bearer token and project keys.',
       );
     }
     assertCredential(token, 'token');
-    return { kind: 'management', token };
+    return { kind: 'bearer', token };
   }
 
   assertCredential(accessKey, 'accessKey');
@@ -48,7 +48,7 @@ export function classifyCredentials(
 export function getAuthorizationHeader(
   credentials: ClassifiedCredentials,
 ): string {
-  if (credentials.kind === 'management') {
+  if (credentials.kind === 'bearer') {
     return `Bearer ${credentials.token}`;
   }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,6 @@
 export type {
+  BearerCredentials,
   EdgeStoreCredentials,
-  ManagementCredentials,
   ProjectCredentials,
 } from './credentials';
 export {

--- a/packages/sdk/src/internal/transport.test.ts
+++ b/packages/sdk/src/internal/transport.test.ts
@@ -20,7 +20,7 @@ describe('createTransport', () => {
         accessKey: 'project',
         secretKey: 'secret',
       }),
-      baseUrl: 'https://example.com/v2/',
+      apiUrl: 'https://example.com/v2/',
       fetch,
     });
 

--- a/packages/sdk/src/internal/transport.ts
+++ b/packages/sdk/src/internal/transport.ts
@@ -20,7 +20,7 @@ export const DEFAULT_CONTROL_TIMEOUT_MS = 30_000;
 
 export type TransportOptions = {
   credentials: ClassifiedCredentials;
-  baseUrl?: string;
+  apiUrl?: string;
   fetch?: typeof globalThis.fetch;
   controlTimeoutMs?: number;
 };
@@ -54,7 +54,7 @@ export function createTransport(options: TransportOptions): Transport {
     throw new RangeError('controlTimeoutMs must be a non-negative number.');
   }
   const client = createClient<paths>({
-    baseUrl: normalizeBaseUrl(options.baseUrl ?? DEFAULT_API_URL),
+    baseUrl: normalizeApiUrl(options.apiUrl ?? DEFAULT_API_URL),
     fetch: (request) =>
       fetch(
         new Request(request, {
@@ -115,8 +115,8 @@ function unwrapData<TBody>(body: TBody | undefined): ApiData<TBody> {
   return body as ApiData<TBody>;
 }
 
-function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, '');
+function normalizeApiUrl(apiUrl: string): string {
+  return apiUrl.replace(/\/+$/, '');
 }
 
 function createApiError(response: Response, body: unknown): EdgeStoreApiError {

--- a/packages/sdk/src/managementAccess.test.ts
+++ b/packages/sdk/src/managementAccess.test.ts
@@ -18,7 +18,7 @@ describe('management access resources', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { token: 'management-token' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
 
@@ -41,7 +41,7 @@ describe('management access resources', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { token: 'management-token' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
 

--- a/packages/sdk/src/managementAccessContract.test.ts
+++ b/packages/sdk/src/managementAccessContract.test.ts
@@ -18,7 +18,7 @@ describe('management access request mappings', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { token: 'management-token' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
     const account = 'account-id';

--- a/packages/sdk/src/managementClient.ts
+++ b/packages/sdk/src/managementClient.ts
@@ -9,7 +9,7 @@ import {
   type ManagementResourceClient,
 } from './managementResources';
 
-/** Complete administrative client available to management credentials. */
+/** Complete administrative client available to Bearer credentials. */
 export type ManagementClient = ManagementResourceClient &
   ManagementAccessClient & {
     /** Describes the identity represented by the management credential. */

--- a/packages/sdk/src/managementContract.test.ts
+++ b/packages/sdk/src/managementContract.test.ts
@@ -10,7 +10,7 @@ describe('management resource request mappings', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { token: 'management-token' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
     const project = 'project-id';

--- a/packages/sdk/src/managementResources.test.ts
+++ b/packages/sdk/src/managementResources.test.ts
@@ -5,7 +5,7 @@ import { createEdgeStoreSdk } from './sdk';
 function createManagementSdk(fetch: typeof globalThis.fetch) {
   return createEdgeStoreSdk({
     credentials: { token: 'management-token' },
-    baseUrl: 'https://example.com/v2',
+    apiUrl: 'https://example.com/v2',
     fetch,
   });
 }

--- a/packages/sdk/src/runtimeContract.test.ts
+++ b/packages/sdk/src/runtimeContract.test.ts
@@ -18,7 +18,7 @@ describe('runtime request mappings', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { accessKey: 'project', secretKey: 'secret' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
     const mutationBody = {

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -34,7 +34,7 @@ describe('createEdgeStoreSdk', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { accessKey: 'project', secretKey: 'secret' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
 
@@ -48,7 +48,7 @@ describe('createEdgeStoreSdk', () => {
       .toEqualTypeOf<RuntimeCallOptions | undefined>();
   });
 
-  it('requires an explicit project for management credentials', async () => {
+  it('requires an explicit project for Bearer credentials', async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
       const request = input instanceof Request ? input : new Request(input);
       expect(request.url).toBe(
@@ -61,7 +61,7 @@ describe('createEdgeStoreSdk', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { token: 'management-token' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
 
@@ -99,7 +99,7 @@ describe('createEdgeStoreSdk', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { accessKey: 'project', secretKey: 'secret' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
 
@@ -155,7 +155,7 @@ describe('createEdgeStoreSdk', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { accessKey: 'project', secretKey: 'secret' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
 

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -1,6 +1,6 @@
 import type {
+  BearerCredentials,
   EdgeStoreCredentials,
-  ManagementCredentials,
   ProjectCredentials,
 } from './credentials';
 import { classifyCredentials } from './credentials';
@@ -18,14 +18,14 @@ import {
 import { createSystemClient, type SystemClient } from './system';
 import type { UploadDefaults } from './uploadTypes';
 
-/** Configuration shared by project- and management-credential SDK clients. */
+/** Configuration shared by project- and Bearer-credential SDK clients. */
 export type EdgeStoreSdkOptions<
   TCredentials extends EdgeStoreCredentials = EdgeStoreCredentials,
 > = {
   /** Credentials that determine which SDK resources are available. */
   credentials: TCredentials;
-  /** EdgeStore API base URL. Defaults to the hosted API v2 endpoint. */
-  baseUrl?: string;
+  /** Complete EdgeStore API v2 URL. Defaults to the hosted API endpoint. */
+  apiUrl?: string;
   /** Fetch implementation used for API requests and upload transfers. */
   fetch?: typeof globalThis.fetch;
   /** Defaults used by the high-level upload helpers. */
@@ -65,7 +65,7 @@ export function createEdgeStoreSdk(
   options: EdgeStoreSdkOptions<ProjectCredentials>,
 ): ProjectEdgeStoreSdk;
 export function createEdgeStoreSdk(
-  options: EdgeStoreSdkOptions<ManagementCredentials>,
+  options: EdgeStoreSdkOptions<BearerCredentials>,
 ): ManagementEdgeStoreSdk;
 export function createEdgeStoreSdk(
   options: EdgeStoreSdkOptions<EdgeStoreCredentials>,
@@ -77,7 +77,7 @@ export function createEdgeStoreSdk(
   const transport = createTransport({ ...options, credentials });
   const system = createSystemClient(transport);
 
-  return credentials.kind === 'management'
+  return credentials.kind === 'bearer'
     ? {
         runtime: createExplicitProjectRuntimeClient(transport, options.upload),
         management: createManagementClient(transport),

--- a/packages/sdk/src/system.test.ts
+++ b/packages/sdk/src/system.test.ts
@@ -11,7 +11,7 @@ describe('system resources', () => {
     });
     const sdk = createEdgeStoreSdk({
       credentials: { accessKey: 'project', secretKey: 'secret' },
-      baseUrl: 'https://example.com/v2',
+      apiUrl: 'https://example.com/v2',
       fetch,
     });
     await expect(sdk.system.health()).resolves.toEqual({

--- a/packages/sdk/src/upload.test.ts
+++ b/packages/sdk/src/upload.test.ts
@@ -9,7 +9,7 @@ import { MIN_MULTIPART_PART_SIZE_BYTES } from './uploadTypes';
 function createSdk(fetch: typeof globalThis.fetch) {
   return createEdgeStoreSdk({
     credentials: { accessKey: 'project', secretKey: 'secret' },
-    baseUrl: 'https://api.example/v2',
+    apiUrl: 'https://api.example/v2',
     fetch,
   });
 }

--- a/packages/server/src/providers/edgestore/index.ts
+++ b/packages/server/src/providers/edgestore/index.ts
@@ -66,7 +66,7 @@ export function edgestore(options?: EdgeStoreProviderOptions) {
 
   const sdk = createEdgeStoreSdk({
     credentials: { accessKey, secretKey },
-    baseUrl: options?.apiUrl ?? getApiUrl(),
+    apiUrl: options?.apiUrl ?? getApiUrl(),
   });
 
   const provider = defineProvider({


### PR DESCRIPTION
## Summary

- rename the public token credential type to BearerCredentials and use bearer as the internal discriminator
- rename the SDK endpoint option from baseUrl to apiUrl
- define apiUrl as the complete API v2 URL without implicit path appending

## Verification

- SDK typecheck, tests, lint, codegen check, and build
- full stack build, tests, type tests, lint, format check, and docs build

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
