### PR TITLE
Temporary Vercel test: components project path change

### DIFF
--- a/examples/components/.vercel-ignore-test.md
+++ b/examples/components/.vercel-ignore-test.md
@@ -1,0 +1,5 @@
+# Temporary Vercel ignore test
+
+This marker intentionally changes **example-components** for Vercel path-filter testing.
+
+Delete this file and close the associated temporary PR after verification.

--- a/examples/components/.vercel-ignore-test.md
+++ b/examples/components/.vercel-ignore-test.md
@@ -2,4 +2,6 @@
 
 This marker intentionally changes **example-components** for Vercel path-filter testing.
 
+Post-configuration verification commit for the components project.
+
 Delete this file and close the associated temporary PR after verification.


### PR DESCRIPTION
Temporary test PR for Vercel path filtering.

Changes only `examples/components/.vercel-ignore-test.md`.

Expected: `example-components` creates a Preview deployment; the docs and access-control projects ignore this PR.

Close without merging after observing the Vercel result.