### PR TITLE
[CLI 12] chore(sdk): sync management OAuth contract

### DIFF
--- a/.changeset/bright-pandas-auth.md
+++ b/.changeset/bright-pandas-auth.md
@@ -1,0 +1,6 @@
+---
+'@edgestore/sdk': patch
+---
+
+Update the pinned API v2 contract with OAuth user principals and the latest
+management token scopes and presets.

--- a/packages/sdk/src/generated/api-v2.ts
+++ b/packages/sdk/src/generated/api-v2.ts
@@ -1941,7 +1941,7 @@ export interface operations {
                                 /** @description Owning account ID. */
                                 accountId: string;
                                 /** @description Effective management permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "file:delete" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                             } | {
                                 /**
                                  * @description User-owned management-token principal.
@@ -1951,7 +1951,52 @@ export interface operations {
                                 /** @description Authenticated token ID. */
                                 tokenId: string;
                                 /** @description Effective management permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "file:delete" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                /** @description Authenticated user identity. */
+                                user: {
+                                    /** @description Unique EdgeStore user ID. */
+                                    id: string;
+                                    /** @description User ID from the identity provider. */
+                                    clerkUserId: string;
+                                    /** @description User's personal account ID. */
+                                    accountId: string;
+                                    /** @description Primary email address. */
+                                    email: string;
+                                    /** @description Username when configured. */
+                                    username: string | null;
+                                    /** @description First name when configured. */
+                                    firstName: string | null;
+                                    /** @description Last name when configured. */
+                                    lastName: string | null;
+                                    /** @description Profile image URL. */
+                                    picture: string;
+                                };
+                            } | {
+                                /**
+                                 * @description OAuth user principal.
+                                 * @constant
+                                 */
+                                kind: "oauth_user";
+                                /** @description OAuth subject identifier. */
+                                subject: string;
+                                /** @description OAuth client identifier. */
+                                clientId: string;
+                                /** @description Effective management permissions. */
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "file:delete" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                /** @description Accounts and projects this OAuth grant may access. */
+                                access: {
+                                    accounts: {
+                                        accountId: string;
+                                        projects: {
+                                            /** @constant */
+                                            mode: "all";
+                                        } | {
+                                            /** @constant */
+                                            mode: "selected";
+                                            projectIds: string[];
+                                        };
+                                    }[];
+                                };
                                 /** @description Authenticated user identity. */
                                 user: {
                                     /** @description Unique EdgeStore user ID. */
@@ -6161,7 +6206,7 @@ export interface operations {
                                 /** @description Non-secret token prefix used to identify the credential. */
                                 tokenPrefix: string;
                                 /** @description Granted permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "file:delete" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                                 /** @description ISO 8601 creation timestamp. */
                                 createdAt: string;
                                 /** @description ISO 8601 last-update timestamp. */
@@ -6261,9 +6306,9 @@ export interface operations {
                      * @description Named permission set. Mutually exclusive with scopes.
                      * @enum {string}
                      */
-                    preset?: "deploy" | "read-only" | "full-access";
+                    preset?: "deploy" | "storage-management" | "read-only" | "full-access";
                     /** @description Explicit permissions. Mutually exclusive with preset. */
-                    scopes?: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                    scopes?: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "file:delete" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                     /** @description ISO 8601 expiration timestamp, or null for no expiration. */
                     expiresAt?: string | null;
                 };
@@ -6294,7 +6339,7 @@ export interface operations {
                                 /** @description Non-secret token prefix used to identify the credential. */
                                 tokenPrefix: string;
                                 /** @description Granted permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "file:delete" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                                 /** @description ISO 8601 creation timestamp. */
                                 createdAt: string;
                                 /** @description ISO 8601 last-update timestamp. */
@@ -6413,7 +6458,7 @@ export interface operations {
                                 /** @description Non-secret token prefix used to identify the credential. */
                                 tokenPrefix: string;
                                 /** @description Granted permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "file:delete" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                                 /** @description ISO 8601 creation timestamp. */
                                 createdAt: string;
                                 /** @description ISO 8601 last-update timestamp. */
@@ -6501,9 +6546,9 @@ export interface operations {
                      * @description Named permission set. Mutually exclusive with scopes.
                      * @enum {string}
                      */
-                    preset?: "deploy" | "read-only" | "full-access";
+                    preset?: "deploy" | "storage-management" | "read-only" | "full-access";
                     /** @description Explicit permissions. Mutually exclusive with preset. */
-                    scopes?: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                    scopes?: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "file:delete" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                     /** @description ISO 8601 expiration timestamp, or null for no expiration. */
                     expiresAt?: string | null;
                 };
@@ -6534,7 +6579,7 @@ export interface operations {
                                 /** @description Non-secret token prefix used to identify the credential. */
                                 tokenPrefix: string;
                                 /** @description Granted permissions. */
-                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
+                                scopes: ("account:read" | "project:read" | "project:create" | "project:delete" | "bucket:read" | "bucket:write" | "bucket:delete" | "bucket:empty" | "file:read" | "file:write" | "file:delete" | "project-key:read" | "project-key:create" | "project-key:revoke" | "member:read" | "member:write" | "token:read" | "token:create" | "token:revoke")[];
                                 /** @description ISO 8601 creation timestamp. */
                                 createdAt: string;
                                 /** @description ISO 8601 last-update timestamp. */
@@ -7313,8 +7358,8 @@ export interface operations {
                                     } | {
                                         /** @description Inclusive lower and upper bounds. */
                                         between: [
-                                            unknown,
-                                            unknown
+                                            string,
+                                            string
                                         ];
                                     };
                                 };
@@ -7340,8 +7385,8 @@ export interface operations {
                                     } | {
                                         /** @description Inclusive lower and upper bounds. */
                                         between: [
-                                            unknown,
-                                            unknown
+                                            string,
+                                            string
                                         ];
                                     };
                                 };
@@ -7399,8 +7444,8 @@ export interface operations {
                                     } | {
                                         /** @description Inclusive lower and upper bounds. */
                                         between: [
-                                            unknown,
-                                            unknown
+                                            string,
+                                            string
                                         ];
                                     };
                                 };
@@ -7426,8 +7471,8 @@ export interface operations {
                                     } | {
                                         /** @description Inclusive lower and upper bounds. */
                                         between: [
-                                            unknown,
-                                            unknown
+                                            string,
+                                            string
                                         ];
                                     };
                                 };
@@ -7567,8 +7612,8 @@ export interface operations {
                                     } | {
                                         /** @description Inclusive lower and upper bounds. */
                                         between: [
-                                            unknown,
-                                            unknown
+                                            string,
+                                            string
                                         ];
                                     };
                                 };
@@ -7594,8 +7639,8 @@ export interface operations {
                                     } | {
                                         /** @description Inclusive lower and upper bounds. */
                                         between: [
-                                            unknown,
-                                            unknown
+                                            string,
+                                            string
                                         ];
                                     };
                                 };
