### PR TITLE
refactor: align multipart planning and provider file responses

### DIFF
--- a/.changeset/introduce-api-v2-sdk.md
+++ b/.changeset/introduce-api-v2-sdk.md
@@ -6,6 +6,7 @@ Introduce the supported, server-only EdgeStore API v2 SDK. The SDK exposes
 resource-oriented runtime, management, and system clients; project and Bearer
 credentials; explicit management project scoping; cursor pagination; typed
 errors; and a complete upload workflow for local, streaming, multipart, and
-remote URL sources. Its public documentation is derived from the pinned
-OpenAPI contract, and the published package includes its TypeScript sources for
-editor navigation.
+remote URL sources. A public multipart planner applies the same upload
+thresholds, part sizing, and limits across SDK and provider integrations. Its
+public documentation is derived from the pinned OpenAPI contract, and the
+published package includes its TypeScript sources for editor navigation.

--- a/.changeset/redesign-provider-backend-client.md
+++ b/.changeset/redesign-provider-backend-client.md
@@ -12,9 +12,12 @@ eagerly created, type-safe backend client through `.client`.
 Providers now use the resource-oriented `EdgeStoreProvider` contract and the
 public `defineProvider` helper. File references, cursors, capabilities, inputs,
 and results are inferred from each provider definition, and unsupported
-backend methods remain absent. The hosted `edgestore()` provider uses the new
-API v2 SDK and supports project credentials or a Bearer token with an explicit
-project. Direct storage providers are exposed as `s3()` and `azureBlob()`.
+backend methods remain absent. Provider `get` and `list` operations can return
+router path and metadata fields independently; their presence and optionality
+are reflected in the generated backend client. The hosted `edgestore()`
+provider uses the new API v2 SDK and supports project credentials or a Bearer
+token with an explicit project. Direct storage providers are exposed as `s3()`
+and `azureBlob()`.
 
 Backend and React lifecycle methods use singular names with `Many` batch
 variants. Batch mutations preserve per-file failures, frontend deletion

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -15,6 +15,11 @@ export {
 } from './errors';
 export type { ManagementClient } from './managementClient';
 export {
+  planMultipartUpload,
+  type MultipartUploadPlan,
+  type MultipartUploadPlanOptions,
+} from './multipartPlan';
+export {
   createEdgeStoreSdk,
   type EdgeStoreSdkOptions,
   type ManagementEdgeStoreSdk,

--- a/packages/sdk/src/multipartPlan.test.ts
+++ b/packages/sdk/src/multipartPlan.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { planMultipartUpload } from './multipartPlan';
+import {
+  DEFAULT_MULTIPART_PART_SIZE_BYTES,
+  DEFAULT_MULTIPART_THRESHOLD_BYTES,
+  MAX_MULTIPART_PARTS,
+  MIN_MULTIPART_PART_SIZE_BYTES,
+} from './uploadTypes';
+
+describe('planMultipartUpload', () => {
+  it('selects single or multipart upload at the canonical threshold', () => {
+    expect(
+      planMultipartUpload({ sizeBytes: DEFAULT_MULTIPART_THRESHOLD_BYTES }),
+    ).toBeNull();
+
+    expect(
+      planMultipartUpload({ sizeBytes: DEFAULT_MULTIPART_THRESHOLD_BYTES + 1 }),
+    ).toEqual({
+      partSizeBytes: DEFAULT_MULTIPART_PART_SIZE_BYTES,
+      totalParts: 7,
+      partNumbers: [1, 2, 3, 4, 5, 6, 7],
+    });
+  });
+
+  it('enforces multipart geometry and input constraints', () => {
+    const plan = planMultipartUpload({
+      sizeBytes: DEFAULT_MULTIPART_PART_SIZE_BYTES * MAX_MULTIPART_PARTS + 1,
+      forceMultipart: true,
+    });
+
+    expect(plan).not.toBeNull();
+    if (!plan) throw new Error('Expected a multipart upload plan.');
+    expect(plan.partSizeBytes).toBeGreaterThan(
+      DEFAULT_MULTIPART_PART_SIZE_BYTES,
+    );
+    expect(plan.totalParts).toBeLessThanOrEqual(MAX_MULTIPART_PARTS);
+    expect(plan.partNumbers).toHaveLength(plan.totalParts);
+
+    expect(() =>
+      planMultipartUpload({
+        sizeBytes: 1,
+        preferredPartSizeBytes: MIN_MULTIPART_PART_SIZE_BYTES - 1,
+        forceMultipart: true,
+      }),
+    ).toThrow('preferredPartSizeBytes must be at least');
+  });
+});

--- a/packages/sdk/src/multipartPlan.ts
+++ b/packages/sdk/src/multipartPlan.ts
@@ -1,0 +1,70 @@
+import {
+  assertNonNegative,
+  getPositiveInteger,
+} from './internal/uploadValidation';
+import {
+  DEFAULT_MULTIPART_PART_SIZE_BYTES,
+  DEFAULT_MULTIPART_THRESHOLD_BYTES,
+  MAX_MULTIPART_PARTS,
+  MIN_MULTIPART_PART_SIZE_BYTES,
+} from './uploadTypes';
+
+/** Inputs used to decide whether and how to split an upload into parts. */
+export type MultipartUploadPlanOptions = {
+  /** Exact number of bytes in the upload source. */
+  sizeBytes: number;
+  /** Size above which multipart upload is selected automatically. */
+  thresholdBytes?: number;
+  /** Preferred size of each part before enforcing the maximum part count. */
+  preferredPartSizeBytes?: number;
+  /** Select multipart upload regardless of the threshold. */
+  forceMultipart?: boolean;
+};
+
+/** Resolved multipart transfer geometry. */
+export type MultipartUploadPlan = {
+  /** Final part size after enforcing the maximum part count. */
+  partSizeBytes: number;
+  /** Number of parts required to transfer the source. */
+  totalParts: number;
+  /** One-based part numbers to request from EdgeStore. */
+  partNumbers: number[];
+};
+
+/**
+ * Plans a multipart upload using EdgeStore's canonical thresholds and limits.
+ *
+ * Returns `null` when the source should use a single upload.
+ */
+export function planMultipartUpload({
+  sizeBytes,
+  thresholdBytes = DEFAULT_MULTIPART_THRESHOLD_BYTES,
+  preferredPartSizeBytes,
+  forceMultipart = false,
+}: MultipartUploadPlanOptions): MultipartUploadPlan | null {
+  assertNonNegative(sizeBytes, 'sizeBytes');
+  assertNonNegative(thresholdBytes, 'thresholdBytes');
+  const requestedPartSizeBytes = getPositiveInteger(
+    preferredPartSizeBytes,
+    DEFAULT_MULTIPART_PART_SIZE_BYTES,
+    'preferredPartSizeBytes',
+  );
+  if (requestedPartSizeBytes < MIN_MULTIPART_PART_SIZE_BYTES) {
+    throw new RangeError(
+      `preferredPartSizeBytes must be at least ${MIN_MULTIPART_PART_SIZE_BYTES} bytes (5 MiB).`,
+    );
+  }
+  if (!forceMultipart && sizeBytes <= thresholdBytes) return null;
+
+  const partSizeBytes = Math.max(
+    requestedPartSizeBytes,
+    Math.ceil(sizeBytes / MAX_MULTIPART_PARTS),
+  );
+  const totalParts = Math.max(1, Math.ceil(sizeBytes / partSizeBytes));
+
+  return {
+    partSizeBytes,
+    totalParts,
+    partNumbers: Array.from({ length: totalParts }, (_, index) => index + 1),
+  };
+}

--- a/packages/sdk/src/upload.test.ts
+++ b/packages/sdk/src/upload.test.ts
@@ -515,7 +515,7 @@ describe('runtime upload orchestration', () => {
         multipart: { partSizeBytes: MIN_MULTIPART_PART_SIZE_BYTES - 1 },
       }),
     ).rejects.toThrow(
-      `multipart.partSizeBytes must be at least ${MIN_MULTIPART_PART_SIZE_BYTES} bytes (5 MiB).`,
+      `preferredPartSizeBytes must be at least ${MIN_MULTIPART_PART_SIZE_BYTES} bytes (5 MiB).`,
     );
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/packages/sdk/src/upload.ts
+++ b/packages/sdk/src/upload.ts
@@ -22,13 +22,10 @@ import {
   assertNonNegative,
   getPositiveInteger,
 } from './internal/uploadValidation';
