### PR TITLE
[SDK 13] feat: add project-scoped runtime clients

### DIFF
--- a/.changeset/add-sdk-project-scoping.md
+++ b/.changeset/add-sdk-project-scoping.md
@@ -1,0 +1,5 @@
+---
+'@edgestore/sdk': minor
+---
+
+Add `runtime.forProject(project)` for eagerly scoped Bearer-authenticated runtime clients.

--- a/packages/sdk/src/runtime.ts
+++ b/packages/sdk/src/runtime.ts
@@ -245,13 +245,39 @@ export type RuntimeClient<TMode extends ProjectMode> = {
 
 /** Runtime client scoped to the project credential's current project. */
 export type ProjectRuntimeClient = RuntimeClient<'current'>;
-/** Runtime client whose calls require an explicit project ID or slug. */
-export type ExplicitProjectRuntimeClient = RuntimeClient<'explicit'>;
+/**
+ * Runtime client whose calls either require a project or can be scoped once
+ * with {@link ExplicitProjectRuntimeClient.forProject}.
+ */
+export type ExplicitProjectRuntimeClient = ProjectOperationTree<
+  RuntimeClient<'explicit'>
+> & {
+  /** Creates an eagerly built runtime client scoped to one project. */
+  forProject(project: string): ProjectRuntimeClient;
+};
 
 export function createExplicitProjectRuntimeClient(
   transport: Transport,
   uploadDefaults?: UploadDefaults,
-): ProjectOperationTree<ExplicitProjectRuntimeClient> {
+): ExplicitProjectRuntimeClient {
+  const operations = createExplicitProjectRuntimeOperations(
+    transport,
+    uploadDefaults,
+  );
+
+  return {
+    ...operations,
+    forProject: (project) => {
+      assertProject(project);
+      return scopeProjectOperations(operations, project);
+    },
+  };
+}
+
+function createExplicitProjectRuntimeOperations(
+  transport: Transport,
+  uploadDefaults?: UploadDefaults,
+): ProjectOperationTree<RuntimeClient<'explicit'>> {
   const operations = createRuntimeOperations(transport);
   const uploadContext = { transport, operations };
 
@@ -272,9 +298,15 @@ export function createProjectRuntimeClient(
   uploadDefaults?: UploadDefaults,
 ): ProjectRuntimeClient {
   return scopeProjectOperations(
-    createExplicitProjectRuntimeClient(transport, uploadDefaults),
+    createExplicitProjectRuntimeOperations(transport, uploadDefaults),
     '_current',
   );
+}
+
+function assertProject(project: string): void {
+  if (typeof project !== 'string' || !project.trim()) {
+    throw new TypeError('EdgeStore project must not be empty.');
+  }
 }
 
 export type { RuntimeOperations };

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import type { EdgeStoreCredentials } from './credentials';
 import { EdgeStoreFileMutationError } from './errors';
-import type { RuntimeCallOptions } from './runtime';
+import type { RuntimeBucketGetInput, RuntimeCallOptions } from './runtime';
 import {
   createEdgeStoreSdk,
   type ManagementEdgeStoreSdk,
@@ -75,6 +75,43 @@ describe('createEdgeStoreSdk', () => {
     expectTypeOf<ProjectGet>().parameter(0).toMatchTypeOf<{
       project: string;
     }>();
+  });
+
+  it('scopes Bearer runtime operations to one project', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      expect(request.url).toBe(
+        'https://example.com/v2/runtime/projects/project-id/buckets/documents',
+      );
+      expect(request.headers.get('authorization')).toBe(
+        'Bearer management-token',
+      );
+      return Response.json({ data: { bucket: { name: 'documents' } } });
+    });
+    const sdk = createEdgeStoreSdk({
+      credentials: { token: 'management-token' },
+      apiUrl: 'https://example.com/v2',
+      fetch,
+    });
+
+    const runtime = sdk.runtime.forProject('project-id');
+    const result = await runtime.buckets.get({ bucket: 'documents' });
+
+    expect(result.bucket.name).toBe('documents');
+    expectTypeOf(runtime).toEqualTypeOf<ProjectEdgeStoreSdk['runtime']>();
+    expectTypeOf<typeof runtime.buckets.get>()
+      .parameter(0)
+      .toEqualTypeOf<RuntimeBucketGetInput & { project?: never }>();
+  });
+
+  it('rejects an empty project when scoping Bearer runtime operations', () => {
+    const sdk = createEdgeStoreSdk({
+      credentials: { token: 'management-token' },
+    });
+
+    expect(() => sdk.runtime.forProject('  ')).toThrow(
+      'EdgeStore project must not be empty.',
+    );
   });
 
   it('maps upload request fields to the API contract', async () => {


### PR DESCRIPTION
## Summary

- add runtime.forProject(project) to Bearer-authenticated SDK clients
- eagerly construct a plain project-scoped runtime object while retaining explicit project operations
- remove project from scoped operation inputs and reject empty selectors

## Verification

- runtime URL, authorization, validation, and type-level tests
- SDK typecheck, tests, lint, codegen check, and build
- full stack build, tests, type tests, lint, format check, and docs build

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
