### PR TITLE
Temporary Vercel test: unrelated repository path change

### DIFF
--- a/packages/shared/.vercel-ignore-test.md
+++ b/packages/shared/.vercel-ignore-test.md
@@ -1,0 +1,5 @@
+# Temporary Vercel ignore test
+
+This marker intentionally changes **unrelated packages/shared** for Vercel path-filter testing.
+
+Delete this file and close the associated temporary PR after verification.


### PR DESCRIPTION
Control PR superseded: `packages/shared` is an internal dependency of the published packages, so it is intentionally excluded from the clean unrelated-path test. Close without merging.