### PR TITLE
Temporary Vercel test: unrelated workspace app path change

### DIFF
--- a/examples/fastify-basic/.vercel-ignore-test.md
+++ b/examples/fastify-basic/.vercel-ignore-test.md
@@ -2,6 +2,6 @@
 
 This marker is in the unrelated `examples/fastify-basic` workspace and is used as a control for the three Vercel projects under test.
 
-Second commit: verifies skipping after the branch already has completed Preview deployments.
+Post-configuration verification commit for the unrelated control.
 
 Delete this file and close the associated temporary PR after verification.

--- a/examples/fastify-basic/.vercel-ignore-test.md
+++ b/examples/fastify-basic/.vercel-ignore-test.md
@@ -1,0 +1,5 @@
+# Temporary Vercel ignore test
+
+This marker is in the unrelated `examples/fastify-basic` workspace and is used as a control for the three Vercel projects under test.
+
+Delete this file and close the associated temporary PR after verification.

--- a/examples/fastify-basic/.vercel-ignore-test.md
+++ b/examples/fastify-basic/.vercel-ignore-test.md
@@ -2,4 +2,6 @@
 
 This marker is in the unrelated `examples/fastify-basic` workspace and is used as a control for the three Vercel projects under test.
 
+Second commit: verifies skipping after the branch already has completed Preview deployments.
+
 Delete this file and close the associated temporary PR after verification.


### PR DESCRIPTION
Temporary control PR for Vercel path filtering.

Changes only `examples/fastify-basic/.vercel-ignore-test.md`, outside all three Vercel project roots and not an internal dependency of those projects.

Expected: all three Vercel projects ignore this PR and create no Preview deployments.

Close without merging after observing the Vercel result.