### PR TITLE
[SDK 15] docs: document management-token SDK usage

### DIFF
--- a/docs/content/docs/(getting-started)/sdk.mdx
+++ b/docs/content/docs/(getting-started)/sdk.mdx
@@ -113,8 +113,9 @@ an item failure; plural mutations return the complete partial result.
 
 ## Management client
 
-Management credentials require an explicit project selector for runtime calls
-and also expose account, project, credential, token, and membership resources.
+A management token uses Bearer authentication and exposes account, project,
+credential, token, and membership resources. Runtime calls can select a
+project per operation or create an eagerly scoped runtime client once.
 
 ```ts
 const management = createEdgeStoreSdk({
@@ -127,8 +128,12 @@ const projects = await management.management.projects.list({
   account: 'account-id',
 });
 
-const buckets = await management.runtime.buckets.list({
-  project: projects.projects[0]!.id,
+const project = management.runtime.forProject(projects.projects[0]!.id);
+const buckets = await project.buckets.list();
+
+// An explicit selector remains useful for one-off calls.
+const anotherProject = await management.runtime.projects.get({
+  project: 'another-project-id',
 });
 
 const { accessUrls } =
@@ -202,13 +207,16 @@ timeout errors have dedicated classes.
 
 ## Custom environments
 
-Use `baseUrl` for a compatible API v2 deployment and `fetch` to provide a
+Use `apiUrl` for a compatible API v2 deployment and `fetch` to provide a
 custom server-side transport implementation.
 
 ```ts
 const sdk = createEdgeStoreSdk({
   credentials: { accessKey, secretKey },
-  baseUrl: 'https://api.example.com/v2',
+  apiUrl: 'https://api.example.com/v2',
   fetch: instrumentedFetch,
 });
 ```
+
+`apiUrl` is the complete v2 URL. The SDK does not append `/v2` to an explicit
+value.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -29,8 +29,20 @@ const result = await sdk.runtime.uploads.upload({
 ```
 
 Project credentials expose runtime resources for their current project.
-Management tokens expose management resources and runtime calls with an
-explicit `project` selector.
+Management tokens expose management resources and runtime calls that can use
+an explicit `project` selector or an eagerly scoped client:
+
+```ts
+const management = createEdgeStoreSdk({
+  credentials: { token: process.env.EDGE_STORE_MANAGEMENT_TOKEN! },
+});
+
+const project = management.runtime.forProject('project-id');
+const files = await project.files.search({ bucket: 'documents' });
+```
+
+Use `apiUrl` when targeting a compatible API v2 deployment. Its value is the
+complete v2 URL, such as `https://api.example.com/v2`.
 
 Use `runtime.files.generateSignedReadUrls` for protected runtime reads and
 `management.files.generateAccessUrls` when management code needs readable URLs


### PR DESCRIPTION
## Summary

- document management-token SDK construction and project-scoped runtime usage
- show explicit project selectors for one-off runtime calls
- document apiUrl as the complete v2 endpoint
- keep internal dashboard session-token behavior out of public documentation

## Verification

- Prettier formatting
- production docs build
- full stack build, typecheck, tests, type tests, lint, and format check

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