@@ -7653,8 +7698,8 @@ export interface operations {
                                     } | {
                                         /** @description Inclusive lower and upper bounds. */
                                         between: [
-                                            unknown,
-                                            unknown
+                                            string,
+                                            string
                                         ];
                                     };
                                 };
@@ -7680,8 +7725,8 @@ export interface operations {
                                     } | {
                                         /** @description Inclusive lower and upper bounds. */
                                         between: [
-                                            unknown,
-                                            unknown
+                                            string,
+                                            string
                                         ];
                                     };
                                 };

--- a/packages/sdk/src/generated/openapi-v2.json
+++ b/packages/sdk/src/generated/openapi-v2.json
@@ -1848,6 +1848,7 @@
                                       "bucket:empty",
                                       "file:read",
                                       "file:write",
+                                      "file:delete",
                                       "project-key:read",
                                       "project-key:create",
                                       "project-key:revoke",
@@ -1894,6 +1895,7 @@
                                       "bucket:empty",
                                       "file:read",
                                       "file:write",
+                                      "file:delete",
                                       "project-key:read",
                                       "project-key:create",
                                       "project-key:revoke",
@@ -1981,6 +1983,185 @@
                                 "kind",
                                 "tokenId",
                                 "scopes",
+                                "user"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "const": "oauth_user",
+                                  "description": "OAuth user principal."
+                                },
+                                "subject": {
+                                  "type": "string",
+                                  "description": "OAuth subject identifier."
+                                },
+                                "clientId": {
+                                  "type": "string",
+                                  "description": "OAuth client identifier."
+                                },
+                                "scopes": {
+                                  "type": "array",
+                                  "items": {
+                                    "enum": [
+                                      "account:read",
+                                      "project:read",
+                                      "project:create",
+                                      "project:delete",
+                                      "bucket:read",
+                                      "bucket:write",
+                                      "bucket:delete",
+                                      "bucket:empty",
+                                      "file:read",
+                                      "file:write",
+                                      "file:delete",
+                                      "project-key:read",
+                                      "project-key:create",
+                                      "project-key:revoke",
+                                      "member:read",
+                                      "member:write",
+                                      "token:read",
+                                      "token:create",
+                                      "token:revoke"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "description": "Effective management permissions."
+                                },
+                                "access": {
+                                  "type": "object",
+                                  "properties": {
+                                    "accounts": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "accountId": {
+                                            "type": "string"
+                                          },
+                                          "projects": {
+                                            "anyOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "mode": {
+                                                    "const": "all"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "mode"
+                                                ]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "mode": {
+                                                    "const": "selected"
+                                                  },
+                                                  "projectIds": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "mode",
+                                                  "projectIds"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "accountId",
+                                          "projects"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "accounts"
+                                  ],
+                                  "description": "Accounts and projects this OAuth grant may access."
+                                },
+                                "user": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "Unique EdgeStore user ID."
+                                    },
+                                    "clerkUserId": {
+                                      "type": "string",
+                                      "description": "User ID from the identity provider."
+                                    },
+                                    "accountId": {
+                                      "type": "string",
+                                      "description": "User's personal account ID."
+                                    },
+                                    "email": {
+                                      "type": "string",
+                                      "description": "Primary email address."
+                                    },
+                                    "username": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "description": "Username when configured."
+                                    },
+                                    "firstName": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "description": "First name when configured."
+                                    },
+                                    "lastName": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "description": "Last name when configured."
+                                    },
+                                    "picture": {
+                                      "type": "string",
+                                      "description": "Profile image URL."
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "clerkUserId",
+                                    "accountId",
+                                    "email",
+                                    "username",
+                                    "firstName",
+                                    "lastName",
+                                    "picture"
+                                  ],
+                                  "description": "Authenticated user identity."
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "subject",
+                                "clientId",
+                                "scopes",
+                                "access",
                                 "user"
                               ]
                             }
