### PR TITLE
[CLI 11] feat: support monorepo workspaces

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -37,10 +37,11 @@ edgestore --cwd apps/web init
 edgestore --cwd apps/web bucket list
 ```
 
-Each workspace package keeps its own `.edgestore/config.json`. From the
-monorepo root, the CLI uses the only configured package automatically or asks
-which package to use when more than one is configured. Automation should pass
-`--cwd` or an explicit `--project` when the choice is ambiguous.
+Each workspace package keeps its own `.edgestore/config.json`. From a configured
+monorepo root, the CLI uses the root configuration. From an unconfigured root,
+it uses the only configured package automatically or asks which package to use
+when more than one is configured. Automation should pass `--cwd` or an explicit
+`--project` when the choice is ambiguous.
 
 Use `--json` for structured output and `--plain` for commands with one natural
 value. Run `edgestore completion bash`, `zsh`, or `fish` to configure shell

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,6 +29,19 @@ edgestore file upload ./logo.png --bucket publicFiles
 edgestore project key create <basePath> --name local --output .env.local
 ```
 
+In a monorepo, run commands from the application package or select it
+explicitly with `--cwd`:
+
+```sh
+edgestore --cwd apps/web init
+edgestore --cwd apps/web bucket list
+```
+
+Each workspace package keeps its own `.edgestore/config.json`. From the
+monorepo root, the CLI uses the only configured package automatically or asks
+which package to use when more than one is configured. Automation should pass
+`--cwd` or an explicit `--project` when the choice is ambiguous.
+
 Use `--json` for structured output and `--plain` for commands with one natural
 value. Run `edgestore completion bash`, `zsh`, or `fish` to configure shell
 completion.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@clack/prompts": "1.7.0",
     "@edgestore/sdk": "0.7.0",
+    "@manypkg/find-root": "3.1.0",
     "@manypkg/get-packages": "3.1.0",
     "@napi-rs/keyring": "1.3.0",
     "commander": "15.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@clack/prompts": "1.7.0",
     "@edgestore/sdk": "0.7.0",
+    "@manypkg/get-packages": "3.1.0",
     "@napi-rs/keyring": "1.3.0",
     "commander": "15.0.0",
     "env-paths": "4.0.0",

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { runCli } from './cli';
 import { createFixture } from './testFixture';
@@ -97,4 +100,33 @@ describe('runCli', () => {
       expect(fixture.stderr()).toBe('');
     },
   );
+
+  it('applies an explicit working directory before running a command', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'edgestore-cwd-'));
+    try {
+      const exitCode = await runCli(
+        ['--cwd', directory, 'account', 'list'],
+        fixture.runtime,
+        '0.0.0',
+      );
+
+      expect(exitCode).toBe(0);
+      expect(fixture.runtime.cwd).toBe(directory);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a missing working directory', async () => {
+    const exitCode = await runCli(
+      ['--json', '--cwd', '/missing/edgestore-app', 'account', 'list'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(fixture.stderr()).error).toMatchObject({
+      code: 'working_directory_not_found',
+    });
+  });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -61,6 +61,7 @@ import {
 } from './commands/upload';
 import { CliError, normalizeError } from './core/errors';
 import { outputFor, type CliRuntime, type GlobalFlags } from './core/runtime';
