### PR TITLE
Temporary Vercel test: access-control project path change

### DIFF
--- a/examples/basic-access-control/.vercel-ignore-test.md
+++ b/examples/basic-access-control/.vercel-ignore-test.md
@@ -2,4 +2,6 @@
 
 This marker intentionally changes **example-access-control** for Vercel path-filter testing.
 
+Post-configuration verification commit for the access-control project.
+
 Delete this file and close the associated temporary PR after verification.

--- a/examples/basic-access-control/.vercel-ignore-test.md
+++ b/examples/basic-access-control/.vercel-ignore-test.md
@@ -1,0 +1,5 @@
+# Temporary Vercel ignore test
+
+This marker intentionally changes **example-access-control** for Vercel path-filter testing.
+
+Delete this file and close the associated temporary PR after verification.


### PR DESCRIPTION
Temporary test PR for Vercel path filtering.

Changes only `examples/basic-access-control/.vercel-ignore-test.md`.

Expected: `example-access-control` creates a Preview deployment; the docs and components projects ignore this PR.

Close without merging after observing the Vercel result.