### PR TITLE
Temporary Vercel test: docs project path change

### DIFF
--- a/docs/.vercel-ignore-test.md
+++ b/docs/.vercel-ignore-test.md
@@ -2,4 +2,6 @@
 
 This marker intentionally changes **docs** for Vercel path-filter testing.
 
+Post-configuration verification commit for the docs project.
+
 Delete this file and close the associated temporary PR after verification.

--- a/docs/.vercel-ignore-test.md
+++ b/docs/.vercel-ignore-test.md
@@ -1,0 +1,5 @@
+# Temporary Vercel ignore test
+
+This marker intentionally changes **docs** for Vercel path-filter testing.
+
+Delete this file and close the associated temporary PR after verification.


### PR DESCRIPTION
Temporary test PR for Vercel path filtering.

Changes only `docs/.vercel-ignore-test.md`.

Expected: `edgestore-docs` creates a Preview deployment; the two example projects ignore this PR.

Close without merging after observing the Vercel result.