### PR TITLE
chore: configure Codex worktree environments

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,51 @@
+version = 1
+name = "EdgeStore"
+
+[setup]
+script = '''
+set -eu
+
+git -C "$CODEX_SOURCE_TREE_PATH" \
+  ls-files --others --ignored --exclude-standard -- \
+  ':(glob)**/.env*' \
+  ':(exclude,glob)**/node_modules/**' \
+  ':(exclude,glob)**/.local/**' \
+  ':(exclude,glob)**/.next/**' |
+while IFS= read -r relative_path
+do
+  source_file="$CODEX_SOURCE_TREE_PATH/$relative_path"
+  destination_file="$CODEX_WORKTREE_PATH/$relative_path"
+
+  if [ -e "$destination_file" ] && [ ! -L "$destination_file" ]; then
+    echo "Skipping existing environment file: $relative_path" >&2
+    continue
+  fi
+
+  mkdir -p "$(dirname "$destination_file")"
+  ln -sfn "$source_file" "$destination_file"
+done
+
+node --version
+pnpm --version
+pnpm install --frozen-lockfile --prefer-offline
+'''
+
+[[actions]]
+name = "Docs"
+icon = "run"
+command = "pnpm docs:dev"
+
+[[actions]]
+name = "Example"
+icon = "run"
+command = "pnpm dev"
+
+[[actions]]
+name = "Tests"
+icon = "test"
+command = "pnpm test"
+
+[[actions]]
+name = "Checks"
+icon = "test"
+command = "pnpm typecheck && pnpm lint"


### PR DESCRIPTION
## What changed

- add a shared Codex local-environment configuration for the EdgeStore library repository
- symlink ignored project `.env*` files from the source checkout into new worktrees while excluding dependency, `.local`, and `.next` internals
- preserve real environment files that already exist in a worktree
- install dependencies with the frozen lockfile and the repository-pinned pnpm version
- expose quick actions for docs, the basic example, package tests, and type/lint checks

## Why

Fresh Codex worktrees do not contain ignored environment files or installed dependencies. This previously required repeated manual setup and made copied environment files liable to drift from the root checkout. Linking the ignored files keeps the root checkout canonical while allowing worktrees to run docs, examples, and smoke-test workflows.

## Impact

New Codex worktrees can initialize automatically and provide the repository's common development commands in the app toolbar. Existing non-symlink environment files are never overwritten.

## Validation

- validated the setup script with `sh -n`
- completed `pnpm install --frozen-lockfile --prefer-offline` using Node 24.12.0 and pnpm 10.26.2
- verified all 17 expected project environment symlinks in a clean worktree
- verified there are no broken symlink targets
- ran `git diff --check` against `origin/main`