+import { resolveWorkingDirectory } from './core/workspace';
 
 export async function runCli(
   argv: string[],
@@ -129,6 +130,7 @@ function createProgram(
     .option('--json', 'emit structured JSON')
     .option('--plain', 'emit a single plain-text value')
     .option('--api-url <url>', 'override the EdgeStore API URL')
+    .option('--cwd <directory>', 'run as if started in this directory')
     .option('--no-color', 'disable color output')
     .option('--no-progress', 'disable progress output')
     .showHelpAfterError()
@@ -149,7 +151,11 @@ Common workflows:
 `,
     );
 
-  program.hook('preAction', () => {
+  program.hook('preAction', async () => {
+    const requestedCwd = globalFlags(program).cwd;
+    if (requestedCwd) {
+      runtime.setCwd(await resolveWorkingDirectory(runtime.cwd, requestedCwd));
+    }
     outputFor(runtime, globalFlags(program));
   });
 
@@ -773,6 +779,7 @@ function globalFlags(program: Command): GlobalFlags {
     json?: boolean;
     plain?: boolean;
     apiUrl?: string;
+    cwd?: string;
     color: boolean;
     progress: boolean;
   }>();
@@ -781,6 +788,7 @@ function globalFlags(program: Command): GlobalFlags {
     json: options.json,
     plain: options.plain,
     apiUrl: options.apiUrl,
+    cwd: options.cwd,
     color: options.color,
     progress: options.progress,
   };

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -2,6 +2,7 @@ import type { ManagementEdgeStoreSdk } from '@edgestore/sdk';
 import { usageError } from '../core/errors';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { apiUrlFor, credentialFor, outputFor } from '../core/runtime';
+import { selectWorkspaceContext } from '../core/workspace';
 
 export type LoginOptions = {
   token?: boolean;
@@ -81,6 +82,7 @@ export async function whoamiCommand(
   runtime: CliRuntime,
   flags: GlobalFlags,
 ): Promise<void> {
+  await selectWorkspaceContext(runtime, flags, 'read');
   const credential = await credentialFor(runtime, flags);
   const apiUrl = apiUrlFor(runtime, flags);
   const sdk = runtime.sdkFactory({

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -10,7 +10,7 @@ export async function bucketListCommand(
   flags: GlobalFlags,
   project?: string,
 ): Promise<void> {
-  const projectRef = await resolvedProjectRef(runtime, project);
+  const projectRef = await resolvedProjectRef(runtime, flags, project);
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.buckets.list({
     project: projectRef,
@@ -71,7 +71,7 @@ export async function bucketCreateCommand(
   }
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.buckets.create({
-    project: await resolvedProjectRef(runtime, input.project),
+    project: await resolvedProjectRef(runtime, flags, input.project),
     name: input.bucket,
     type,
     visibility: input.public ? 'public' : 'protected',
@@ -95,7 +95,7 @@ export async function bucketDeleteCommand(
   input: { bucket: string; project?: string; yes?: boolean },
 ): Promise<void> {
   validateBucketName(input.bucket);
-  const project = await resolvedProjectRef(runtime, input.project);
+  const project = await resolvedProjectRef(runtime, flags, input.project);
   let bucket = input.bucket;
   if (!input.yes) {
     if (!runtime.io.inputIsTty || flags.json) {
@@ -135,7 +135,7 @@ export async function bucketEmptyCommand(
     yes?: boolean;
   },
 ): Promise<void> {
-  const project = await resolvedProjectRef(runtime, input.project);
+  const project = await resolvedProjectRef(runtime, flags, input.project);
   if (!input.yes) {
     if (!runtime.io.inputIsTty || flags.json) {
       throw usageError(
@@ -230,7 +230,7 @@ export async function bucketEmptyStatusCommand(
   flags: GlobalFlags,
   input: { bucket: string; project?: string; job?: string },
 ): Promise<void> {
-  const project = await resolvedProjectRef(runtime, input.project);
+  const project = await resolvedProjectRef(runtime, flags, input.project);
   const sdk = await sdkFor(runtime, flags);
   const result = input.job
     ? await sdk.management.buckets.emptyJobs.get({
@@ -268,7 +268,7 @@ async function getBucket(
 ) {
   const sdk = await sdkFor(runtime, flags);
   return sdk.management.buckets.get({
-    project: await resolvedProjectRef(runtime, input.project),
+    project: await resolvedProjectRef(runtime, flags, input.project),
     bucket: input.bucket,
     signal: runtime.signal,
   });

--- a/packages/cli/src/commands/completion.ts
+++ b/packages/cli/src/commands/completion.ts
@@ -6,7 +6,7 @@ const topLevel =
   'login logout whoami doctor init account member project token bucket file open completion';
 
 const globalOptions =
-  '--json --plain --api-url --color --no-color --progress --no-progress --help --version';
+  '--json --plain --api-url --cwd --color --no-color --progress --no-progress --help --version';
 
 const bashCandidates: Record<string, string> = {
   '': topLevel,
@@ -149,7 +149,7 @@ function bashCompletionScript(): string {
       continue
     fi
     case "$word" in
-      --api-url|--link|--name|--account|--output|--bucket|--bucket-type|--page|--limit|--role|--scope|--preset|--expires-at|--type|--retry|--job|--project|--cursor|--path)
+      --api-url|--cwd|--link|--name|--account|--output|--bucket|--bucket-type|--page|--limit|--role|--scope|--preset|--expires-at|--type|--retry|--job|--project|--cursor|--path)
         skip_value=1
         continue
         ;;

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -209,7 +209,7 @@ async function checkEnvFile(
   const label = localConfig?.config.envFile ?? '.env.local';
   const configRoot = localConfig?.config.envFile
     ? path.dirname(path.dirname(localConfig.path))
-    : runtime.cwd;
+    : runtime.workspaceCwd;
   const envPath = path.resolve(configRoot, label);
   let contents = '';
   try {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -5,6 +5,7 @@ import { resolveCredential } from '../core/credentials';
 import { renderTable } from '../core/output';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { apiUrlFor, outputFor } from '../core/runtime';
+import { selectWorkspaceContext } from '../core/workspace';
 
 type Check = {
   name: string;
@@ -17,6 +18,7 @@ export async function doctorCommand(
   flags: GlobalFlags,
   version: string,
 ): Promise<void> {
+  await selectWorkspaceContext(runtime, flags, 'read');
   const checks: Check[] = [{ name: 'CLI', status: 'pass', detail: version }];
   const apiUrl = apiUrlFor(runtime, flags);
 

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -34,7 +34,7 @@ export async function fileListCommand(
       '--all and --cursor cannot be used together.',
     );
   }
-  const project = await resolvedProjectRef(runtime, input.project);
+  const project = await resolvedProjectRef(runtime, flags, input.project);
   const sdk = await sdkFor(runtime, flags);
   const files = [];
   let cursor = input.cursor;
@@ -80,7 +80,7 @@ export async function fileInfoCommand(
 ): Promise<void> {
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.files.lookup({
-    project: await resolvedProjectRef(runtime, input.project),
+    project: await resolvedProjectRef(runtime, flags, input.project),
     file: fileReference(input.reference, input.bucket),
     signal: runtime.signal,
   });
@@ -112,7 +112,7 @@ export async function fileDownloadCommand(
 ): Promise<void> {
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.files.generateAccessUrls({
-    project: await resolvedProjectRef(runtime, input.project),
+    project: await resolvedProjectRef(runtime, flags, input.project),
     files: [fileReference(input.reference, input.bucket)],
     signal: runtime.signal,
   });
@@ -183,7 +183,7 @@ export async function fileDeleteCommand(
       'delete',
     );
   }
-  const project = await resolvedProjectRef(runtime, input.project);
+  const project = await resolvedProjectRef(runtime, flags, input.project);
   const sdk = await sdkFor(runtime, flags);
   const refs = input.references.map((value) =>
     fileReference(value, input.bucket),

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -128,6 +128,23 @@ describe('renderInstallCommand', () => {
       }),
     ).toBe('yarn --cwd apps/web add @edgestore/server');
   });
+
+  it('uses pnpm directory targeting outside the workspace root', () => {
+    const plan: PackagePlan = {
+      framework: 'node',
+      manager: 'pnpm',
+      missing: ['@edgestore/server'],
+      workspace,
+    };
+
+    expect(
+      renderInstallCommand('pnpm', ['add', '@edgestore/server'], {
+        plan,
+        packageCwd: '/repo/apps/web',
+        invocationCwd: '/repo/apps/web/src',
+      }),
+    ).toBe('pnpm --dir .. add @edgestore/server');
+  });
 });
 
 async function repository(): Promise<string> {

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { detectPackages } from './init';
+import { detectPackages, renderInstallCommand, type PackagePlan } from './init';
 
 describe('detectPackages', () => {
   let directory: string | undefined;
@@ -68,6 +68,65 @@ describe('detectPackages', () => {
       code: 'invalid_package_manifest',
       message: `Invalid package manifest at ${path.join(directory, 'package.json')}.`,
     });
+  });
+});
+
+describe('renderInstallCommand', () => {
+  const workspace = { root: '/repo', packageName: 'web' };
+
+  it.each([
+    {
+      manager: 'pnpm' as const,
+      args: ['add', '@edgestore/server'],
+      expected: 'pnpm --filter ./apps/web add @edgestore/server',
+    },
+    {
+      manager: 'npm' as const,
+      args: ['install', '@edgestore/server'],
+      expected: 'npm install @edgestore/server --workspace apps/web',
+    },
+    {
+      manager: 'yarn' as const,
+      args: ['add', '@edgestore/server'],
+      expected: 'yarn workspace web add @edgestore/server',
+    },
+    {
+      manager: 'bun' as const,
+      args: ['add', '@edgestore/server'],
+      expected: 'bun --cwd apps/web add @edgestore/server',
+    },
+  ])('renders a $manager workspace command', ({ manager, args, expected }) => {
+    const plan: PackagePlan = {
+      framework: 'node',
+      manager,
+      missing: ['@edgestore/server'],
+      workspace,
+    };
+
+    expect(
+      renderInstallCommand(manager, args, {
+        plan,
+        packageCwd: '/repo/apps/web',
+        invocationCwd: '/repo',
+      }),
+    ).toBe(expected);
+  });
+
+  it('falls back to cwd targeting for an unnamed Yarn workspace', () => {
+    const plan: PackagePlan = {
+      framework: 'node',
+      manager: 'yarn',
+      missing: ['@edgestore/server'],
+      workspace: { root: '/repo' },
+    };
+
+    expect(
+      renderInstallCommand('yarn', ['add', '@edgestore/server'], {
+        plan,
+        packageCwd: '/repo/apps/web',
+        invocationCwd: '/repo',
+      }),
+    ).toBe('yarn --cwd apps/web add @edgestore/server');
   });
 });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -91,8 +91,7 @@ export async function initCommand(
   const interactive = runtime.io.inputIsTty && !flags.json && !flags.plain;
   validateOptions(options, interactive);
   const packages = await detectPackages(packageCwd, {
-    installAtWorkspaceRoot:
-      Boolean(flags.cwd) && (await isWorkspaceRoot(packageCwd)),
+    installAtWorkspaceRoot: await isWorkspaceRoot(packageCwd),
   });
   const sdk = await sdkFor(runtime, flags);
   const account = await resolveAccount({ runtime, sdk, options, interactive });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,7 +5,7 @@ import { Writable } from 'node:stream';
 import { promisify } from 'node:util';
 import type { ManagementEdgeStoreSdk } from '@edgestore/sdk';
 import { detect } from 'package-manager-detector/detect';
-import { renderCliCommand } from '../core/command';
+import { renderCliCommand, renderShellCommand } from '../core/command';
 import { findGitRoot } from '../core/config';
 import { CliError, normalizeError, usageError } from '../core/errors';
 import type { CliRuntime, CliSdk, GlobalFlags } from '../core/runtime';
@@ -14,7 +14,11 @@ import {
   deliverEnvSecretWithRollback,
   preflightEnvSecret,
 } from '../core/secretDelivery';
-import { isWorkspaceRoot, selectWorkspaceContext } from '../core/workspace';
+import {
+  findWorkspaceRoot,
+  isWorkspaceRoot,
+  selectWorkspaceContext,
+} from '../core/workspace';
 import { activeAccount } from './account';
 import { parseBucketType } from './bucket';
 
@@ -226,6 +230,7 @@ export async function initCommand(
   try {
     install = await installPackages(runtime, packages, {
       cwd: packageCwd,
+      invocationCwd: runtime.cwd,
       requested: options.install,
       interactive,
       structured: Boolean(flags.json || flags.plain),
@@ -543,14 +548,21 @@ export type PackagePlan = {
   manager?: 'pnpm' | 'npm' | 'yarn' | 'bun';
   missing: string[];
   installAtWorkspaceRoot?: boolean;
+  workspace?: {
+    root: string;
+    packageName?: string;
+  };
 };
 
 export async function detectPackages(
   cwd: string,
   options: { installAtWorkspaceRoot?: boolean } = {},
 ): Promise<PackagePlan> {
+  const resolvedCwd = path.resolve(cwd);
+  const workspaceRoot = await findWorkspaceRoot(resolvedCwd);
   const packagePath = path.join(cwd, 'package.json');
   let manifest: {
+    name?: string;
     packageManager?: string;
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
@@ -610,6 +622,14 @@ export async function detectPackages(
     manager: await detectPackageManager(cwd),
     missing: wanted.filter((name) => !dependencies[name]),
     installAtWorkspaceRoot: options.installAtWorkspaceRoot,
+    ...(workspaceRoot && workspaceRoot !== resolvedCwd
+      ? {
+          workspace: {
+            root: workspaceRoot,
+            ...(manifest.name ? { packageName: manifest.name } : {}),
+          },
+        }
+      : {}),
   };
 }
 
@@ -618,19 +638,24 @@ async function installPackages(
   plan: PackagePlan,
   options: {
     cwd: string;
+    invocationCwd: string;
     requested?: boolean;
     interactive: boolean;
     structured: boolean;
     json: boolean;
   },
-): Promise<{ command?: string; ran: boolean }> {
+): Promise<{ command?: string; cwd?: string; ran: boolean }> {
   if (!plan.manager || !plan.missing.length) return { ran: false };
   const args = installArgs(
     plan.manager,
     plan.missing,
     plan.installAtWorkspaceRoot,
   );
-  const command = [plan.manager, ...args].join(' ');
+  const command = renderInstallCommand(plan.manager, args, {
+    plan,
+    packageCwd: options.cwd,
+    invocationCwd: options.invocationCwd,
+  });
   const shouldInstall =
     options.requested ??
     (options.interactive
@@ -639,7 +664,7 @@ async function installPackages(
           true,
         )
       : false);
-  if (!shouldInstall) return { command, ran: false };
+  if (!shouldInstall) return { command, cwd: options.cwd, ran: false };
   const captured = options.structured ? createOutputCapture() : undefined;
   try {
     await runtime.runCommand(plan.manager, args, {
@@ -666,7 +691,56 @@ async function installPackages(
       diagnostics.endsWith('\n') ? diagnostics : `${diagnostics}\n`,
     );
   }
-  return { command, ran: true };
+  return { command, cwd: options.cwd, ran: true };
+}
+
+export function renderInstallCommand(
+  manager: NonNullable<PackagePlan['manager']>,
+  args: string[],
+  context: {
+    plan: PackagePlan;
+    packageCwd: string;
+    invocationCwd: string;
+  },
+): string {
+  const { plan, packageCwd, invocationCwd } = context;
+  const workspace = plan.workspace;
+  if (invocationCwd === workspace?.root) {
+    const workspacePath = path
+      .relative(workspace.root, packageCwd)
+      .replaceAll(path.sep, '/');
+    if (manager === 'pnpm') {
+      return renderShellCommand([
+        manager,
+        '--filter',
+        `./${workspacePath}`,
+        ...args,
+      ]);
+    }
+    if (manager === 'npm') {
+      return renderShellCommand([
+        manager,
+        ...args,
+        '--workspace',
+        workspacePath,
+      ]);
+    }
+    if (manager === 'yarn' && workspace.packageName) {
+      return renderShellCommand([
+        manager,
+        'workspace',
+        workspace.packageName,
+        ...args,
+      ]);
+    }
+  }
+
+  const relativeCwd = path.relative(invocationCwd, packageCwd) || '.';
+  if (relativeCwd === '.') return renderShellCommand([manager, ...args]);
+  if (manager === 'npm') {
+    return renderShellCommand([manager, '--prefix', relativeCwd, ...args]);
+  }
+  return renderShellCommand([manager, '--cwd', relativeCwd, ...args]);
 }
 
 function createOutputCapture(limit = 32_768): {
@@ -864,7 +938,8 @@ async function detectPackageManager(
   cwd: string,
 ): Promise<'pnpm' | 'npm' | 'yarn' | 'bun'> {
   const start = path.resolve(cwd);
-  const boundary = (await findGitRoot(start)) ?? start;
+  const boundary =
+    (await findWorkspaceRoot(start)) ?? (await findGitRoot(start)) ?? start;
   let directory = start;
   while (true) {
     for (const strategy of [

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -740,6 +740,9 @@ export function renderInstallCommand(
   if (manager === 'npm') {
     return renderShellCommand([manager, '--prefix', relativeCwd, ...args]);
   }
+  if (manager === 'pnpm') {
+    return renderShellCommand([manager, '--dir', relativeCwd, ...args]);
+  }
   return renderShellCommand([manager, '--cwd', relativeCwd, ...args]);
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -83,11 +83,12 @@ export async function initCommand(
   options: InitOptions,
 ): Promise<void> {
   await selectWorkspaceContext(runtime, flags, 'write');
+  const packageCwd = runtime.workspaceCwd;
   const interactive = runtime.io.inputIsTty && !flags.json && !flags.plain;
   validateOptions(options, interactive);
-  const packages = await detectPackages(runtime.cwd, {
+  const packages = await detectPackages(packageCwd, {
     installAtWorkspaceRoot:
-      Boolean(flags.cwd) && (await isWorkspaceRoot(runtime.cwd)),
+      Boolean(flags.cwd) && (await isWorkspaceRoot(packageCwd)),
   });
   const sdk = await sdkFor(runtime, flags);
   const account = await resolveAccount({ runtime, sdk, options, interactive });
@@ -100,11 +101,11 @@ export async function initCommand(
   let envFile: string | undefined;
   if (secretOutput) {
     await preflightEnvSecret(
-      runtime.cwd,
+      packageCwd,
       ['EDGE_STORE_ACCESS_KEY', 'EDGE_STORE_SECRET_KEY'],
       { output: secretOutput, update: options.update },
     );
-    envFile = await protectSecretFile(runtime.cwd, secretOutput);
+    envFile = await protectSecretFile(packageCwd, secretOutput);
   }
 
   const projectResult =
@@ -128,7 +129,7 @@ export async function initCommand(
     );
     try {
       await deliverEnvSecretWithRollback({
-        cwd: runtime.cwd,
+        cwd: packageCwd,
         values: {
           EDGE_STORE_ACCESS_KEY: keyResult.key.accessKey,
           EDGE_STORE_SECRET_KEY: keyResult.secretKey,
@@ -224,6 +225,7 @@ export async function initCommand(
   let install: Awaited<ReturnType<typeof installPackages>>;
   try {
     install = await installPackages(runtime, packages, {
+      cwd: packageCwd,
       requested: options.install,
       interactive,
       structured: Boolean(flags.json || flags.plain),
@@ -247,7 +249,7 @@ export async function initCommand(
     `Linked ${projectResult.project.name} (${projectResult.project.basePath}).`,
     `Config: ${configPath}`,
     ...(secretOutput
-      ? [`Secrets: ${path.resolve(runtime.cwd, secretOutput)}`]
+      ? [`Secrets: ${path.resolve(packageCwd, secretOutput)}`]
       : []),
     ...(bucket ? [`Bucket: ${bucket.name}`] : []),
     ...(install.command && !install.ran
@@ -407,7 +409,7 @@ async function createProject(context: InitContext, createKey: boolean) {
     (await promptText(runtime, {
       interactive,
       message: 'Project name',
-      placeholder: path.basename(runtime.cwd),
+      placeholder: path.basename(runtime.workspaceCwd),
     }));
   return sdk.management.projects.create({
     account,
@@ -615,6 +617,7 @@ async function installPackages(
   runtime: CliRuntime,
   plan: PackagePlan,
   options: {
+    cwd: string;
     requested?: boolean;
     interactive: boolean;
     structured: boolean;
@@ -640,7 +643,7 @@ async function installPackages(
   const captured = options.structured ? createOutputCapture() : undefined;
   try {
     await runtime.runCommand(plan.manager, args, {
-      cwd: runtime.cwd,
+      cwd: options.cwd,
       ...(captured ? { stdout: captured.stream, stderr: captured.stream } : {}),
     });
   } catch (error) {
@@ -700,7 +703,9 @@ async function resolveSecretOutput(
   if (explicitOutput) return explicitOutput;
   if (!interactive) return '.env.local';
 
-  const discovered = (await readdir(runtime.cwd, { withFileTypes: true }))
+  const discovered = (
+    await readdir(runtime.workspaceCwd, { withFileTypes: true })
+  )
     .filter(
       (entry) =>
         entry.isFile() &&

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -14,6 +14,7 @@ import {
   deliverEnvSecretWithRollback,
   preflightEnvSecret,
 } from '../core/secretDelivery';
+import { isWorkspaceRoot, selectWorkspaceContext } from '../core/workspace';
 import { activeAccount } from './account';
 import { parseBucketType } from './bucket';
 
@@ -81,9 +82,13 @@ export async function initCommand(
   flags: GlobalFlags,
   options: InitOptions,
 ): Promise<void> {
+  await selectWorkspaceContext(runtime, flags, 'write');
   const interactive = runtime.io.inputIsTty && !flags.json && !flags.plain;
   validateOptions(options, interactive);
-  const packages = await detectPackages(runtime.cwd);
+  const packages = await detectPackages(runtime.cwd, {
+    installAtWorkspaceRoot:
+      Boolean(flags.cwd) && (await isWorkspaceRoot(runtime.cwd)),
+  });
   const sdk = await sdkFor(runtime, flags);
   const account = await resolveAccount({ runtime, sdk, options, interactive });
   const context = { runtime, sdk, options, interactive, account };
@@ -535,9 +540,13 @@ export type PackagePlan = {
   framework: 'next' | 'react' | 'node' | 'unknown';
   manager?: 'pnpm' | 'npm' | 'yarn' | 'bun';
   missing: string[];
+  installAtWorkspaceRoot?: boolean;
 };
 
-export async function detectPackages(cwd: string): Promise<PackagePlan> {
+export async function detectPackages(
+  cwd: string,
+  options: { installAtWorkspaceRoot?: boolean } = {},
+): Promise<PackagePlan> {
   const packagePath = path.join(cwd, 'package.json');
   let manifest: {
     packageManager?: string;
@@ -598,6 +607,7 @@ export async function detectPackages(cwd: string): Promise<PackagePlan> {
     framework,
     manager: await detectPackageManager(cwd),
     missing: wanted.filter((name) => !dependencies[name]),
+    installAtWorkspaceRoot: options.installAtWorkspaceRoot,
   };
 }
 
@@ -612,7 +622,11 @@ async function installPackages(
   },
 ): Promise<{ command?: string; ran: boolean }> {
   if (!plan.manager || !plan.missing.length) return { ran: false };
-  const args = installArgs(plan.manager, plan.missing);
+  const args = installArgs(
+    plan.manager,
+    plan.missing,
+    plan.installAtWorkspaceRoot,
+  );
   const command = [plan.manager, ...args].join(' ');
   const shouldInstall =
     options.requested ??
@@ -715,28 +729,35 @@ function projectKeyName(output: string | undefined): string {
 async function protectSecretFile(cwd: string, output: string): Promise<string> {
   const absolute = path.resolve(cwd, output);
   const gitRoot = await findGitRoot(cwd);
-  const root = gitRoot ?? path.resolve(cwd);
-  const relative = path.relative(root, absolute);
-  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+  const packageRoot = path.resolve(cwd);
+  const boundary = gitRoot ?? packageRoot;
+  const repositoryRelative = path.relative(boundary, absolute);
+  const packageRelative = path.relative(packageRoot, absolute);
+  if (
+    !packageRelative ||
+    packageRelative.startsWith('..') ||
+    path.isAbsolute(packageRelative)
+  ) {
     throw usageError(
       'secret_output_unprotected',
-      `Secret output ${absolute} must be inside ${root}.`,
-      ['Choose an env file inside the current repository.'],
+      `Secret output ${absolute} must be inside ${packageRoot}.`,
+      ['Choose an env file inside the selected package.'],
     );
   }
-  const normalized = relative.replaceAll(path.sep, '/');
+  const normalized = packageRelative.replaceAll(path.sep, '/');
+  const gitPath = repositoryRelative.replaceAll(path.sep, '/');
   if (gitRoot) {
-    if (await isTrackedFile(gitRoot, normalized)) {
+    if (await isTrackedFile(gitRoot, gitPath)) {
       throw usageError(
         'secret_output_tracked',
         `Secret output ${absolute} is already tracked by Git.`,
         ['Remove it from Git before creating a project key.'],
       );
     }
-    if (await isIgnoredFile(gitRoot, normalized)) return normalized;
+    if (await isIgnoredFile(gitRoot, gitPath)) return normalized;
   }
 
-  const gitignorePath = path.join(root, '.gitignore');
+  const gitignorePath = path.join(packageRoot, '.gitignore');
   let contents = '';
   try {
     contents = await readFile(gitignorePath, 'utf8');
@@ -759,7 +780,7 @@ async function protectSecretFile(cwd: string, output: string): Promise<string> {
       },
     );
   }
-  if (gitRoot && !(await isIgnoredFile(gitRoot, normalized))) {
+  if (gitRoot && !(await isIgnoredFile(gitRoot, gitPath))) {
     throw new CliError(
       'secret_output_unprotected',
       `Could not protect secret output ${absolute}.`,
@@ -881,8 +902,12 @@ function packageJsonForStrategy(
 function installArgs(
   manager: 'pnpm' | 'npm' | 'yarn' | 'bun',
   packages: string[],
+  installAtWorkspaceRoot = false,
 ): string[] {
   if (manager === 'npm') return ['install', ...packages];
+  if (manager === 'pnpm' && installAtWorkspaceRoot) {
+    return ['add', '-w', ...packages];
+  }
   return ['add', ...packages];
 }
 

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -15,7 +15,7 @@ export async function openCommand(
   const target = parseTarget(input.target);
   const project =
     target === 'project'
-      ? await resolvedProjectRef(runtime, input.project)
+      ? await resolvedProjectRef(runtime, flags, input.project)
       : undefined;
   const url = dashboardUrl(runtime, target, project);
 

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -2,6 +2,7 @@ import { usageError } from '../core/errors';
 import { renderTable } from '../core/output';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { outputFor, sdkFor } from '../core/runtime';
+import { selectWorkspaceContext } from '../core/workspace';
 import { activeAccount } from './account';
 
 export async function projectListCommand(
@@ -9,6 +10,7 @@ export async function projectListCommand(
   flags: GlobalFlags,
   options: { account?: string },
 ): Promise<void> {
+  await selectWorkspaceContext(runtime, flags, 'read');
   const account = await activeAccount(runtime, options.account);
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.projects.list({
@@ -141,6 +143,7 @@ export async function projectCurrentCommand(
   runtime: CliRuntime,
   flags: GlobalFlags,
 ): Promise<void> {
+  await selectWorkspaceContext(runtime, flags, 'read');
   const located = await runtime.repoConfig.read();
   if (!located) {
     throw missingProjectError();
@@ -166,6 +169,7 @@ export async function projectLinkCommand(
   flags: GlobalFlags,
   projectRef: string,
 ): Promise<void> {
+  await selectWorkspaceContext(runtime, flags, 'write');
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.projects.get({
     project: projectRef,
@@ -191,6 +195,7 @@ export async function projectUnlinkCommand(
   runtime: CliRuntime,
   flags: GlobalFlags,
 ): Promise<void> {
+  await selectWorkspaceContext(runtime, flags, 'read');
   const configPath = await runtime.repoConfig.remove();
   if (!configPath) {
     throw missingProjectError();
@@ -205,9 +210,11 @@ export async function projectUnlinkCommand(
 
 export async function resolvedProjectRef(
   runtime: CliRuntime,
+  flags: GlobalFlags,
   explicit?: string,
 ): Promise<string> {
   if (explicit) return explicit;
+  await selectWorkspaceContext(runtime, flags, 'read');
   const located = await runtime.repoConfig.read();
   if (!located) throw missingProjectError();
   return located.config.project;
@@ -220,7 +227,7 @@ async function getProject(
 ) {
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.projects.get({
-    project: await resolvedProjectRef(runtime, explicit),
+    project: await resolvedProjectRef(runtime, flags, explicit),
     signal: runtime.signal,
   });
   return result.project;

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -49,7 +49,7 @@ export async function fileUploadCommand(
     );
   }
 
-  const project = await resolvedProjectRef(runtime, input.project);
+  const project = await resolvedProjectRef(runtime, flags, input.project);
   const sdk = await sdkFor(runtime, flags);
   const results = [];
   for (const [index, localFile] of localFiles.entries()) {
@@ -220,7 +220,7 @@ export async function fileUploadStatusCommand(
 ): Promise<void> {
   const sdk = await sdkFor(runtime, flags);
   const result = await sdk.management.uploads.get({
-    project: await resolvedProjectRef(runtime, input.project),
+    project: await resolvedProjectRef(runtime, flags, input.project),
     uploadId: input.uploadId,
     signal: runtime.signal,
   });
@@ -238,7 +238,7 @@ export async function fileUploadCancelCommand(
   flags: GlobalFlags,
   input: { uploadId: string; project?: string; yes?: boolean },
 ): Promise<void> {
-  const project = await resolvedProjectRef(runtime, input.project);
+  const project = await resolvedProjectRef(runtime, flags, input.project);
   if (!input.yes) {
     if (!runtime.io.inputIsTty || flags.json) {
       throw usageError(

--- a/packages/cli/src/core/command.test.ts
+++ b/packages/cli/src/core/command.test.ts
@@ -18,6 +18,7 @@ describe('renderCliCommand', () => {
         {
           json: true,
           apiUrl: 'https://api-dev.edgestore.dev',
+          cwd: 'apps/web client',
           color: false,
           progress: false,
         },
@@ -25,7 +26,7 @@ describe('renderCliCommand', () => {
         { project: 'x36t1ejdlz' },
       ),
     ).toBe(
-      'edgestore --json --api-url https://api-dev.edgestore.dev bucket empty-status publicFiles --job job_123 --project x36t1ejdlz',
+      "edgestore --json --api-url https://api-dev.edgestore.dev --cwd 'apps/web client' bucket empty-status publicFiles --job job_123 --project x36t1ejdlz",
     );
   });
 

--- a/packages/cli/src/core/command.ts
+++ b/packages/cli/src/core/command.ts
@@ -14,6 +14,7 @@ export function renderCliCommand(
     if (flags.plain) args.push('--plain');
   }
   if (flags.apiUrl) args.push('--api-url', flags.apiUrl);
+  if (flags.cwd) args.push('--cwd', flags.cwd);
   args.push(...command);
   if (options.project) args.push('--project', options.project);
   return args.map(quoteShellArgument).join(' ');

--- a/packages/cli/src/core/command.ts
+++ b/packages/cli/src/core/command.ts
@@ -17,6 +17,10 @@ export function renderCliCommand(
   if (flags.cwd) args.push('--cwd', flags.cwd);
   args.push(...command);
   if (options.project) args.push('--project', options.project);
+  return renderShellCommand(args);
+}
+
+export function renderShellCommand(args: string[]): string {
   return args.map(quoteShellArgument).join(' ');
 }
 

--- a/packages/cli/src/core/config.test.ts
+++ b/packages/cli/src/core/config.test.ts
@@ -41,28 +41,48 @@ describe('GlobalConfigStore', () => {
 });
 
 describe('RepoConfigStore', () => {
-  it('writes at the Git root and discovers the config from a child', async () => {
+  it('writes at the nearest package root and discovers it from a child', async () => {
     const root = await temporaryDirectory();
     await writeFile(path.join(root, '.git'), 'gitdir: elsewhere\n');
-    const child = path.join(root, 'apps', 'web');
+    await writeFile(path.join(root, 'package.json'), '{}');
+    const workspace = path.join(root, 'apps', 'web');
+    const child = path.join(workspace, 'src');
     await mkdir(child, { recursive: true });
+    await writeFile(path.join(workspace, 'package.json'), '{}');
     const store = new RepoConfigStore(child);
 
     const configPath = await store.write({
       account: 'acc_123',
       project: 'x36t1ejdlz',
-      envFile: 'apps/web/.env.development.local',
+      envFile: '.env.development.local',
     });
 
-    expect(configPath).toBe(path.join(root, '.edgestore', 'config.json'));
+    expect(configPath).toBe(path.join(workspace, '.edgestore', 'config.json'));
     await expect(store.read()).resolves.toEqual({
       config: {
         account: 'acc_123',
         project: 'x36t1ejdlz',
-        envFile: 'apps/web/.env.development.local',
+        envFile: '.env.development.local',
       },
       path: configPath,
     });
+  });
+
+  it('does not inherit the monorepo root config inside a workspace', async () => {
+    const root = await temporaryDirectory();
+    await writeFile(path.join(root, '.git'), 'gitdir: elsewhere\n');
+    await writeFile(path.join(root, 'package.json'), '{}');
+    await new RepoConfigStore(root).write({
+      account: 'acc_root',
+      project: 'root-project',
+    });
+    const workspace = path.join(root, 'apps', 'web');
+    await mkdir(workspace, { recursive: true });
+    await writeFile(path.join(workspace, 'package.json'), '{}');
+
+    await expect(
+      new RepoConfigStore(workspace).read(),
+    ).resolves.toBeUndefined();
   });
 
   it('removes only the local config', async () => {

--- a/packages/cli/src/core/config.test.ts
+++ b/packages/cli/src/core/config.test.ts
@@ -85,6 +85,25 @@ describe('RepoConfigStore', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('falls back to the Git root when no package manifest exists', async () => {
+    const root = await temporaryDirectory();
+    await writeFile(path.join(root, '.git'), 'gitdir: elsewhere\n');
+    const child = path.join(root, 'scripts', 'release');
+    await mkdir(child, { recursive: true });
+    const store = new RepoConfigStore(child);
+
+    const configPath = await store.write({
+      account: 'acc_123',
+      project: 'x36t1ejdlz',
+    });
+
+    expect(configPath).toBe(path.join(root, '.edgestore', 'config.json'));
+    await expect(store.read()).resolves.toMatchObject({
+      config: { account: 'acc_123', project: 'x36t1ejdlz' },
+      path: configPath,
+    });
+  });
+
   it('removes only the local config', async () => {
     const root = await temporaryDirectory();
     const store = new RepoConfigStore(root);

--- a/packages/cli/src/core/config.test.ts
+++ b/packages/cli/src/core/config.test.ts
@@ -122,8 +122,9 @@ describe('RepoConfigStore', () => {
     );
   });
 
-  it('does not search parent directories outside a Git repository', async () => {
+  it('discovers the nearest package outside a Git repository', async () => {
     const parent = await temporaryDirectory();
+    await writeFile(path.join(parent, 'package.json'), '{}');
     const parentStore = new RepoConfigStore(parent);
     await parentStore.write({
       account: 'acc_parent',
@@ -132,7 +133,9 @@ describe('RepoConfigStore', () => {
     const child = path.join(parent, 'child');
     await mkdir(child);
 
-    await expect(new RepoConfigStore(child).read()).resolves.toBeUndefined();
+    await expect(new RepoConfigStore(child).read()).resolves.toMatchObject({
+      config: { account: 'acc_parent', project: 'parent-project' },
+    });
   });
 });
 

--- a/packages/cli/src/core/config.ts
+++ b/packages/cli/src/core/config.ts
@@ -52,7 +52,7 @@ export class RepoConfigStore {
 
   async read(): Promise<LocatedRepoConfig | undefined> {
     const configPath = path.join(
-      await findPackageRoot(this.cwd),
+      await findRepoConfigRoot(this.cwd),
       '.edgestore',
       'config.json',
     );
@@ -65,7 +65,7 @@ export class RepoConfigStore {
   }
 
   async write(config: RepoConfig): Promise<string> {
-    const root = await findPackageRoot(this.cwd);
+    const root = await findRepoConfigRoot(this.cwd);
     const configPath = path.join(root, '.edgestore', 'config.json');
     await writeConfig(configPath, repoConfigSchema.parse(config));
     return configPath;
@@ -156,6 +156,14 @@ export async function findPackageRoot(start: string): Promise<string> {
     if (parent === current) return initial;
     current = parent;
   }
+}
+
+async function findRepoConfigRoot(start: string): Promise<string> {
+  const packageRoot = await findPackageRoot(start);
+  if (await pathExists(path.join(packageRoot, 'package.json'))) {
+    return packageRoot;
+  }
+  return (await findGitRoot(start)) ?? packageRoot;
 }
 
 async function pathExists(candidate: string): Promise<boolean> {

--- a/packages/cli/src/core/config.ts
+++ b/packages/cli/src/core/config.ts
@@ -51,10 +51,12 @@ export class RepoConfigStore {
   constructor(private readonly cwd: string) {}
 
   async read(): Promise<LocatedRepoConfig | undefined> {
-    const configPath = await findRepoConfig(this.cwd);
-    if (!configPath) {
-      return undefined;
-    }
+    const configPath = path.join(
+      await findPackageRoot(this.cwd),
+      '.edgestore',
+      'config.json',
+    );
+    if (!(await pathExists(configPath))) return undefined;
 
     return {
       config: await readConfig(configPath, repoConfigSchema),
@@ -63,7 +65,7 @@ export class RepoConfigStore {
   }
 
   async write(config: RepoConfig): Promise<string> {
-    const root = (await findGitRoot(this.cwd)) ?? this.cwd;
+    const root = await findPackageRoot(this.cwd);
     const configPath = path.join(root, '.edgestore', 'config.json');
     await writeConfig(configPath, repoConfigSchema.parse(config));
     return configPath;
@@ -126,28 +128,6 @@ async function writeConfig<TConfig>(
   await rename(temporaryPath, configPath);
 }
 
-async function findRepoConfig(start: string): Promise<string | undefined> {
-  let current = path.resolve(start);
-  const gitRoot = await findGitRoot(current);
-
-  if (!gitRoot) {
-    const candidate = path.join(current, '.edgestore', 'config.json');
-    return (await pathExists(candidate)) ? candidate : undefined;
-  }
-
-  while (true) {
-    const candidate = path.join(current, '.edgestore', 'config.json');
-    if (await pathExists(candidate)) {
-      return candidate;
-    }
-
-    if (current === gitRoot) {
-      return undefined;
-    }
-    current = path.dirname(current);
-  }
-}
-
 export async function findGitRoot(start: string): Promise<string | undefined> {
   let current = path.resolve(start);
 
@@ -160,6 +140,21 @@ export async function findGitRoot(start: string): Promise<string | undefined> {
     if (parent === current) {
       return undefined;
     }
+    current = parent;
+  }
+}
+
+export async function findPackageRoot(start: string): Promise<string> {
+  const initial = path.resolve(start);
+  const gitRoot = await findGitRoot(initial);
+  if (!gitRoot) return initial;
+  let current = initial;
+
+  while (true) {
+    if (await pathExists(path.join(current, 'package.json'))) return current;
+    if (current === gitRoot) return initial;
+    const parent = path.dirname(current);
+    if (parent === current) return initial;
     current = parent;
   }
 }

--- a/packages/cli/src/core/config.ts
+++ b/packages/cli/src/core/config.ts
@@ -147,7 +147,6 @@ export async function findGitRoot(start: string): Promise<string | undefined> {
 export async function findPackageRoot(start: string): Promise<string> {
   const initial = path.resolve(start);
   const gitRoot = await findGitRoot(initial);
-  if (!gitRoot) return initial;
   let current = initial;
 
   while (true) {

--- a/packages/cli/src/core/runtime.ts
+++ b/packages/cli/src/core/runtime.ts
@@ -27,6 +27,7 @@ export type GlobalFlags = {
   json?: boolean;
   plain?: boolean;
   apiUrl?: string;
+  cwd?: string;
   color: boolean;
   progress: boolean;
 };
@@ -89,6 +90,7 @@ export type CliRuntime = {
   env: NodeJS.ProcessEnv;
   io: RuntimeIo;
   signal: AbortSignal;
+  setCwd(cwd: string): void;
   globalConfig: {
     path: string;
     read(): Promise<GlobalConfig>;
@@ -116,8 +118,7 @@ export type CliRuntime = {
 
 export function createDefaultRuntime(signal: AbortSignal): CliRuntime {
   const paths = envPaths('edgestore', { suffix: '' });
-
-  return {
+  const runtime: CliRuntime = {
     exitCode: 0,
     cwd: process.cwd(),
     env: process.env,
@@ -129,6 +130,10 @@ export function createDefaultRuntime(signal: AbortSignal): CliRuntime {
       outputIsTty: Boolean(process.stdout.isTTY),
     },
     signal,
+    setCwd(cwd) {
+      runtime.cwd = cwd;
+      runtime.repoConfig = new RepoConfigStore(cwd);
+    },
     globalConfig: new GlobalConfigStore(path.join(paths.config, 'config.json')),
     repoConfig: new RepoConfigStore(process.cwd()),
     credentials: new KeyringCredentialStore(),
@@ -138,6 +143,7 @@ export function createDefaultRuntime(signal: AbortSignal): CliRuntime {
     openUrl,
     runCommand,
   };
+  return runtime;
 }
 
 export function outputFor(runtime: CliRuntime, flags: GlobalFlags): CliOutput {

--- a/packages/cli/src/core/runtime.ts
+++ b/packages/cli/src/core/runtime.ts
@@ -87,10 +87,12 @@ export type SdkFactory = (options: {
 export type CliRuntime = {
   exitCode: number;
   cwd: string;
+  workspaceCwd: string;
   env: NodeJS.ProcessEnv;
   io: RuntimeIo;
   signal: AbortSignal;
   setCwd(cwd: string): void;
+  setWorkspaceCwd(cwd: string): void;
   globalConfig: {
     path: string;
     read(): Promise<GlobalConfig>;
@@ -118,9 +120,11 @@ export type CliRuntime = {
 
 export function createDefaultRuntime(signal: AbortSignal): CliRuntime {
   const paths = envPaths('edgestore', { suffix: '' });
+  const cwd = process.cwd();
   const runtime: CliRuntime = {
     exitCode: 0,
-    cwd: process.cwd(),
+    cwd,
+    workspaceCwd: cwd,
     env: process.env,
     io: {
       stdin: process.stdin,
@@ -132,10 +136,14 @@ export function createDefaultRuntime(signal: AbortSignal): CliRuntime {
     signal,
     setCwd(cwd) {
       runtime.cwd = cwd;
+      runtime.setWorkspaceCwd(cwd);
+    },
+    setWorkspaceCwd(cwd) {
+      runtime.workspaceCwd = cwd;
       runtime.repoConfig = new RepoConfigStore(cwd);
     },
     globalConfig: new GlobalConfigStore(path.join(paths.config, 'config.json')),
-    repoConfig: new RepoConfigStore(process.cwd()),
+    repoConfig: new RepoConfigStore(cwd),
     credentials: new KeyringCredentialStore(),
     prompts: new DefaultCliPrompts(),
     sdkFactory: ({ token, baseUrl }) =>

--- a/packages/cli/src/core/workspace.test.ts
+++ b/packages/cli/src/core/workspace.test.ts
@@ -28,7 +28,8 @@ describe('selectWorkspaceContext', () => {
 
     await selectWorkspaceContext(fixture.runtime, flags, 'read');
 
-    expect(fixture.runtime.cwd).toBe(workspace);
+    expect(fixture.runtime.cwd).toBe(source);
+    expect(fixture.runtime.workspaceCwd).toBe(workspace);
   });
 
   it('uses the only configured workspace from the monorepo root', async () => {
@@ -41,7 +42,8 @@ describe('selectWorkspaceContext', () => {
 
     await selectWorkspaceContext(fixture.runtime, flags, 'read');
 
-    expect(fixture.runtime.cwd).toBe(workspace);
+    expect(fixture.runtime.cwd).toBe(root);
+    expect(fixture.runtime.workspaceCwd).toBe(workspace);
   });
 
   it('prompts for one of multiple configured workspaces', async () => {
@@ -58,7 +60,8 @@ describe('selectWorkspaceContext', () => {
 
     await selectWorkspaceContext(fixture.runtime, flags, 'read');
 
-    expect(fixture.runtime.cwd).toBe(api);
+    expect(fixture.runtime.cwd).toBe(root);
+    expect(fixture.runtime.workspaceCwd).toBe(api);
     expect(select).toHaveBeenCalledWith(
       'Which workspace package should EdgeStore use?',
       expect.arrayContaining([
@@ -98,7 +101,52 @@ describe('selectWorkspaceContext', () => {
 
     await selectWorkspaceContext(fixture.runtime, flags, 'write');
 
-    expect(fixture.runtime.cwd).toBe(api);
+    expect(fixture.runtime.cwd).toBe(root);
+    expect(fixture.runtime.workspaceCwd).toBe(api);
+  });
+
+  it('discovers a workspace without a Git repository', async () => {
+    const root = await monorepo(false);
+    const workspace = await packageDirectory(root, 'apps/web', 'web');
+    await configure(workspace, 'web-project');
+    const fixture = createFixture();
+    fixture.runtime.cwd = root;
+
+    await selectWorkspaceContext(fixture.runtime, flags, 'read');
+
+    expect(fixture.runtime.workspaceCwd).toBe(workspace);
+  });
+
+  it('normalizes an explicit subdirectory to its workspace package', async () => {
+    const root = await monorepo();
+    const workspace = await packageDirectory(root, 'apps/web', 'web');
+    const source = path.join(workspace, 'src');
+    await mkdir(source);
+    const fixture = createFixture();
+    fixture.runtime.setCwd(source);
+
+    await selectWorkspaceContext(
+      fixture.runtime,
+      { ...flags, cwd: 'apps/web/src' },
+      'read',
+    );
+
+    expect(fixture.runtime.cwd).toBe(source);
+    expect(fixture.runtime.workspaceCwd).toBe(workspace);
+  });
+
+  it('does not discover a parent workspace across a nested Git root', async () => {
+    const root = await monorepo();
+    const nested = await packageDirectory(root, 'vendor/tool', 'tool');
+    await mkdir(path.join(nested, '.git'));
+    const source = path.join(nested, 'src');
+    await mkdir(source);
+    const fixture = createFixture();
+    fixture.runtime.cwd = source;
+
+    await selectWorkspaceContext(fixture.runtime, flags, 'read');
+
+    expect(fixture.runtime.workspaceCwd).toBe(nested);
   });
 
   it('does not discover a workspace for an explicit project', async () => {
@@ -108,13 +156,14 @@ describe('selectWorkspaceContext', () => {
       resolvedProjectRef(fixture.runtime, flags, 'x36t1ejdlz'),
     ).resolves.toBe('x36t1ejdlz');
     expect(fixture.runtime.cwd).toBe('/repo');
+    expect(fixture.runtime.workspaceCwd).toBe('/repo');
   });
 });
 
-async function monorepo(): Promise<string> {
+async function monorepo(git = true): Promise<string> {
   const root = await mkdtemp(path.join(tmpdir(), 'edgestore-workspace-'));
   directories.push(root);
-  await mkdir(path.join(root, '.git'));
+  if (git) await mkdir(path.join(root, '.git'));
   await writeFile(path.join(root, 'package.json'), '{"private":true}\n');
   await writeFile(
     path.join(root, 'pnpm-workspace.yaml'),

--- a/packages/cli/src/core/workspace.test.ts
+++ b/packages/cli/src/core/workspace.test.ts
@@ -1,0 +1,147 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolvedProjectRef } from '../commands/project';
+import { createFixture } from '../testFixture';
+import { selectWorkspaceContext } from './workspace';
+
+const directories: string[] = [];
+const flags = { color: false, progress: false };
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe('selectWorkspaceContext', () => {
+  it('targets the nearest package when run inside a workspace', async () => {
+    const root = await monorepo();
+    const workspace = await packageDirectory(root, 'apps/web', 'web');
+    const source = path.join(workspace, 'src');
+    await mkdir(source);
+    const fixture = createFixture();
+    fixture.runtime.cwd = source;
+
+    await selectWorkspaceContext(fixture.runtime, flags, 'read');
+
+    expect(fixture.runtime.cwd).toBe(workspace);
+  });
+
+  it('uses the only configured workspace from the monorepo root', async () => {
+    const root = await monorepo();
+    const workspace = await packageDirectory(root, 'apps/web', 'web');
+    await packageDirectory(root, 'apps/api', 'api');
+    await configure(workspace, 'web-project');
+    const fixture = createFixture();
+    fixture.runtime.cwd = root;
+
+    await selectWorkspaceContext(fixture.runtime, flags, 'read');
+
+    expect(fixture.runtime.cwd).toBe(workspace);
+  });
+
+  it('prompts for one of multiple configured workspaces', async () => {
+    const root = await monorepo();
+    const web = await packageDirectory(root, 'apps/web', 'web');
+    const api = await packageDirectory(root, 'apps/api', 'api');
+    await configure(web, 'web-project');
+    await configure(api, 'api-project');
+    const fixture = createFixture();
+    fixture.runtime.cwd = root;
+    const select = vi.fn(async () => api);
+    fixture.runtime.prompts.select =
+      select as typeof fixture.runtime.prompts.select;
+
+    await selectWorkspaceContext(fixture.runtime, flags, 'read');
+
+    expect(fixture.runtime.cwd).toBe(api);
+    expect(select).toHaveBeenCalledWith(
+      'Which workspace package should EdgeStore use?',
+      expect.arrayContaining([
+        { value: web, label: 'web', hint: 'apps/web' },
+        { value: api, label: 'api', hint: 'apps/api' },
+      ]),
+    );
+  });
+
+  it('requires explicit context for ambiguous automation', async () => {
+    const root = await monorepo();
+    const web = await packageDirectory(root, 'apps/web', 'web');
+    const api = await packageDirectory(root, 'apps/api', 'api');
+    await configure(web, 'web-project');
+    await configure(api, 'api-project');
+    const fixture = createFixture();
+    fixture.runtime.cwd = root;
+    fixture.runtime.io.inputIsTty = false;
+
+    await expect(
+      selectWorkspaceContext(fixture.runtime, { ...flags, json: true }, 'read'),
+    ).rejects.toMatchObject({
+      code: 'workspace_context_required',
+      exitCode: 2,
+    });
+  });
+
+  it('prompts for an application package before writing the first link', async () => {
+    const root = await monorepo();
+    await packageDirectory(root, 'apps/web', 'web');
+    const api = await packageDirectory(root, 'apps/api', 'api');
+    const fixture = createFixture();
+    fixture.runtime.cwd = root;
+    fixture.runtime.prompts.select = vi.fn(
+      async () => api,
+    ) as typeof fixture.runtime.prompts.select;
+
+    await selectWorkspaceContext(fixture.runtime, flags, 'write');
+
+    expect(fixture.runtime.cwd).toBe(api);
+  });
+
+  it('does not discover a workspace for an explicit project', async () => {
+    const fixture = createFixture();
+
+    await expect(
+      resolvedProjectRef(fixture.runtime, flags, 'x36t1ejdlz'),
+    ).resolves.toBe('x36t1ejdlz');
+    expect(fixture.runtime.cwd).toBe('/repo');
+  });
+});
+
+async function monorepo(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'edgestore-workspace-'));
+  directories.push(root);
+  await mkdir(path.join(root, '.git'));
+  await writeFile(path.join(root, 'package.json'), '{"private":true}\n');
+  await writeFile(
+    path.join(root, 'pnpm-workspace.yaml'),
+    "packages:\n  - 'apps/*'\n",
+  );
+  return root;
+}
+
+async function packageDirectory(
+  root: string,
+  relative: string,
+  name: string,
+): Promise<string> {
+  const directory = path.join(root, relative);
+  await mkdir(directory, { recursive: true });
+  await writeFile(
+    path.join(directory, 'package.json'),
+    `${JSON.stringify({ name })}\n`,
+  );
+  return directory;
+}
+
+async function configure(directory: string, project: string): Promise<void> {
+  const configDirectory = path.join(directory, '.edgestore');
+  await mkdir(configDirectory);
+  await writeFile(
+    path.join(configDirectory, 'config.json'),
+    `${JSON.stringify({ account: 'acc_123', project })}\n`,
+  );
+}

--- a/packages/cli/src/core/workspace.test.ts
+++ b/packages/cli/src/core/workspace.test.ts
@@ -46,6 +46,23 @@ describe('selectWorkspaceContext', () => {
     expect(fixture.runtime.workspaceCwd).toBe(workspace);
   });
 
+  it('prefers a configured root over configured child packages', async () => {
+    const root = await monorepo();
+    const workspace = await packageDirectory(root, 'apps/web', 'web');
+    await configure(root, 'root-project');
+    await configure(workspace, 'web-project');
+    const fixture = createFixture();
+    fixture.runtime.cwd = root;
+    const select = vi.fn(async () => workspace);
+    fixture.runtime.prompts.select =
+      select as typeof fixture.runtime.prompts.select;
+
+    await selectWorkspaceContext(fixture.runtime, flags, 'read');
+
+    expect(fixture.runtime.workspaceCwd).toBe(root);
+    expect(select).not.toHaveBeenCalled();
+  });
+
   it('prompts for one of multiple configured workspaces', async () => {
     const root = await monorepo();
     const web = await packageDirectory(root, 'apps/web', 'web');

--- a/packages/cli/src/core/workspace.ts
+++ b/packages/cli/src/core/workspace.ts
@@ -51,9 +51,8 @@ async function selectWorkspaceDirectory(
   purpose: ContextPurpose,
 ): Promise<string> {
   const start = path.resolve(runtime.cwd);
-  const gitRoot = await findGitRoot(start);
   const packageRoot = await findPackageRoot(start);
-  const workspaceRoot = await findWorkspaceRoot(start, gitRoot);
+  const workspaceRoot = await findWorkspaceRoot(start);
   if (!workspaceRoot || start !== workspaceRoot || flags.cwd) {
     return packageRoot;
   }
@@ -85,12 +84,13 @@ async function selectWorkspaceDirectory(
   return workspaceRoot;
 }
 
-async function findWorkspaceRoot(
+export async function findWorkspaceRoot(
   start: string,
-  gitRoot: string | undefined,
 ): Promise<string | undefined> {
+  const resolvedStart = path.resolve(start);
+  const gitRoot = await findGitRoot(resolvedStart);
   try {
-    const root = await findRoot(start);
+    const root = await findRoot(resolvedStart);
     if (root.tool === 'root') return undefined;
     if (gitRoot && !isWithin(gitRoot, root.rootDir)) return undefined;
     return root.rootDir;

--- a/packages/cli/src/core/workspace.ts
+++ b/packages/cli/src/core/workspace.ts
@@ -1,5 +1,6 @@
 import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
+import { findRoot, NoPkgJsonFound } from '@manypkg/find-root';
 import { getPackages } from '@manypkg/get-packages';
 import { findGitRoot, findPackageRoot } from './config';
 import { usageError } from './errors';
@@ -28,21 +29,18 @@ export async function selectWorkspaceContext(
   flags: GlobalFlags,
   purpose: ContextPurpose,
 ): Promise<void> {
-  if (flags.cwd) return;
-
   const selected = await selectWorkspaceDirectory(runtime, flags, purpose);
-  if (selected !== runtime.cwd) runtime.setCwd(selected);
+  if (selected !== runtime.workspaceCwd) runtime.setWorkspaceCwd(selected);
 }
 
 export async function isWorkspaceRoot(directory: string): Promise<boolean> {
-  if (await exists(path.join(directory, 'pnpm-workspace.yaml'))) return true;
   try {
-    const manifest = JSON.parse(
-      await readFile(path.join(directory, 'package.json'), 'utf8'),
-    ) as { workspaces?: unknown };
-    return Array.isArray(manifest.workspaces) || Boolean(manifest.workspaces);
+    const root = await findRoot(directory);
+    return root.tool !== 'root' && root.rootDir === path.resolve(directory);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    if (error instanceof NoPkgJsonFound || error instanceof SyntaxError) {
+      return false;
+    }
     throw error;
   }
 }
@@ -55,18 +53,20 @@ async function selectWorkspaceDirectory(
   const start = path.resolve(runtime.cwd);
   const gitRoot = await findGitRoot(start);
   const packageRoot = await findPackageRoot(start);
-  if (!gitRoot || start !== gitRoot) return packageRoot;
-  if (!(await isWorkspaceRoot(gitRoot))) return packageRoot;
+  const workspaceRoot = await findWorkspaceRoot(start, gitRoot);
+  if (!workspaceRoot || start !== workspaceRoot || flags.cwd) {
+    return packageRoot;
+  }
 
-  const packages = await discoverPackageDirectories(gitRoot);
+  const packages = await discoverPackageDirectories(workspaceRoot);
   const configured = [];
-  for (const directory of [gitRoot, ...packages]) {
+  for (const directory of [workspaceRoot, ...packages]) {
     if (await exists(path.join(directory, '.edgestore', 'config.json'))) {
       configured.push(directory);
     }
   }
 
-  if (configured.includes(gitRoot)) return gitRoot;
+  if (configured.includes(workspaceRoot)) return workspaceRoot;
   if (configured.length === 1) return configured[0]!;
   if (configured.length > 1) {
     return chooseWorkspace(runtime, flags, {
@@ -74,7 +74,7 @@ async function selectWorkspaceDirectory(
       kind: 'configured',
     });
   }
-  if (purpose === 'read') return gitRoot;
+  if (purpose === 'read') return workspaceRoot;
   if (packages.length === 1) return packages[0]!;
   if (packages.length > 1) {
     return chooseWorkspace(runtime, flags, {
@@ -82,7 +82,31 @@ async function selectWorkspaceDirectory(
       kind: 'available',
     });
   }
-  return gitRoot;
+  return workspaceRoot;
+}
+
+async function findWorkspaceRoot(
+  start: string,
+  gitRoot: string | undefined,
+): Promise<string | undefined> {
+  try {
+    const root = await findRoot(start);
+    if (root.tool === 'root') return undefined;
+    if (gitRoot && !isWithin(gitRoot, root.rootDir)) return undefined;
+    return root.rootDir;
+  } catch (error) {
+    if (error instanceof NoPkgJsonFound || error instanceof SyntaxError) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function isWithin(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return (
+    !relative || (!relative.startsWith(`..${path.sep}`) && relative !== '..')
+  );
 }
 
 async function chooseWorkspace(

--- a/packages/cli/src/core/workspace.ts
+++ b/packages/cli/src/core/workspace.ts
@@ -1,0 +1,144 @@
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { getPackages } from '@manypkg/get-packages';
+import { findGitRoot, findPackageRoot } from './config';
+import { usageError } from './errors';
+import type { CliRuntime, GlobalFlags } from './runtime';
+
+type ContextPurpose = 'read' | 'write';
+
+export async function resolveWorkingDirectory(
+  current: string,
+  requested: string,
+): Promise<string> {
+  const resolved = path.resolve(current, requested);
+  try {
+    if ((await stat(resolved)).isDirectory()) return resolved;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  throw usageError(
+    'working_directory_not_found',
+    `Working directory does not exist: ${resolved}.`,
+  );
+}
+
+export async function selectWorkspaceContext(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  purpose: ContextPurpose,
+): Promise<void> {
+  if (flags.cwd) return;
+
+  const selected = await selectWorkspaceDirectory(runtime, flags, purpose);
+  if (selected !== runtime.cwd) runtime.setCwd(selected);
+}
+
+export async function isWorkspaceRoot(directory: string): Promise<boolean> {
+  if (await exists(path.join(directory, 'pnpm-workspace.yaml'))) return true;
+  try {
+    const manifest = JSON.parse(
+      await readFile(path.join(directory, 'package.json'), 'utf8'),
+    ) as { workspaces?: unknown };
+    return Array.isArray(manifest.workspaces) || Boolean(manifest.workspaces);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+async function selectWorkspaceDirectory(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  purpose: ContextPurpose,
+): Promise<string> {
+  const start = path.resolve(runtime.cwd);
+  const gitRoot = await findGitRoot(start);
+  const packageRoot = await findPackageRoot(start);
+  if (!gitRoot || start !== gitRoot) return packageRoot;
+  if (!(await isWorkspaceRoot(gitRoot))) return packageRoot;
+
+  const packages = await discoverPackageDirectories(gitRoot);
+  const configured = [];
+  for (const directory of [gitRoot, ...packages]) {
+    if (await exists(path.join(directory, '.edgestore', 'config.json'))) {
+      configured.push(directory);
+    }
+  }
+
+  if (configured.includes(gitRoot)) return gitRoot;
+  if (configured.length === 1) return configured[0]!;
+  if (configured.length > 1) {
+    return chooseWorkspace(runtime, flags, {
+      directories: configured,
+      kind: 'configured',
+    });
+  }
+  if (purpose === 'read') return gitRoot;
+  if (packages.length === 1) return packages[0]!;
+  if (packages.length > 1) {
+    return chooseWorkspace(runtime, flags, {
+      directories: packages,
+      kind: 'available',
+    });
+  }
+  return gitRoot;
+}
+
+async function chooseWorkspace(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+  input: {
+    directories: string[];
+    kind: 'configured' | 'available';
+  },
+): Promise<string> {
+  const interactive = runtime.io.inputIsTty && !flags.json && !flags.plain;
+  if (!interactive) {
+    throw usageError(
+      'workspace_context_required',
+      `Multiple ${input.kind} workspaces were found.`,
+      ['Pass --cwd <directory> to select a workspace package.'],
+    );
+  }
+
+  return runtime.prompts.select(
+    'Which workspace package should EdgeStore use?',
+    await Promise.all(
+      input.directories.map(async (directory) => ({
+        value: directory,
+        label: await packageLabel(directory),
+        hint: path.relative(runtime.cwd, directory) || '.',
+      })),
+    ),
+  );
+}
+
+async function discoverPackageDirectories(root: string): Promise<string[]> {
+  const workspace = await getPackages(root);
+  return workspace.packages.map((workspacePackage) => workspacePackage.dir);
+}
+
+async function packageLabel(directory: string): Promise<string> {
+  try {
+    const manifest = JSON.parse(
+      await readFile(path.join(directory, 'package.json'), 'utf8'),
+    ) as { name?: unknown };
+    if (typeof manifest.name === 'string' && manifest.name.trim()) {
+      return manifest.name;
+    }
+  } catch {
+    // Invalid manifests are reported by init before remote mutations.
+  }
+  return path.basename(directory);
+}
+
+async function exists(candidate: string): Promise<boolean> {
+  try {
+    await stat(candidate);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}

--- a/packages/cli/src/file.test.ts
+++ b/packages/cli/src/file.test.ts
@@ -1,4 +1,5 @@
 import {
+  mkdir,
   mkdtemp,
   readdir,
   readFile,
@@ -178,6 +179,47 @@ describe('file', () => {
       path: 'reports',
       fileName: 'renamed.txt',
     });
+  });
+
+  it('keeps upload paths relative to the invocation directory', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-upload-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.repoConfig.config = {
+      account: account.id,
+      project: project.basePath,
+    };
+    await writeFile(
+      path.join(temporaryDirectory, 'package.json'),
+      JSON.stringify({ private: true }),
+    );
+    await writeFile(
+      path.join(temporaryDirectory, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'apps/*'\n",
+    );
+    await writeFile(path.join(temporaryDirectory, 'logo.txt'), 'upload me');
+    const appDirectory = path.join(temporaryDirectory, 'apps', 'web');
+    await mkdir(path.join(appDirectory, '.edgestore'), { recursive: true });
+    await writeFile(
+      path.join(appDirectory, 'package.json'),
+      JSON.stringify({ name: 'web' }),
+    );
+    await writeFile(
+      path.join(appDirectory, '.edgestore', 'config.json'),
+      JSON.stringify({ account: account.id, project: project.basePath }),
+    );
+
+    const exitCode = await runCli(
+      ['file', 'upload', 'logo.txt', '--bucket', 'publicFiles'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fixture.uploadFile).toHaveBeenCalledOnce();
+    expect(fixture.runtime.cwd).toBe(temporaryDirectory);
+    expect(fixture.runtime.workspaceCwd).toBe(appDirectory);
   });
 
   it('rejects --keep-name with an exact upload destination', async () => {

--- a/packages/cli/src/init.integration.test.ts
+++ b/packages/cli/src/init.integration.test.ts
@@ -407,7 +407,7 @@ describe('init.integration', () => {
     );
   });
 
-  it('uses pnpm workspace-root mode only for an explicitly selected root', async () => {
+  it('uses pnpm workspace-root mode for the selected root', async () => {
     temporaryDirectory = await mkdtemp(
       path.join(tmpdir(), 'edgestore-cli-init-'),
     );
@@ -427,15 +427,7 @@ describe('init.integration', () => {
     );
 
     const exitCode = await runCli(
-      [
-        '--cwd',
-        '.',
-        'init',
-        '--link',
-        project.basePath,
-        '--without-key',
-        '--install',
-      ],
+      ['init', '--link', project.basePath, '--without-key', '--install'],
       fixture.runtime,
       '0.0.0',
     );

--- a/packages/cli/src/init.integration.test.ts
+++ b/packages/cli/src/init.integration.test.ts
@@ -491,7 +491,8 @@ describe('init.integration', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(fixture.runtime.cwd).toBe(appDirectory);
+    expect(fixture.runtime.cwd).toBe(temporaryDirectory);
+    expect(fixture.runtime.workspaceCwd).toBe(appDirectory);
     expect(fixture.runCommand).toHaveBeenCalledWith(
       'pnpm',
       ['add', '@edgestore/server', '@edgestore/react'],

--- a/packages/cli/src/init.integration.test.ts
+++ b/packages/cli/src/init.integration.test.ts
@@ -448,13 +448,12 @@ describe('init.integration', () => {
     );
   });
 
-  it('detects and installs from the only configured workspace package', async () => {
+  it('detects, installs, and renders commands for a Git-less workspace package', async () => {
     temporaryDirectory = await mkdtemp(
       path.join(tmpdir(), 'edgestore-cli-init-'),
     );
     fixture.runtime.cwd = temporaryDirectory;
     fixture.runtime.io.inputIsTty = false;
-    await mkdir(path.join(temporaryDirectory, '.git'));
     await writeFile(
       path.join(temporaryDirectory, 'pnpm-workspace.yaml'),
       "packages:\n  - 'apps/*'\n",
@@ -498,6 +497,23 @@ describe('init.integration', () => {
       ['add', '@edgestore/server', '@edgestore/react'],
       { cwd: appDirectory },
     );
+
+    const deferredFixture = createFixture();
+    deferredFixture.runtime.cwd = temporaryDirectory;
+    deferredFixture.runtime.io.inputIsTty = false;
+    const deferredExitCode = await runCli(
+      ['--json', 'init', '--link', project.basePath, '--without-key'],
+      deferredFixture.runtime,
+      '0.0.0',
+    );
+
+    expect(deferredExitCode).toBe(0);
+    expect(JSON.parse(deferredFixture.stdout()).install).toEqual({
+      command:
+        'pnpm --filter ./apps/web add @edgestore/server @edgestore/react',
+      cwd: appDirectory,
+      ran: false,
+    });
   });
 
   it('keeps package-manager output off structured stdout', async () => {

--- a/packages/cli/src/init.integration.test.ts
+++ b/packages/cli/src/init.integration.test.ts
@@ -407,6 +407,98 @@ describe('init.integration', () => {
     );
   });
 
+  it('uses pnpm workspace-root mode only for an explicitly selected root', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-init-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.runtime.io.inputIsTty = false;
+    await mkdir(path.join(temporaryDirectory, '.git'));
+    await writeFile(
+      path.join(temporaryDirectory, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'apps/*'\n",
+    );
+    await writeFile(
+      path.join(temporaryDirectory, 'package.json'),
+      JSON.stringify({
+        packageManager: 'pnpm@11.15.1',
+        dependencies: { next: '16' },
+      }),
+    );
+
+    const exitCode = await runCli(
+      [
+        '--cwd',
+        '.',
+        'init',
+        '--link',
+        project.basePath,
+        '--without-key',
+        '--install',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fixture.runCommand).toHaveBeenCalledWith(
+      'pnpm',
+      ['add', '-w', '@edgestore/server', '@edgestore/react'],
+      { cwd: temporaryDirectory },
+    );
+  });
+
+  it('detects and installs from the only configured workspace package', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-init-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    fixture.runtime.io.inputIsTty = false;
+    await mkdir(path.join(temporaryDirectory, '.git'));
+    await writeFile(
+      path.join(temporaryDirectory, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'apps/*'\n",
+    );
+    await writeFile(
+      path.join(temporaryDirectory, 'package.json'),
+      JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        packageManager: 'pnpm@11.15.1',
+      }),
+    );
+    const appDirectory = path.join(temporaryDirectory, 'apps', 'web');
+    const apiDirectory = path.join(temporaryDirectory, 'apps', 'api');
+    await mkdir(path.join(appDirectory, '.edgestore'), { recursive: true });
+    await mkdir(apiDirectory, { recursive: true });
+    await writeFile(
+      path.join(appDirectory, 'package.json'),
+      JSON.stringify({ name: 'web', dependencies: { next: '16' } }),
+    );
+    await writeFile(
+      path.join(apiDirectory, 'package.json'),
+      JSON.stringify({ name: 'api' }),
+    );
+    await writeFile(
+      path.join(appDirectory, '.edgestore', 'config.json'),
+      JSON.stringify({ account: account.id, project: project.basePath }),
+    );
+
+    const exitCode = await runCli(
+      ['init', '--link', project.basePath, '--without-key', '--install'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fixture.runtime.cwd).toBe(appDirectory);
+    expect(fixture.runCommand).toHaveBeenCalledWith(
+      'pnpm',
+      ['add', '@edgestore/server', '@edgestore/react'],
+      { cwd: appDirectory },
+    );
+  });
+
   it('keeps package-manager output off structured stdout', async () => {
     temporaryDirectory = await mkdtemp(
       path.join(tmpdir(), 'edgestore-cli-init-'),

--- a/packages/cli/src/testFixture.ts
+++ b/packages/cli/src/testFixture.ts
@@ -539,6 +539,7 @@ export function createFixture(): CliTestFixture {
   const runtime: CliRuntime = {
     exitCode: 0,
     cwd: '/repo',
+    workspaceCwd: '/repo',
     env: {},
     io: {
       stdin: Readable.from([]),
@@ -550,6 +551,10 @@ export function createFixture(): CliTestFixture {
     signal: abortController.signal,
     setCwd(cwd) {
       runtime.cwd = cwd;
+      runtime.setWorkspaceCwd(cwd);
+    },
+    setWorkspaceCwd(cwd) {
+      runtime.workspaceCwd = cwd;
     },
     globalConfig: {
       path: '/config/edgestore/config.json',

--- a/packages/cli/src/testFixture.ts
+++ b/packages/cli/src/testFixture.ts
@@ -548,6 +548,9 @@ export function createFixture(): CliTestFixture {
       outputIsTty: false,
     },
     signal: abortController.signal,
+    setCwd(cwd) {
+      runtime.cwd = cwd;
+    },
     globalConfig: {
       path: '/config/edgestore/config.json',
       read: vi.fn(async () => ({ ...globalConfig })),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,6 +881,9 @@ importers:
       '@edgestore/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@manypkg/get-packages':
+        specifier: 3.1.0
+        version: 3.1.0
       '@napi-rs/keyring':
         specifier: 1.3.0
         version: 1.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,6 +881,9 @@ importers:
       '@edgestore/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@manypkg/find-root':
+        specifier: 3.1.0
+        version: 3.1.0
       '@manypkg/get-packages':
         specifier: 3.1.0
         version: 3.1.0


### PR DESCRIPTION
## Summary

- add global `--cwd <directory>` targeting and preserve it in generated follow-up commands
- keep EdgeStore config, env output, Gitignore updates, framework detection, and package installation scoped to the selected workspace package
- discover declared pnpm/npm/Yarn workspace packages, auto-select a single configured package, and prompt for ambiguous interactive use
- require `--cwd` or an explicit `--project` for ambiguous automation, while keeping account-level commands workspace-independent
- add pnpm `-w` only when the workspace root is explicitly selected

## Changeset

No additional changeset is included. The CLI is still unreleased, and `.changeset/calm-clouds-guide.md` in the base PR already owns the single comprehensive minor release entry for the initial CLI stack.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @edgestore/cli build`
- `pnpm check:dependencies`
- `pnpm exec prettier --check packages/cli pnpm-lock.yaml`

Stacked on #209.