+import { planMultipartUpload } from './multipartPlan';
 import {
   DEFAULT_MULTIPART_CONCURRENCY,
-  DEFAULT_MULTIPART_PART_SIZE_BYTES,
-  DEFAULT_MULTIPART_THRESHOLD_BYTES,
   DEFAULT_PROCESSING_TIMEOUT_MS,
-  MAX_MULTIPART_PARTS,
-  MIN_MULTIPART_PART_SIZE_BYTES,
   type CompletedUpload,
   type RuntimeUploadFromUrlInput,
   type RuntimeUploadInput,
@@ -87,9 +84,6 @@ export async function uploadRuntimeFile(
   const prepared = prepareSource(source);
   const totalBytes = prepared.sizeBytes;
   assertNonNegative(processingTimeoutMs, 'processingTimeoutMs');
-  const multipartThresholdBytes =
-    defaults.multipartThresholdBytes ?? DEFAULT_MULTIPART_THRESHOLD_BYTES;
-  assertNonNegative(multipartThresholdBytes, 'upload.multipartThresholdBytes');
 
   throwIfAborted(signal);
   reportProgress(onProgress, {
@@ -98,39 +92,25 @@ export async function uploadRuntimeFile(
     phase: 'preparing',
   });
 
-  const requestedPartSizeBytes = getPositiveInteger(
-    typeof multipart === 'object'
-      ? multipart.partSizeBytes
-      : defaults.multipartPartSizeBytes,
-    defaults.multipartPartSizeBytes ?? DEFAULT_MULTIPART_PART_SIZE_BYTES,
-    'multipart.partSizeBytes',
-  );
-  if (requestedPartSizeBytes < MIN_MULTIPART_PART_SIZE_BYTES) {
-    throw new RangeError(
-      `multipart.partSizeBytes must be at least ${MIN_MULTIPART_PART_SIZE_BYTES} bytes (5 MiB).`,
-    );
-  }
-  const partSizeBytes = Math.max(
-    requestedPartSizeBytes,
-    Math.ceil(totalBytes / MAX_MULTIPART_PARTS),
-  );
-  const useMultipart =
-    prepared.kind === 'stream' ||
-    multipart === true ||
-    typeof multipart === 'object' ||
-    totalBytes > multipartThresholdBytes;
+  const multipartPlan = planMultipartUpload({
+    sizeBytes: totalBytes,
+    thresholdBytes: defaults.multipartThresholdBytes,
+    preferredPartSizeBytes:
+      typeof multipart === 'object'
+        ? (multipart.partSizeBytes ?? defaults.multipartPartSizeBytes)
+        : defaults.multipartPartSizeBytes,
+    forceMultipart:
+      prepared.kind === 'stream' ||
+      multipart === true ||
+      typeof multipart === 'object',
+  });
 
   const bucketResult = await operations.buckets.get({
     project,
     bucket,
     signal,
   });
-  const partNumbers = useMultipart
-    ? Array.from(
-        { length: Math.max(1, Math.ceil(totalBytes / partSizeBytes)) },
-        (_, index) => index + 1,
-      )
-    : undefined;
+  const partNumbers = multipartPlan?.partNumbers;
 
   const requested = await operations.uploads.request({
     project,
@@ -176,6 +156,11 @@ export async function uploadRuntimeFile(
           'The API returned a single upload URL for a stream source.',
         );
       }
+      if (!multipartPlan) {
+        throw new TypeError(
+          'The API returned a multipart upload for a single-upload request.',
+        );
+      }
       const concurrency = getPositiveInteger(
         typeof multipart === 'object'
           ? multipart.concurrency
@@ -186,7 +171,7 @@ export async function uploadRuntimeFile(
       const transferOptions = {
         uploadId,
         parts: requested.upload.parts,
-        partSizeBytes,
+        partSizeBytes: multipartPlan.partSizeBytes,
         signal,
         onProgress,
       };

--- a/packages/server/src/adapters/shared.lifecycle.test.ts
+++ b/packages/server/src/adapters/shared.lifecycle.test.ts
@@ -128,6 +128,36 @@ describe('frontend file mutations', () => {
     expect(provider.files.delete).not.toHaveBeenCalled();
   });
 
+  it('requires stored router fields for frontend deletion authorization', async () => {
+    const beforeDelete = vi.fn(() => true);
+    const es = initEdgeStore.create();
+    const router = es.router({
+      documents: es.fileBucket().beforeDelete(beforeDelete),
+    });
+    const provider = createProvider();
+    const ctxToken = await createContextToken({ router, ctx: {} });
+    vi.mocked(provider.files.get!).mockResolvedValue({
+      url: originalUrls[0]!,
+      sizeBytes: 10,
+      uploadedAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(
+      deleteFiles({
+        provider,
+        router,
+        ctxToken,
+        body: { bucketName: 'documents', urls: [proxiedUrls[0]!] },
+        logger,
+      }),
+    ).rejects.toThrow(
+      'Provider test-provider must return path and metadata from files.get to authorize frontend deletion.',
+    );
+    expect(beforeDelete).not.toHaveBeenCalled();
+    expect(provider.files.delete).not.toHaveBeenCalled();
+  });
+
   it('authorizes every file before attempting a batch delete', async () => {
     const beforeDelete = vi
       .fn()

--- a/packages/server/src/adapters/shared.lifecycle.test.ts
+++ b/packages/server/src/adapters/shared.lifecycle.test.ts
@@ -128,7 +128,7 @@ describe('frontend file mutations', () => {
     expect(provider.files.delete).not.toHaveBeenCalled();
   });
 
-  it('requires stored router fields for frontend deletion authorization', async () => {
+  it('uses empty router fields when none are configured', async () => {
     const beforeDelete = vi.fn(() => true);
     const es = initEdgeStore.create();
     const router = es.router({
@@ -151,8 +151,87 @@ describe('frontend file mutations', () => {
         body: { bucketName: 'documents', urls: [proxiedUrls[0]!] },
         logger,
       }),
+    ).resolves.toEqual({ succeeded: [proxiedUrls[0]], failed: [] });
+    expect(beforeDelete).toHaveBeenCalledWith({
+      ctx: {},
+      fileInfo: {
+        url: originalUrls[0],
+        size: 10,
+        uploadedAt: expect.any(Date),
+        path: {},
+        metadata: {},
+      },
+    });
+    expect(provider.files.delete).toHaveBeenCalledOnce();
+  });
+
+  it('requires stored path when the router configures path fields', async () => {
+    const beforeDelete = vi.fn(() => true);
+    const es = initEdgeStore.context<{ userId: string }>().create();
+    const router = es.router({
+      documents: es
+        .fileBucket()
+        .path(({ ctx }) => [{ author: ctx.userId }])
+        .beforeDelete(beforeDelete),
+    });
+    const provider = createProvider();
+    const ctxToken = await createContextToken({
+      router,
+      ctx: { userId: 'user-1' },
+    });
+    vi.mocked(provider.files.get!).mockResolvedValue({
+      url: originalUrls[0]!,
+      sizeBytes: 10,
+      uploadedAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(
+      deleteFiles({
+        provider,
+        router,
+        ctxToken,
+        body: { bucketName: 'documents', urls: [proxiedUrls[0]!] },
+        logger,
+      }),
     ).rejects.toThrow(
-      'Provider test-provider must return path and metadata from files.get to authorize frontend deletion.',
+      'Provider test-provider must return path from files.get to authorize frontend deletion for a bucket with configured path fields.',
+    );
+    expect(beforeDelete).not.toHaveBeenCalled();
+    expect(provider.files.delete).not.toHaveBeenCalled();
+  });
+
+  it('requires stored metadata when the router configures metadata fields', async () => {
+    const beforeDelete = vi.fn(() => true);
+    const es = initEdgeStore.context<{ userId: string }>().create();
+    const router = es.router({
+      documents: es
+        .fileBucket()
+        .metadata(({ ctx }) => ({ author: ctx.userId }))
+        .beforeDelete(beforeDelete),
+    });
+    const provider = createProvider();
+    const ctxToken = await createContextToken({
+      router,
+      ctx: { userId: 'user-1' },
+    });
+    vi.mocked(provider.files.get!).mockResolvedValue({
+      url: originalUrls[0]!,
+      sizeBytes: 10,
+      uploadedAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(
+      deleteFiles({
+        provider,
+        router,
+        ctxToken,
+        body: { bucketName: 'documents', urls: [proxiedUrls[0]!] },
+        logger,
+      }),
+    ).rejects.toThrow(
+      'Provider test-provider must return metadata from files.get to authorize frontend deletion for a bucket with configured metadata fields.',
     );
     expect(beforeDelete).not.toHaveBeenCalled();
     expect(provider.files.delete).not.toHaveBeenCalled();

--- a/packages/server/src/adapters/shared.ts
+++ b/packages/server/src/adapters/shared.ts
@@ -293,10 +293,11 @@ export async function requestUpload<TCtx extends AnyContext>(params: {
     bucket,
     pathAttrs: { ctx, input: parsedInput },
   });
-  const metadata = await bucket._def.metadata?.({
-    ctx,
-    input: parsedInput,
-  });
+  const metadata =
+    (await bucket._def.metadata?.({
+      ctx,
+      input: parsedInput,
+    })) ?? {};
   const isPublic = bucket._def.accessControl === undefined;
   const autoSignedUrls = bucket._def.autoSignedUrls;
 
@@ -573,9 +574,15 @@ export async function deleteFiles<TCtx extends AnyContext>(params: {
   );
   const authorizations = await Promise.all(
     fileRecords.map((file) => {
-      if (file.path === undefined || file.metadata === undefined) {
+      if (file.path === undefined && bucket._def.path.length > 0) {
         throw new EdgeStoreError({
-          message: `Provider ${provider.name} must return path and metadata from files.get to authorize frontend deletion.`,
+          message: `Provider ${provider.name} must return path from files.get to authorize frontend deletion for a bucket with configured path fields.`,
+          code: 'SERVER_ERROR',
+        });
+      }
+      if (file.metadata === undefined && bucket._def.metadata !== undefined) {
+        throw new EdgeStoreError({
+          message: `Provider ${provider.name} must return metadata from files.get to authorize frontend deletion for a bucket with configured metadata fields.`,
           code: 'SERVER_ERROR',
         });
       }
@@ -586,8 +593,8 @@ export async function deleteFiles<TCtx extends AnyContext>(params: {
             url: file.url,
             size: file.sizeBytes,
             uploadedAt: new Date(file.uploadedAt),
-            path: file.path,
-            metadata: file.metadata,
+            path: file.path ?? {},
+            metadata: file.metadata ?? {},
           },
         }),
       );

--- a/packages/server/src/adapters/shared.ts
+++ b/packages/server/src/adapters/shared.ts
@@ -572,8 +572,14 @@ export async function deleteFiles<TCtx extends AnyContext>(params: {
     ),
   );
   const authorizations = await Promise.all(
-    fileRecords.map((file) =>
-      Promise.resolve(
+    fileRecords.map((file) => {
+      if (file.path === undefined || file.metadata === undefined) {
+        throw new EdgeStoreError({
+          message: `Provider ${provider.name} must return path and metadata from files.get to authorize frontend deletion.`,
+          code: 'SERVER_ERROR',
+        });
+      }
+      return Promise.resolve(
         bucket._def.beforeDelete!({
           ctx,
           fileInfo: {
@@ -584,8 +590,8 @@ export async function deleteFiles<TCtx extends AnyContext>(params: {
             metadata: file.metadata,
           },
         }),
-      ),
-    ),
+      );
+    }),
   );
   if (authorizations.some((allowed) => !allowed)) {
     throw new EdgeStoreError({

--- a/packages/server/src/core/client/bucketClient.ts
+++ b/packages/server/src/core/client/bucketClient.ts
@@ -123,10 +123,11 @@ function createUploadMethods<
         bucket: context.bucket,
         pathAttrs: { ctx, input: parsedInput },
       });
-      const metadata = await context.bucket._def.metadata({
-        ctx,
-        input: parsedInput,
-      });
+      const metadata =
+        (await context.bucket._def.metadata?.({
+          ctx,
+          input: parsedInput,
+        })) ?? {};
       const uploadResult = await upload({
         bucketName: context.bucketName,
         bucketType: context.bucket._def.type,

--- a/packages/server/src/core/client/index.ts
+++ b/packages/server/src/core/client/index.ts
@@ -20,7 +20,6 @@ import {
   type ProviderMutationError,
   type ProviderReference,
   type ProviderReferenceInput,
-  type RouterFileFieldsProvider,
   type Simplify,
 } from '@edgestore/shared';
 import type { z, ZodNever } from 'zod';
@@ -36,35 +35,51 @@ export type Comparison<TType = string> =
 
 export type EdgeStoreFileReference = FileReference;
 
-type ProviderFileFields<TFile extends BackendFile> = TFile extends ProviderFile
+type RouterFieldValue<TValue, TRouterValue> =
+  TValue extends Record<string, string> ? TRouterValue : TValue;
+
+type ProviderRouterField<
+  TBucket extends AnyBuilder,
+  TFile extends BackendFile,
+  TKey extends 'metadata' | 'path',
+> = TKey extends keyof TFile
+  ? {
+      [TField in keyof Pick<TFile, TKey>]: RouterFieldValue<
+        Pick<TFile, TKey>[TField],
+        TKey extends 'metadata'
+          ? InferMetadataObject<TBucket>
+          : InferBucketPathObject<TBucket>
+      >;
+    }
+  : object;
+
+type ProviderRouterFields<
+  TBucket extends AnyBuilder,
+  TFile extends BackendFile,
+> = ProviderRouterField<TBucket, TFile, 'metadata'> &
+  ProviderRouterField<TBucket, TFile, 'path'>;
+
+type ProviderFileFields<
+  TBucket extends AnyBuilder,
+  TFile extends BackendFile,
+> = TFile extends ProviderFile
   ? Omit<ProviderFile, 'metadata' | 'path'> &
       Omit<TFile, keyof ProviderFile> &
-      Pick<TFile, 'metadata' | 'path'>
+      ProviderRouterFields<TBucket, TFile>
   : Omit<TFile, 'metadata' | 'path' | 'uploadedAt' | 'updatedAt'> & {
       uploadedAt: Date;
       updatedAt: Date;
-      metadata: TFile['metadata'];
-      path: TFile['path'];
-    };
+    } & ProviderRouterFields<TBucket, TFile>;
 
 export type FileRecord<
-  _TBucket extends AnyBuilder,
+  TBucket extends AnyBuilder,
   TFile extends BackendFile = ProviderFile,
-> = ProviderFileFields<TFile>;
+> = ProviderFileFields<TBucket, TFile>;
 
 type RouterFileFields<TBucket extends AnyBuilder> = {
   metadata: InferMetadataObject<TBucket>;
   path: InferBucketPathObject<TBucket>;
 };
-
-type ReadFileRecord<
-  TBucket extends AnyBuilder,
-  TProvider,
-  TFile extends BackendFile,
-> = TProvider extends RouterFileFieldsProvider
-  ? Omit<FileRecord<TBucket, TFile>, 'metadata' | 'path'> &
-      RouterFileFields<TBucket>
-  : FileRecord<TBucket, TFile>;
 
 export type GetFileRes<
   TBucket extends AnyBuilder,
@@ -280,13 +295,7 @@ type GetFileBucketClient<TBucket extends AnyBuilder, TProvider> = [
       get: (
         ref: ProviderReferenceInput<TProvider>,
       ) => Promise<
-        Prettify<
-          ReadFileRecord<
-            TBucket,
-            TProvider,
-            ProviderCapabilityFile<TProvider, 'get'>
-          >
-        >
+        Prettify<FileRecord<TBucket, ProviderCapabilityFile<TProvider, 'get'>>>
       >;
     };
 
@@ -321,11 +330,7 @@ type ListBucketClient<TBucket extends AnyBuilder, TProvider> = [
         params?: ListFilesRequest<TBucket, ProviderCursor<TProvider>>,
       ) => Promise<{
         items: Prettify<
-          ReadFileRecord<
-            TBucket,
-            TProvider,
-            ProviderCapabilityFile<TProvider, 'list'>
-          >
+          FileRecord<TBucket, ProviderCapabilityFile<TProvider, 'list'>>
         >[];
         limit: number;
         nextCursor: ProviderCursor<TProvider> | null;

--- a/packages/server/src/providers/azure-blob/index.test.ts
+++ b/packages/server/src/providers/azure-blob/index.test.ts
@@ -244,8 +244,6 @@ describe('azureBlob', () => {
       'documents/_public/a b/file.txt',
     );
     expect(res).toEqual({
-      metadata: {},
-      path: {},
       sizeBytes: 123,
       uploadedAt: new Date('2026-01-02T03:04:05.000Z'),
       updatedAt: new Date('2026-01-02T03:04:05.000Z'),

--- a/packages/server/src/providers/azure-blob/index.ts
+++ b/packages/server/src/providers/azure-blob/index.ts
@@ -216,8 +216,6 @@ export function azureBlob(options?: AzureBlobProviderOptions) {
         const timestamp = lastModified ?? new Date();
         return {
           url: blobClient.url.split('?')[0]!,
-          metadata: {},
-          path: {},
           sizeBytes: contentLength ?? 0,
           uploadedAt: timestamp,
           updatedAt: timestamp,

--- a/packages/server/src/providers/edgestore/index.test.ts
+++ b/packages/server/src/providers/edgestore/index.test.ts
@@ -1,4 +1,5 @@
 import { createEdgeStoreSdk } from '@edgestore/sdk';
+import type * as EdgeStoreSdkModule from '@edgestore/sdk';
 import { initEdgeStore } from '@edgestore/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { edgestore } from '.';
@@ -26,16 +27,18 @@ const runtime = vi.hoisted(() => ({
 
 const forProject = vi.hoisted(() => vi.fn(() => runtime));
 
-vi.mock('@edgestore/sdk', () => ({
-  createEdgeStoreSdk: vi.fn(
-    (options: { credentials: Record<string, string> }) =>
-      'token' in options.credentials
-        ? { runtime: { forProject } }
-        : { runtime },
-  ),
-  DEFAULT_MULTIPART_PART_SIZE_BYTES: 16 * 1024 * 1024,
-  DEFAULT_MULTIPART_THRESHOLD_BYTES: 100 * 1024 * 1024,
-}));
+vi.mock('@edgestore/sdk', async (importOriginal) => {
+  const sdk = await importOriginal<typeof EdgeStoreSdkModule>();
+  return {
+    ...sdk,
+    createEdgeStoreSdk: vi.fn(
+      (options: { credentials: Record<string, string> }) =>
+        'token' in options.credentials
+          ? { runtime: { forProject } }
+          : { runtime },
+    ),
+  };
+});
 
 const fileInfo = {
   type: 'text/plain',

--- a/packages/server/src/providers/edgestore/index.ts
+++ b/packages/server/src/providers/edgestore/index.ts
@@ -1,7 +1,6 @@
 import {
   createEdgeStoreSdk,
-  DEFAULT_MULTIPART_PART_SIZE_BYTES,
-  DEFAULT_MULTIPART_THRESHOLD_BYTES,
+  planMultipartUpload,
   type ProjectRuntimeClient,
 } from '@edgestore/sdk';
 import {
@@ -10,7 +9,6 @@ import {
   type ProviderFileMutationResult,
   type RequestUploadParams,
   type RequestUploadRes,
-  type RouterFileFieldsProvider,
 } from '@edgestore/shared';
 import { z } from 'zod';
 import { defineProvider } from '../../core/provider';
@@ -128,25 +126,22 @@ export function edgestore(options?: EdgeStoreProviderOptions) {
         fileInfo,
         autoSignedUrls,
       }): Promise<RequestUploadRes> {
-        let partSize = DEFAULT_MULTIPART_PART_SIZE_BYTES;
-        if (fileInfo.size > DEFAULT_MULTIPART_THRESHOLD_BYTES) {
-          let totalParts = Math.ceil(fileInfo.size / partSize);
-          if (totalParts > 10_000) {
-            totalParts = 10_000;
-            partSize = Math.ceil(fileInfo.size / totalParts);
-          }
+        const multipartPlan = planMultipartUpload({
+          sizeBytes: fileInfo.size,
+        });
+        if (multipartPlan) {
           return mapUploadResponse(
             await runtime.uploads.request({
               bucket: bucketName,
               ...mapRawUploadRequest(bucketType, fileInfo, autoSignedUrls),
               multipart: {
-                partNumbers: Array.from(
-                  { length: totalParts },
-                  (_, index) => index + 1,
-                ),
+                partNumbers: multipartPlan.partNumbers,
               },
             }),
-            { partSize, totalParts },
+            {
+              partSize: multipartPlan.partSizeBytes,
+              totalParts: multipartPlan.totalParts,
+            },
           );
         }
         return mapUploadResponse(
@@ -264,7 +259,7 @@ export function edgestore(options?: EdgeStoreProviderOptions) {
     },
   });
 
-  return provider as typeof provider & RouterFileFieldsProvider;
+  return provider;
 }
 
 export type EdgeStoreBackendProvider = ReturnType<typeof edgestore>;

--- a/packages/server/src/providers/s3/index.test.ts
+++ b/packages/server/src/providers/s3/index.test.ts
@@ -394,6 +394,31 @@ describe('s3', () => {
     );
   });
 
+  it('does not claim to retrieve router fields', async () => {
+    const provider = s3({
+      bucketName: 'storage-bucket',
+      region: 'us-east-1',
+      baseUrl: 'https://cdn.example.com',
+    });
+    const lastModified = new Date('2026-01-01T00:00:00.000Z');
+    awsMocks.send.mockResolvedValueOnce({
+      ContentLength: 10,
+      LastModified: lastModified,
+    });
+
+    await expect(
+      provider.files.get({
+        bucketName: 'documents',
+        file: { url: 'https://cdn.example.com/documents/path/file.txt' },
+      }),
+    ).resolves.toEqual({
+      url: 'https://cdn.example.com/documents/path/file.txt',
+      sizeBytes: 10,
+      uploadedAt: lastModified,
+      updatedAt: lastModified,
+    });
+  });
+
   it('rejects cross-bucket deletion before contacting S3', async () => {
     const provider = s3({
       bucketName: 'storage-bucket',

--- a/packages/server/src/providers/s3/index.ts
+++ b/packages/server/src/providers/s3/index.ts
@@ -246,8 +246,6 @@ export function s3(options?: S3ProviderOptions) {
 
         return {
           url: file.url,
-          metadata: {},
-          path: {},
           sizeBytes: ContentLength,
           uploadedAt: LastModified,
           updatedAt: LastModified,

--- a/packages/shared/src/internals/bucketBuilder.ts
+++ b/packages/shared/src/internals/bucketBuilder.ts
@@ -73,15 +73,19 @@ type NormalizeMetadata<TMetadata> = string extends keyof TMetadata
       }
     >;
 
-export type InferMetadataObject<TBucket extends Builder<any, AnyDef>> =
-  TBucket['_def']['metadata'] extends (...args: any) => any
-    ? NormalizeMetadata<Awaited<ReturnType<TBucket['_def']['metadata']>>>
+type InferMetadataObjectFromFn<TMetadata> = [
+  Exclude<TMetadata, undefined>,
+] extends [never]
+  ? Record<string, never>
+  : Exclude<TMetadata, undefined> extends (...args: any) => any
+    ? NormalizeMetadata<Awaited<ReturnType<Exclude<TMetadata, undefined>>>>
     : Record<string, never>;
 
+export type InferMetadataObject<TBucket extends Builder<any, AnyDef>> =
+  InferMetadataObjectFromFn<TBucket['_def']['metadata']>;
+
 type InferMetadataObjectFromDef<TDef extends AnyDef> =
-  TDef['metadata'] extends (...args: any) => any
-    ? NormalizeMetadata<Awaited<ReturnType<TDef['metadata']>>>
-    : Record<string, never>;
+  InferMetadataObjectFromFn<TDef['metadata']>;
 
 export type AnyContextValue = string | undefined;
 
@@ -193,7 +197,7 @@ type BucketType = 'IMAGE' | 'FILE';
 type Def<
   TInput extends AnyInput,
   TPath extends AnyPath,
-  TMetadata extends AnyMetadataFn,
+  TMetadata extends AnyMetadataFn | undefined,
 > = {
   type: BucketType;
   input: TInput;
@@ -206,7 +210,7 @@ type Def<
   beforeDelete?: BeforeDeleteFn<any, any>;
 };
 
-type AnyDef = Def<AnyInput, AnyPath, AnyMetadataFn>;
+type AnyDef = Def<AnyInput, AnyPath, AnyMetadataFn | undefined>;
 
 type Builder<TCtx, TDef extends AnyDef> = {
   /** only used for types */
@@ -389,7 +393,7 @@ function createBuilder<
   TType extends BucketType,
   TInput extends AnyInput = z.ZodNever,
   TPath extends AnyPath = [],
-  TMetadata extends AnyMetadataFn = () => Record<string, never>,
+  TMetadata extends AnyMetadataFn | undefined = undefined,
 >(
   opts: { type: TType },
   initDef?: Partial<AnyDef>,
@@ -411,7 +415,7 @@ function createBuilder<
     type: opts.type,
     input: z.never(),
     path: [],
-    metadata: () => ({}),
+    metadata: undefined,
     ...initDef,
   };
 

--- a/packages/shared/src/internals/providerTypes.ts
+++ b/packages/shared/src/internals/providerTypes.ts
@@ -96,8 +96,10 @@ export type ProviderFile = {
 export type BackendFile = {
   url: string;
   sizeBytes: number;
-  path: Record<string, string>;
-  metadata: Record<string, string>;
+  /** Router-derived path values, when this operation retrieves them. */
+  path?: Record<string, string>;
+  /** Router-derived metadata values, when this operation retrieves them. */
+  metadata?: Record<string, string>;
   uploadedAt: Date | string;
   updatedAt: Date | string;
 };
@@ -359,30 +361,19 @@ export type AnyEdgeStoreProvider = EdgeStoreProvider<
   ProviderFiles<any, any>
 >;
 
-declare const routerFileFieldsProviderBrand: unique symbol;
-
-/**
- * @internal Marks providers whose read contract persists the router-derived
- * path and metadata fields.
- */
-export type RouterFileFieldsProvider = {
-  readonly [routerFileFieldsProviderBrand]: true;
-};
-
 export type DefaultEdgeStoreProvider = EdgeStoreProvider<
   StandardSchemaV1<unknown, FileReference>,
   string
-> &
-  RouterFileFieldsProvider & {
-    uploads: ProviderUploads<BackendUploadOperation> & {
-      upload: BackendUploadOperation;
-    };
-    files: ProviderFiles<FileReference, string> & {
-      get: BackendGetFileOperation;
-      list: BackendListFilesOperation;
-      confirm: BackendFileMutationOperation;
-      delete: BackendFileMutationOperation;
-      restore: BackendFileMutationOperation;
-      getSignedUrls: BackendGetSignedUrlsOperation;
-    };
+> & {
+  uploads: ProviderUploads<BackendUploadOperation> & {
+    upload: BackendUploadOperation;
   };
+  files: ProviderFiles<FileReference, string> & {
+    get: BackendGetFileOperation;
+    list: BackendListFilesOperation;
+    confirm: BackendFileMutationOperation;
+    delete: BackendFileMutationOperation;
+    restore: BackendFileMutationOperation;
+    getSignedUrls: BackendGetSignedUrlsOperation;
+  };
+};

--- a/packages/tests/test-d/server.test-d.ts
+++ b/packages/tests/test-d/server.test-d.ts
@@ -83,7 +83,12 @@ const s3EdgeStore = createEdgeStore({
   router: publicRouter,
   provider: s3(),
 });
-void s3EdgeStore.client.files.get({ url: 'https://s3.example/file' });
+void s3EdgeStore.client.files
+  .get({ url: 'https://s3.example/file' })
+  .then((file) => {
+    expectError(file.path);
+    expectError(file.metadata);
+  });
 expectError(s3EdgeStore.client.files.upload);
 expectError(s3EdgeStore.client.files.list);
 expectError(s3EdgeStore.client.files.confirm);

--- a/packages/tests/test-d/server.test-d.ts
+++ b/packages/tests/test-d/server.test-d.ts
@@ -117,8 +117,8 @@ const syntheticProvider = defineProvider({
     get: async ({ file }) => ({
       url: `https://s3.example/${file.objectKey}`,
       sizeBytes: 5,
-      path: { storageRegion: 'us-east-1' as const },
-      metadata: { storageClass: 'archive' as const },
+      path: {},
+      metadata: {},
       uploadedAt: new Date(),
       updatedAt: new Date(),
       eTag: 'etag',
@@ -128,8 +128,6 @@ const syntheticProvider = defineProvider({
         {
           url: 'https://s3.example/files/file.txt',
           sizeBytes: 5,
-          path: { storageRegion: 'us-east-1' as const },
-          metadata: { storageClass: 'archive' as const },
           uploadedAt: new Date(),
           updatedAt: new Date(),
           eTag: 'etag',
@@ -213,16 +211,16 @@ expectError(syntheticClient.files.restore);
 expectError(syntheticClient.files.get({ id: 'file-id' }));
 void syntheticClient.files.get({ objectKey: 'files/file.txt' }).then((file) => {
   expectType<string>(file.eTag);
-  expectType<'us-east-1'>(file.path.storageRegion);
-  expectType<'archive'>(file.metadata.storageClass);
+  expectType<Record<string, never>>(file.path);
+  expectType<Record<string, never>>(file.metadata);
   expectError(file.accountId);
 });
 expectError(syntheticClient.files.list({ cursor: 'next' }));
 void syntheticClient.files.list({ cursor: 1 }).then((page) => {
   expectType<number | null>(page.nextCursor);
   expectType<string>(page.items[0]!.eTag);
-  expectType<'us-east-1'>(page.items[0]!.path.storageRegion);
-  expectType<'archive'>(page.items[0]!.metadata.storageClass);
+  expectError(page.items[0]!.path);
+  expectError(page.items[0]!.metadata);
   expectError(page.items[0]!.accountId);
 });
 void syntheticClient.files.upload({ content: 'hello' }).then((file) => {


### PR DESCRIPTION
## What changed

- added a public, pure `planMultipartUpload` SDK utility and reused it in both high-level SDK uploads and the hosted provider's browser-upload setup
- centralized multipart threshold, part-size, and maximum-part-count behavior, removing the hosted provider's duplicated `10_000` limit
- made provider `path` and `metadata` fields optional and inferred their availability independently from each `get` and `list` response
- removed the private router-field provider brand and the hosted provider's cast
- added a clear frontend-deletion error when `beforeDelete` needs stored router fields that the provider's `get` operation does not return
- updated the consolidated unreleased changesets rather than adding another slice-specific release note

## Why

Multipart geometry was implemented twice and could drift between server-side SDK uploads and browser uploads. Router-field inference also depended on a private cast, while the public custom-provider model is designed to infer each operation's actual response shape.

## Impact

SDK and hosted-provider uploads now use one canonical multipart policy. Custom providers may omit `path` or `metadata` from either `get` or `list`; the generated backend client omits unavailable fields and applies the selected router bucket's types when fields are returned. Other provider-specific response fields remain inferred.

Frontend deletion still requires both fields when running `beforeDelete`, because the adapter cannot construct truthful authorization input without them.

## Validation

- `pnpm exec changeset status`
- `pnpm check:dependencies`
- `pnpm format --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm test:types`
- focused server lint/typecheck/tests after the final mock cleanup