@@ -11373,6 +11554,7 @@
                                     "bucket:empty",
                                     "file:read",
                                     "file:write",
+                                    "file:delete",
                                     "project-key:read",
                                     "project-key:create",
                                     "project-key:revoke",
@@ -11635,6 +11817,7 @@
                   "preset": {
                     "enum": [
                       "deploy",
+                      "storage-management",
                       "read-only",
                       "full-access"
                     ],
@@ -11656,6 +11839,7 @@
                         "bucket:empty",
                         "file:read",
                         "file:write",
+                        "file:delete",
                         "project-key:read",
                         "project-key:create",
                         "project-key:revoke",
@@ -11739,6 +11923,7 @@
                                   "bucket:empty",
                                   "file:read",
                                   "file:write",
+                                  "file:delete",
                                   "project-key:read",
                                   "project-key:create",
                                   "project-key:revoke",
@@ -12056,6 +12241,7 @@
                                     "bucket:empty",
                                     "file:read",
                                     "file:write",
+                                    "file:delete",
                                     "project-key:read",
                                     "project-key:create",
                                     "project-key:revoke",
@@ -12290,6 +12476,7 @@
                   "preset": {
                     "enum": [
                       "deploy",
+                      "storage-management",
                       "read-only",
                       "full-access"
                     ],
@@ -12311,6 +12498,7 @@
                         "bucket:empty",
                         "file:read",
                         "file:write",
+                        "file:delete",
                         "project-key:read",
                         "project-key:create",
                         "project-key:revoke",
@@ -12394,6 +12582,7 @@
                                   "bucket:empty",
                                   "file:read",
                                   "file:write",
+                                  "file:delete",
                                   "project-key:read",
                                   "project-key:create",
                                   "project-key:revoke",
@@ -14202,8 +14391,12 @@
                                             "between": {
                                               "type": "array",
                                               "prefixItems": [
-                                                {},
-                                                {}
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
                                               ],
                                               "description": "Inclusive lower and upper bounds."
                                             }
@@ -14272,8 +14465,12 @@
                                             "between": {
                                               "type": "array",
                                               "prefixItems": [
-                                                {},
-                                                {}
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
                                               ],
                                               "description": "Inclusive lower and upper bounds."
                                             }
@@ -14425,8 +14622,12 @@
                                             "between": {
                                               "type": "array",
                                               "prefixItems": [
-                                                {},
-                                                {}
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
                                               ],
                                               "description": "Inclusive lower and upper bounds."
                                             }
@@ -14495,8 +14696,12 @@
                                             "between": {
                                               "type": "array",
                                               "prefixItems": [
-                                                {},
-                                                {}
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
                                               ],
                                               "description": "Inclusive lower and upper bounds."
                                             }
@@ -14873,8 +15078,12 @@
                                             "between": {
                                               "type": "array",
                                               "prefixItems": [
-                                                {},
-                                                {}
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
                                               ],
                                               "description": "Inclusive lower and upper bounds."
                                             }
@@ -14943,8 +15152,12 @@
                                             "between": {
                                               "type": "array",
                                               "prefixItems": [
-                                                {},
-                                                {}
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
                                               ],
                                               "description": "Inclusive lower and upper bounds."
                                             }
@@ -15096,8 +15309,12 @@
                                             "between": {
                                               "type": "array",
                                               "prefixItems": [
-                                                {},
-                                                {}
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
                                               ],
                                               "description": "Inclusive lower and upper bounds."
                                             }
@@ -15166,8 +15383,12 @@
                                             "between": {
                                               "type": "array",
                                               "prefixItems": [
-                                                {},
-                                                {}
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
                                               ],
                                               "description": "Inclusive lower and upper bounds."
                                             }

--- a/packages/sdk/src/generated/source.ts
+++ b/packages/sdk/src/generated/source.ts
@@ -2,7 +2,7 @@ export const API_V2_SOURCE_REPOSITORY =
   'https://github.com/edgestorejs/edge-store-app' as const;
 
 export const API_V2_SOURCE_COMMIT =
-  '70f0dab08e9181fbbe1f4a0e8b9fa4966003bec8' as const;
+  'c9245218aa11f84e2d959c7d34c3686f12836c4a' as const;
 
 export const API_V2_SCHEMA_SHA256 =
-  'fd0b03eaf0bce45b704cbb5d7f042809df9ee16213d52a9da97eea003f1bb6c8' as const;
+  '4e581267e78d9589b706c971132684194e1ee08037ea55b81d0129c51b259f8f' as const;


### PR DESCRIPTION
## Summary

- sync the SDK's pinned API v2 schema from `edge-store-app` commit `c924521`
- generate the `oauth_user` actor contract exposed by `whoami`
- include the latest `file:delete` scope and `storage-management` preset contract
- record the source repository, commit, and schema checksum

## Why

The browser OAuth CLI slice needs the SDK to understand OAuth user principals before it can validate and display the authenticated identity. Keeping the generated contract in its own slice makes the API-to-SDK change reviewable independently from the CLI protocol implementation.

## Changeset

This PR includes an `@edgestore/sdk` patch changeset because the generated public API response types are expanded.

## Validation

- `pnpm --filter @edgestore/sdk test`
- `pnpm --filter @edgestore/sdk typecheck`
- `pnpm --filter @edgestore/sdk build`
