### PR TITLE
[CLI 13] feat(cli): add browser OAuth login

### DIFF
--- a/.changeset/calm-clouds-guide.md
+++ b/.changeset/calm-clouds-guide.md
@@ -5,7 +5,8 @@
 
 Add the EdgeStore CLI for account and project administration, one-time key and
 management-token workflows, bucket and file operations, uploads, guided
-initialization, dashboard links, shell completion, and diagnostics.
+initialization, browser OAuth with automatic refresh and revocation, dashboard
+links, shell completion, and diagnostics.
 
 Add high-level management uploads to the SDK with transfer retries, multipart
 ETag validation, Retry-After-aware processing polling, and automatic cleanup.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,16 +7,16 @@ npm install --global @edgestore/cli
 edgestore --help
 ```
 
-Log in with a management token, then use `init` for guided local setup:
+Log in through the dashboard, then use `init` for guided local setup:
 
 ```sh
-edgestore login --token
+edgestore login
 edgestore init
 ```
 
-Use `EDGESTORE_TOKEN` for automation. Persisted credentials are stored in the
-operating system credential store and are never written to a plaintext config
-file.
+Use `edgestore login --token` or `EDGESTORE_TOKEN` for automation and other
+non-browser environments. Persisted credentials are stored in the operating
+system credential store and are never written to a plaintext config file.
 
 The CLI manages accounts, projects and their keys, management tokens, buckets,
 files, uploads, team members, and invitations. Secrets are returned only when

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,7 @@
     "@napi-rs/keyring": "1.3.0",
     "commander": "15.0.0",
     "env-paths": "4.0.0",
+    "open": "11.0.0",
     "openid-client": "6.8.4",
     "package-manager-detector": "1.8.0",
     "picocolors": "1.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "@napi-rs/keyring": "1.3.0",
     "commander": "15.0.0",
     "env-paths": "4.0.0",
+    "openid-client": "6.8.4",
     "package-manager-detector": "1.8.0",
     "picocolors": "1.1.1",
     "zod": "4.3.5"

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -123,6 +123,21 @@ describe('auth', () => {
     );
     expect(fixture.stdout()).toContain('Logged out.');
   });
+
+  it('removes a malformed OAuth login without attempting revocation', async () => {
+    const malformed = serializeOAuthCredential(oauthCredential()).slice(0, -1);
+    await fixture.credentials.set('https://api.edgestore.dev', malformed);
+
+    const exitCode = await runCli(['logout'], fixture.runtime, '0.0.0');
+
+    expect(exitCode).toBe(0);
+    expect(fixture.oauthRevoke).not.toHaveBeenCalled();
+    await expect(
+      fixture.credentials.get('https://api.edgestore.dev'),
+    ).resolves.toBeUndefined();
+    expect(fixture.stderr()).toContain('stored OAuth login is invalid');
+    expect(fixture.stdout()).toContain('Logged out.');
+  });
 });
 
 function oauthCredential(): OAuthCredential {

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -26,7 +26,7 @@ describe('auth', () => {
     expect(fixture.openUrl).toHaveBeenCalledWith(
       expect.stringContaining('/oauth/authorize'),
     );
-    expect(fixture.setOAuthClient).toHaveBeenCalledWith(
+    expect(fixture.setCachedOAuthClient).toHaveBeenCalledWith(
       'https://api.edgestore.dev',
       expect.objectContaining({ clientId: 'oauth_client' }),
     );

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -1,12 +1,74 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { runCli } from './cli';
-import { createFixture } from './testFixture';
+import {
+  parseStoredOAuthCredential,
+  serializeOAuthCredential,
+  type OAuthCredential,
+} from './core/credentials';
+import { account, createFixture, teamAccount } from './testFixture';
 
 describe('auth', () => {
   let fixture: ReturnType<typeof createFixture>;
 
   beforeEach(() => {
     fixture = createFixture();
+  });
+
+  it('logs in through the browser by default', async () => {
+    await runCli(['login'], fixture.runtime, '0.0.0');
+
+    expect(fixture.oauthLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiOrigin: 'https://api.edgestore.dev',
+        resource: 'https://api.edgestore.dev/v2',
+      }),
+    );
+    expect(fixture.openUrl).toHaveBeenCalledWith(
+      expect.stringContaining('/oauth/authorize'),
+    );
+    expect(fixture.setOAuthClient).toHaveBeenCalledWith(
+      'https://api.edgestore.dev',
+      expect.objectContaining({ clientId: 'oauth_client' }),
+    );
+    const stored = fixture.setCredential.mock.calls.at(-1)?.[1] as string;
+    expect(parseStoredOAuthCredential(stored)).toMatchObject({
+      accessToken: 'oauth_access',
+      refreshToken: 'oauth_refresh',
+    });
+    expect(fixture.stdout()).toContain('Logged in as ravi@example.com.');
+    expect(fixture.stderr()).toContain(
+      'Opening a browser to continue login...',
+    );
+  });
+
+  it('selects an account authorized by the OAuth grant', async () => {
+    fixture.globalConfig.activeAccount = 'acc_unavailable';
+    fixture.whoami.mockResolvedValueOnce({
+      actor: {
+        kind: 'oauth_user',
+        subject: 'user_123',
+        clientId: 'oauth_client',
+        scopes: ['account:read', 'project:read'],
+        access: {
+          accounts: [{ accountId: teamAccount.id, projects: { mode: 'all' } }],
+        },
+        user: {
+          id: 'user_123',
+          clerkUserId: 'clerk_123',
+          accountId: account.id,
+          email: 'ravi@example.com',
+          username: 'ravi',
+          firstName: 'Ravi',
+          lastName: null,
+          picture: 'https://example.com/ravi.png',
+        },
+      },
+    });
+
+    await runCli(['login'], fixture.runtime, '0.0.0');
+
+    expect(fixture.globalConfig.activeAccount).toBe(teamAccount.id);
+    expect(fixture.stdout()).toContain('2 scopes across 1 account.');
   });
 
   it('validates a token before saving it', async () => {
@@ -45,4 +107,33 @@ describe('auth', () => {
       'interactive_input_disabled',
     );
   });
+
+  it('revokes an OAuth refresh token before removing the local login', async () => {
+    const credential = oauthCredential();
+    await fixture.credentials.set(
+      'https://api.edgestore.dev',
+      serializeOAuthCredential(credential),
+    );
+
+    await runCli(['logout'], fixture.runtime, '0.0.0');
+
+    expect(fixture.oauthRevoke).toHaveBeenCalledWith(
+      credential,
+      fixture.runtime.signal,
+    );
+    expect(fixture.stdout()).toContain('Logged out.');
+  });
 });
+
+function oauthCredential(): OAuthCredential {
+  return {
+    version: 1,
+    kind: 'oauth',
+    accessToken: 'oauth_access',
+    refreshToken: 'oauth_refresh',
+    expiresAt: Date.now() + 60 * 60 * 1_000,
+    clientId: 'oauth_client',
+    issuer: 'https://dashboard.edgestore.dev',
+    resource: 'https://api.edgestore.dev/v2',
+  };
+}

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -39,6 +39,9 @@ describe('auth', () => {
     expect(fixture.stderr()).toContain(
       'Opening a browser to continue login...',
     );
+    expect(fixture.stderr()).toContain(
+      'https://dashboard.edgestore.dev/oauth/authorize?client_id=oauth_client',
+    );
   });
 
   it('selects an account authorized by the OAuth grant', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -143,6 +143,7 @@ function createProgram(
       'after',
       `
 Common workflows:
+  edgestore login
   edgestore login --token
   edgestore init
   edgestore project list
@@ -161,7 +162,7 @@ Common workflows:
 
   program
     .command('login')
-    .description('Log in with a management credential')
+    .description('Log in to EdgeStore')
     .option('--token', 'read and securely store a management token')
     .action(async (options: { token?: boolean }) => {
       await loginCommand(runtime, globalFlags(program), options);

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -52,8 +52,16 @@ export async function logoutCommand(
   flags: GlobalFlags,
 ): Promise<void> {
   const apiOrigin = apiUrlFor(runtime, flags).displayUrl;
+  const output = outputFor(runtime, flags);
   const stored = await runtime.credentials.get(apiOrigin);
-  const oauthCredential = parseStoredOAuthCredential(stored);
+  let oauthCredential;
+  try {
+    oauthCredential = parseStoredOAuthCredential(stored);
+  } catch {
+    output.warning(
+      'The stored OAuth login is invalid. Skipping remote revocation.',
+    );
+  }
   let oauthRevoked: boolean | undefined;
   if (oauthCredential) {
     try {
@@ -62,14 +70,13 @@ export async function logoutCommand(
     } catch (error) {
       if (runtime.signal.aborted) throw error;
       oauthRevoked = false;
-      outputFor(runtime, flags).warning(
+      output.warning(
         'The OAuth grant could not be revoked remotely. The login will still be removed locally.',
       );
     }
   }
   const deleted = await runtime.credentials.delete(apiOrigin);
   const environmentTokenActive = Boolean(runtime.env.EDGESTORE_TOKEN?.trim());
-  const output = outputFor(runtime, flags);
 
   output.result(
     {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -159,7 +159,7 @@ async function browserLogin(
   const result = await runtime.oauth.login({
     apiOrigin: apiUrl.displayUrl,
     resource: apiUrl.sdkBaseUrl,
-    client: await runtime.credentials.getOAuthClient(apiUrl.displayUrl),
+    client: await runtime.credentials.getCachedOAuthClient(apiUrl.displayUrl),
     signal: runtime.signal,
     openUrl: (url) => runtime.openUrl(url),
     onAuthorizationUrl: (url) => {
@@ -175,9 +175,12 @@ async function browserLogin(
       );
     },
     onClientRegistered: (client) =>
-      runtime.credentials.setOAuthClient(apiUrl.displayUrl, client),
+      runtime.credentials.setCachedOAuthClient(apiUrl.displayUrl, client),
   });
-  await runtime.credentials.setOAuthClient(apiUrl.displayUrl, result.client);
+  await runtime.credentials.setCachedOAuthClient(
+    apiUrl.displayUrl,
+    result.client,
+  );
 
   const sdk = runtime.sdkFactory({
     token: result.credential.accessToken,

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,4 +1,8 @@
 import type { ManagementEdgeStoreSdk } from '@edgestore/sdk';
+import {
+  parseStoredOAuthCredential,
+  serializeOAuthCredential,
+} from '../core/credentials';
 import { usageError } from '../core/errors';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { apiUrlFor, credentialFor, outputFor } from '../core/runtime';
@@ -13,13 +17,7 @@ export async function loginCommand(
   flags: GlobalFlags,
   options: LoginOptions,
 ): Promise<void> {
-  if (!options.token) {
-    throw usageError(
-      'browser_login_unavailable',
-      'Browser login is not available yet.',
-      ['edgestore login --token'],
-    );
-  }
+  if (!options.token) return await browserLogin(runtime, flags);
   if (flags.json && runtime.io.inputIsTty) {
     throw usageError(
       'interactive_input_disabled',
@@ -40,14 +38,7 @@ export async function loginCommand(
   const identity = await sdk.management.whoami({ signal: runtime.signal });
 
   await runtime.credentials.set(apiUrl.displayUrl, token);
-  const accountId = accountIdFromActor(identity.actor);
-  if (accountId) {
-    const config = await runtime.globalConfig.read();
-    await runtime.globalConfig.write({
-      ...config,
-      activeAccount: accountId,
-    });
-  }
+  await updateActiveAccount(runtime, identity.actor);
 
   outputFor(runtime, flags).result(
     { authenticated: true, actor: identity.actor },
@@ -60,14 +51,32 @@ export async function logoutCommand(
   runtime: CliRuntime,
   flags: GlobalFlags,
 ): Promise<void> {
-  const deleted = await runtime.credentials.delete(
-    apiUrlFor(runtime, flags).displayUrl,
-  );
+  const apiOrigin = apiUrlFor(runtime, flags).displayUrl;
+  const stored = await runtime.credentials.get(apiOrigin);
+  const oauthCredential = parseStoredOAuthCredential(stored);
+  let oauthRevoked: boolean | undefined;
+  if (oauthCredential) {
+    try {
+      await runtime.oauth.revoke(oauthCredential, runtime.signal);
+      oauthRevoked = true;
+    } catch (error) {
+      if (runtime.signal.aborted) throw error;
+      oauthRevoked = false;
+      outputFor(runtime, flags).warning(
+        'The OAuth grant could not be revoked remotely. The login will still be removed locally.',
+      );
+    }
+  }
+  const deleted = await runtime.credentials.delete(apiOrigin);
   const environmentTokenActive = Boolean(runtime.env.EDGESTORE_TOKEN?.trim());
   const output = outputFor(runtime, flags);
 
   output.result(
-    { loggedOut: deleted, environmentTokenActive },
+    {
+      loggedOut: deleted,
+      environmentTokenActive,
+      ...(oauthRevoked === undefined ? {} : { oauthRevoked }),
+    },
     deleted ? 'Logged out.' : 'No stored login found.',
     String(deleted),
   );
@@ -134,12 +143,81 @@ function actorLabel(
   return actor.user.email;
 }
 
-function accountIdFromActor(
+async function browserLogin(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+): Promise<void> {
+  const apiUrl = apiUrlFor(runtime, flags);
+  const output = outputFor(runtime, flags);
+  const result = await runtime.oauth.login({
+    apiOrigin: apiUrl.displayUrl,
+    resource: apiUrl.sdkBaseUrl,
+    client: await runtime.credentials.getOAuthClient(apiUrl.displayUrl),
+    signal: runtime.signal,
+    openUrl: (url) => runtime.openUrl(url),
+    onAuthorizationUrl: () => {
+      if (output.options.mode === 'human') {
+        runtime.io.stderr.write('Opening a browser to continue login...\n');
+      }
+    },
+    onBrowserOpenFailed: (url) => {
+      output.warning(
+        `Could not open a browser automatically. Open this URL:\n  ${url}`,
+      );
+    },
+    onClientRegistered: (client) =>
+      runtime.credentials.setOAuthClient(apiUrl.displayUrl, client),
+  });
+  await runtime.credentials.setOAuthClient(apiUrl.displayUrl, result.client);
+
+  const sdk = runtime.sdkFactory({
+    token: result.credential.accessToken,
+    baseUrl: apiUrl.sdkBaseUrl,
+  });
+  const identity = await sdk.management.whoami({ signal: runtime.signal });
+  await runtime.credentials.set(
+    apiUrl.displayUrl,
+    serializeOAuthCredential(result.credential),
+  );
+  await updateActiveAccount(runtime, identity.actor);
+
+  const accessSummary =
+    identity.actor.kind === 'oauth_user'
+      ? formatOAuthAccess(
+          identity.actor.scopes.length,
+          identity.actor.access.accounts.length,
+        )
+      : '';
+  output.result(
+    { authenticated: true, actor: identity.actor },
+    `Logged in as ${actorLabel(identity.actor)}.${accessSummary}`,
+    actorLabel(identity.actor),
+  );
+}
+
+function formatOAuthAccess(scopeCount: number, accountCount: number) {
+  return `\nAccess: ${scopeCount} ${scopeCount === 1 ? 'scope' : 'scopes'} across ${accountCount} ${accountCount === 1 ? 'account' : 'accounts'}.`;
+}
+
+async function updateActiveAccount(
+  runtime: CliRuntime,
   actor: Awaited<
     ReturnType<ManagementEdgeStoreSdk['management']['whoami']>
   >['actor'],
-): string | undefined {
-  return actor.kind === 'account_token'
-    ? actor.accountId
-    : actor.user.accountId;
+): Promise<void> {
+  const config = await runtime.globalConfig.read();
+  let accountId: string | undefined;
+  if (actor.kind === 'account_token') {
+    accountId = actor.accountId;
+  } else if (actor.kind === 'oauth_user') {
+    const available = actor.access.accounts.map((item) => item.accountId);
+    accountId = available.includes(config.activeAccount ?? '')
+      ? config.activeAccount
+      : available[0];
+  } else {
+    accountId = actor.user.accountId;
+  }
+  if (accountId && accountId !== config.activeAccount) {
+    await runtime.globalConfig.write({ ...config, activeAccount: accountId });
+  }
 }

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -162,9 +162,11 @@ async function browserLogin(
     client: await runtime.credentials.getOAuthClient(apiUrl.displayUrl),
     signal: runtime.signal,
     openUrl: (url) => runtime.openUrl(url),
-    onAuthorizationUrl: () => {
+    onAuthorizationUrl: (url) => {
       if (output.options.mode === 'human') {
-        runtime.io.stderr.write('Opening a browser to continue login...\n');
+        runtime.io.stderr.write(
+          `Opening a browser to continue login...\nIf it does not open, visit:\n  ${url}\n`,
+        );
       }
     },
     onBrowserOpenFailed: (url) => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -39,7 +39,11 @@ export async function doctorCommand(
     credential = await resolveCredential(
       runtime.env.EDGESTORE_TOKEN,
       runtime.credentials,
-      apiUrl.displayUrl,
+      {
+        apiOrigin: apiUrl.displayUrl,
+        oauth: runtime.oauth,
+        signal: runtime.signal,
+      },
     );
     checks.push({
       name: 'Credential',

--- a/packages/cli/src/core/credentials.test.ts
+++ b/packages/cli/src/core/credentials.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
-import { resolveCredential, type CredentialStore } from './credentials';
+import {
+  parseStoredOAuthCredential,
+  resolveCredential,
+  serializeOAuthCredential,
+  type CredentialStore,
+  type OAuthCredential,
+} from './credentials';
 
 describe('resolveCredential', () => {
   it('prefers EDGESTORE_TOKEN without reading the keychain', async () => {
     const { store, getCredential } = credentialStore('stored');
 
     await expect(
-      resolveCredential(' environment ', store, 'https://api.edgestore.dev'),
+      resolveCredential(' environment ', store, {
+        apiOrigin: 'https://api.edgestore.dev',
+      }),
     ).resolves.toEqual({ token: 'environment', source: 'environment' });
     expect(getCredential).not.toHaveBeenCalled();
   });
@@ -15,22 +23,90 @@ describe('resolveCredential', () => {
     const { store, getCredential } = credentialStore(' stored ');
 
     await expect(
-      resolveCredential(undefined, store, 'https://api-dev.edgestore.dev'),
+      resolveCredential(undefined, store, {
+        apiOrigin: 'https://api-dev.edgestore.dev',
+      }),
     ).resolves.toEqual({ token: 'stored', source: 'keychain' });
     expect(getCredential).toHaveBeenCalledWith('https://api-dev.edgestore.dev');
+  });
+
+  it('uses an unexpired OAuth access token without refreshing it', async () => {
+    const credential = oauthCredential({ expiresAt: 1_000_000 });
+    const { store } = credentialStore(serializeOAuthCredential(credential));
+    const refresh = vi.fn();
+
+    await expect(
+      resolveCredential(undefined, store, {
+        apiOrigin: 'https://api.edgestore.dev',
+        oauth: { refresh },
+        signal: new AbortController().signal,
+        now: () => 1,
+      }),
+    ).resolves.toEqual({ token: 'oauth_access', source: 'oauth' });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('refreshes an expiring OAuth login and stores rotated tokens', async () => {
+    const credential = oauthCredential({ expiresAt: 1_000 });
+    const refreshed = oauthCredential({
+      accessToken: 'oauth_access_new',
+      refreshToken: 'oauth_refresh_new',
+      expiresAt: 1_000_000,
+    });
+    const { store, setCredential } = credentialStore(
+      serializeOAuthCredential(credential),
+    );
+    const refresh = vi.fn(async () => refreshed);
+
+    await expect(
+      resolveCredential(undefined, store, {
+        apiOrigin: 'https://api.edgestore.dev',
+        oauth: { refresh },
+        signal: new AbortController().signal,
+        now: () => 1,
+      }),
+    ).resolves.toEqual({ token: 'oauth_access_new', source: 'oauth' });
+    expect(refresh).toHaveBeenCalledWith(credential, expect.any(AbortSignal));
+    expect(setCredential).toHaveBeenCalledWith(
+      'https://api.edgestore.dev',
+      serializeOAuthCredential(refreshed),
+    );
+    expect(
+      parseStoredOAuthCredential(setCredential.mock.calls[0]?.[1]),
+    ).toEqual(refreshed);
   });
 });
 
 function credentialStore(token: string): {
   store: CredentialStore;
   getCredential: ReturnType<typeof vi.fn<CredentialStore['get']>>;
+  setCredential: ReturnType<typeof vi.fn<CredentialStore['set']>>;
 } {
   const getCredential = vi.fn<CredentialStore['get']>(async () => token);
+  const setCredential = vi.fn<CredentialStore['set']>(async () => undefined);
   const store: CredentialStore = {
     get: getCredential,
-    set: vi.fn(async () => undefined),
+    set: setCredential,
     delete: vi.fn(async () => true),
+    getOAuthClient: vi.fn(async () => undefined),
+    setOAuthClient: vi.fn(async () => undefined),
     available: vi.fn(async () => true),
   };
-  return { store, getCredential };
+  return { store, getCredential, setCredential };
+}
+
+function oauthCredential(
+  overrides: Partial<OAuthCredential> = {},
+): OAuthCredential {
+  return {
+    version: 1,
+    kind: 'oauth',
+    accessToken: 'oauth_access',
+    refreshToken: 'oauth_refresh',
+    expiresAt: 1_000_000,
+    clientId: 'client_123',
+    issuer: 'https://dashboard.edgestore.dev',
+    resource: 'https://api.edgestore.dev/v2',
+    ...overrides,
+  };
 }

--- a/packages/cli/src/core/credentials.test.ts
+++ b/packages/cli/src/core/credentials.test.ts
@@ -1,11 +1,45 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  KeyringCredentialStore,
   parseStoredOAuthCredential,
   resolveCredential,
   serializeOAuthCredential,
   type CredentialStore,
   type OAuthCredential,
 } from './credentials';
+
+const keyringMocks = vi.hoisted(() => {
+  const getPassword = vi.fn<() => Promise<string | null>>();
+  const setPassword = vi.fn<(value: string) => Promise<void>>();
+  const deleteCredential = vi.fn<() => Promise<boolean>>();
+
+  return {
+    getPassword,
+    setPassword,
+    deleteCredential,
+    AsyncEntry: class {
+      getPassword() {
+        return getPassword();
+      }
+
+      setPassword(value: string) {
+        return setPassword(value);
+      }
+
+      deleteCredential() {
+        return deleteCredential();
+      }
+    },
+  };
+});
+
+vi.mock('@napi-rs/keyring', () => ({ AsyncEntry: keyringMocks.AsyncEntry }));
+
+beforeEach(() => {
+  keyringMocks.getPassword.mockReset().mockResolvedValue(null);
+  keyringMocks.setPassword.mockReset().mockResolvedValue(undefined);
+  keyringMocks.deleteCredential.mockReset().mockResolvedValue(true);
+});
 
 describe('resolveCredential', () => {
   it('prefers EDGESTORE_TOKEN without reading the keychain', async () => {
@@ -77,6 +111,58 @@ describe('resolveCredential', () => {
   });
 });
 
+describe('OAuth client cache', () => {
+  it('reads a valid cached registration', async () => {
+    keyringMocks.getPassword.mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        clientId: 'client_123',
+        issuer: 'https://dashboard.edgestore.dev',
+        redirectUri: 'http://127.0.0.1:45678/oauth/callback',
+      }),
+    );
+
+    await expect(
+      new KeyringCredentialStore().getCachedOAuthClient(
+        'https://api.edgestore.dev',
+      ),
+    ).resolves.toMatchObject({ clientId: 'client_123' });
+  });
+
+  it.each([
+    ['malformed JSON', '{'],
+    [
+      'an unsupported version',
+      JSON.stringify({
+        version: 2,
+        clientId: 'client_123',
+        issuer: 'https://dashboard.edgestore.dev',
+        redirectUri: 'http://127.0.0.1:45678/oauth/callback',
+      }),
+    ],
+  ])('treats %s as a cache miss', async (_case, value) => {
+    keyringMocks.getPassword.mockResolvedValueOnce(value);
+
+    await expect(
+      new KeyringCredentialStore().getCachedOAuthClient(
+        'https://api.edgestore.dev',
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('propagates keychain read failures', async () => {
+    keyringMocks.getPassword.mockRejectedValueOnce(
+      new Error('keychain failed'),
+    );
+
+    await expect(
+      new KeyringCredentialStore().getCachedOAuthClient(
+        'https://api.edgestore.dev',
+      ),
+    ).rejects.toThrow('keychain failed');
+  });
+});
+
 function credentialStore(token: string): {
   store: CredentialStore;
   getCredential: ReturnType<typeof vi.fn<CredentialStore['get']>>;
@@ -88,8 +174,8 @@ function credentialStore(token: string): {
     get: getCredential,
     set: setCredential,
     delete: vi.fn(async () => true),
-    getOAuthClient: vi.fn(async () => undefined),
-    setOAuthClient: vi.fn(async () => undefined),
+    getCachedOAuthClient: vi.fn(async () => undefined),
+    setCachedOAuthClient: vi.fn(async () => undefined),
     available: vi.fn(async () => true),
   };
   return { store, getCredential, setCredential };

--- a/packages/cli/src/core/credentials.ts
+++ b/packages/cli/src/core/credentials.ts
@@ -39,10 +39,10 @@ export interface CredentialStore {
   get(apiOrigin: string): Promise<string | undefined>;
   set(apiOrigin: string, token: string): Promise<void>;
   delete(apiOrigin: string): Promise<boolean>;
-  getOAuthClient(
+  getCachedOAuthClient(
     apiOrigin: string,
   ): Promise<OAuthClientRegistration | undefined>;
-  setOAuthClient(
+  setCachedOAuthClient(
     apiOrigin: string,
     client: OAuthClientRegistration,
   ): Promise<void>;
@@ -65,17 +65,17 @@ export class KeyringCredentialStore implements CredentialStore {
     return entry.deleteCredential();
   }
 
-  async getOAuthClient(
+  async getCachedOAuthClient(
     apiOrigin: string,
   ): Promise<OAuthClientRegistration | undefined> {
     const entry = await createEntry(OAUTH_CLIENT_NAME, apiOrigin);
     const value = await entry.getPassword();
     if (!value) return undefined;
 
-    return parseOAuthClientRegistration(value);
+    return parseCachedOAuthClientRegistration(value);
   }
 
-  async setOAuthClient(
+  async setCachedOAuthClient(
     apiOrigin: string,
     client: OAuthClientRegistration,
   ): Promise<void> {
@@ -186,15 +186,17 @@ function parseStoredCredential(value: string): string | OAuthCredential {
   return parseStoredOAuthCredential(value) ?? value;
 }
 
-function parseOAuthClientRegistration(value: string): OAuthClientRegistration {
-  const result = oauthClientRegistrationSchema.safeParse(parseJson(value));
-  if (!result.success) {
-    throw invalidStoredCredential(
-      'The stored OAuth client registration is invalid.',
-      result.error,
-    );
+function parseCachedOAuthClientRegistration(
+  value: string,
+): OAuthClientRegistration | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return undefined;
   }
-  return result.data;
+  const result = oauthClientRegistrationSchema.safeParse(parsed);
+  return result.success ? result.data : undefined;
 }
 
 function parseJson(value: string): unknown {

--- a/packages/cli/src/core/credentials.ts
+++ b/packages/cli/src/core/credentials.ts
@@ -1,29 +1,86 @@
+import { z } from 'zod';
 import { CliError } from './errors';
 
 const SERVICE_NAME = 'edgestore-cli';
 const CREDENTIAL_NAME = 'management-credential';
+const OAUTH_CLIENT_NAME = 'oauth-client';
+const OAUTH_CREDENTIAL_PREFIX = 'edgestore-oauth:';
+const REFRESH_WINDOW_MS = 5 * 60 * 1_000;
+
+const oauthCredentialSchema = z
+  .object({
+    version: z.literal(1),
+    kind: z.literal('oauth'),
+    accessToken: z.string().min(1),
+    refreshToken: z.string().min(1),
+    expiresAt: z.number().int().positive(),
+    clientId: z.string().min(1),
+    issuer: z.string().url(),
+    resource: z.string().url(),
+    scope: z.string().optional(),
+  })
+  .strict();
+
+const oauthClientRegistrationSchema = z
+  .object({
+    version: z.literal(1),
+    clientId: z.string().min(1),
+    issuer: z.string().url(),
+    redirectUri: z.string().url(),
+  })
+  .strict();
+
+export type OAuthCredential = z.infer<typeof oauthCredentialSchema>;
+export type OAuthClientRegistration = z.infer<
+  typeof oauthClientRegistrationSchema
+>;
 
 export interface CredentialStore {
   get(apiOrigin: string): Promise<string | undefined>;
   set(apiOrigin: string, token: string): Promise<void>;
   delete(apiOrigin: string): Promise<boolean>;
+  getOAuthClient(
+    apiOrigin: string,
+  ): Promise<OAuthClientRegistration | undefined>;
+  setOAuthClient(
+    apiOrigin: string,
+    client: OAuthClientRegistration,
+  ): Promise<void>;
   available(): Promise<boolean>;
 }
 
 export class KeyringCredentialStore implements CredentialStore {
   async get(apiOrigin: string): Promise<string | undefined> {
-    const entry = await createEntry(apiOrigin);
+    const entry = await createEntry(CREDENTIAL_NAME, apiOrigin);
     return (await entry.getPassword()) ?? undefined;
   }
 
   async set(apiOrigin: string, token: string): Promise<void> {
-    const entry = await createEntry(apiOrigin);
+    const entry = await createEntry(CREDENTIAL_NAME, apiOrigin);
     await entry.setPassword(token);
   }
 
   async delete(apiOrigin: string): Promise<boolean> {
-    const entry = await createEntry(apiOrigin);
+    const entry = await createEntry(CREDENTIAL_NAME, apiOrigin);
     return entry.deleteCredential();
+  }
+
+  async getOAuthClient(
+    apiOrigin: string,
+  ): Promise<OAuthClientRegistration | undefined> {
+    const entry = await createEntry(OAUTH_CLIENT_NAME, apiOrigin);
+    const value = await entry.getPassword();
+    if (!value) return undefined;
+
+    return parseOAuthClientRegistration(value);
+  }
+
+  async setOAuthClient(
+    apiOrigin: string,
+    client: OAuthClientRegistration,
+  ): Promise<void> {
+    const entry = await createEntry(OAUTH_CLIENT_NAME, apiOrigin);
+    await entry.setPassword(JSON.stringify(client));
   }
 
   async available(): Promise<boolean> {
@@ -36,10 +93,10 @@ export class KeyringCredentialStore implements CredentialStore {
   }
 }
 
-async function createEntry(apiOrigin: string) {
+async function createEntry(name: string, apiOrigin: string) {
   try {
     const { AsyncEntry } = await import('@napi-rs/keyring');
-    return new AsyncEntry(SERVICE_NAME, `${CREDENTIAL_NAME}:${apiOrigin}`);
+    return new AsyncEntry(SERVICE_NAME, `${name}:${apiOrigin}`);
   } catch (error) {
     throw new CliError(
       'keychain_unavailable',
@@ -57,20 +114,100 @@ async function createEntry(apiOrigin: string) {
 
 export type ResolvedCredential = {
   token: string;
-  source: 'environment' | 'keychain';
+  source: 'environment' | 'keychain' | 'oauth';
+};
+
+type OAuthCredentialRefresher = {
+  refresh(
+    credential: OAuthCredential,
+    signal: AbortSignal,
+  ): Promise<OAuthCredential>;
 };
 
 export async function resolveCredential(
   envToken: string | undefined,
   store: CredentialStore,
-  apiOrigin: string,
+  options: {
+    apiOrigin: string;
+    oauth?: OAuthCredentialRefresher;
+    signal?: AbortSignal;
+    now?: () => number;
+  },
 ): Promise<ResolvedCredential | undefined> {
   if (envToken?.trim()) {
     return { token: envToken.trim(), source: 'environment' };
   }
 
-  const token = await store.get(apiOrigin);
-  return token?.trim()
-    ? { token: token.trim(), source: 'keychain' }
-    : undefined;
+  const stored = await store.get(options.apiOrigin);
+  if (!stored?.trim()) return undefined;
+
+  const credential = parseStoredCredential(stored.trim());
+  if (typeof credential === 'string') {
+    return { token: credential, source: 'keychain' };
+  }
+
+  const now = options?.now?.() ?? Date.now();
+  if (credential.expiresAt > now + REFRESH_WINDOW_MS) {
+    return { token: credential.accessToken, source: 'oauth' };
+  }
+  if (!options?.oauth || !options.signal) {
+    throw invalidStoredCredential(
+      'The stored OAuth login has expired and cannot be refreshed.',
+    );
+  }
+
+  const refreshed = await options.oauth.refresh(credential, options.signal);
+  await store.set(options.apiOrigin, serializeOAuthCredential(refreshed));
+  return { token: refreshed.accessToken, source: 'oauth' };
+}
+
+export function serializeOAuthCredential(credential: OAuthCredential): string {
+  return `${OAUTH_CREDENTIAL_PREFIX}${JSON.stringify(
+    oauthCredentialSchema.parse(credential),
+  )}`;
+}
+
+export function parseStoredOAuthCredential(
+  value: string | undefined,
+): OAuthCredential | undefined {
+  if (!value?.startsWith(OAUTH_CREDENTIAL_PREFIX)) return undefined;
+  const parsed = parseJson(value.slice(OAUTH_CREDENTIAL_PREFIX.length));
+  const result = oauthCredentialSchema.safeParse(parsed);
+  if (!result.success) {
+    throw invalidStoredCredential(
+      'The stored OAuth login is invalid.',
+      result.error,
+    );
+  }
+  return result.data;
+}
+
+function parseStoredCredential(value: string): string | OAuthCredential {
+  return parseStoredOAuthCredential(value) ?? value;
+}
+
+function parseOAuthClientRegistration(value: string): OAuthClientRegistration {
+  const result = oauthClientRegistrationSchema.safeParse(parseJson(value));
+  if (!result.success) {
+    throw invalidStoredCredential(
+      'The stored OAuth client registration is invalid.',
+      result.error,
+    );
+  }
+  return result.data;
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw invalidStoredCredential('The stored OAuth data is invalid.', error);
+  }
+}
+
+function invalidStoredCredential(message: string, details?: unknown) {
+  return new CliError('invalid_stored_credential', message, {
+    details,
+    suggestions: ['edgestore login'],
+  });
 }

--- a/packages/cli/src/core/errors.ts
+++ b/packages/cli/src/core/errors.ts
@@ -26,11 +26,11 @@ export class CliError extends Error {
 }
 
 const remediation: Record<string, string[]> = {
-  authentication_required: ['edgestore login --token'],
-  invalid_credential: ['edgestore login --token'],
+  authentication_required: ['edgestore login', 'edgestore login --token'],
+  invalid_credential: ['edgestore login', 'edgestore login --token'],
   credential_not_allowed: [
     'Use a management token instead of a project access key.',
-    'edgestore login --token',
+    'edgestore login',
   ],
   bucket_not_empty: [
     'edgestore bucket empty <bucket>',

--- a/packages/cli/src/core/oauth.test.ts
+++ b/packages/cli/src/core/oauth.test.ts
@@ -3,10 +3,24 @@ import type { OAuthCredential } from './credentials';
 import { DefaultOAuthService } from './oauth';
 
 const oauthMocks = vi.hoisted(() => {
+  class AuthorizationResponseError extends Error {
+    constructor(readonly error: string) {
+      super('authorization response error');
+    }
+  }
+
+  class ResponseBodyError extends Error {
+    constructor(readonly error: string) {
+      super('response body error');
+    }
+  }
+
   const config = {
     clientMetadata: () => ({ client_id: 'client_123' }),
   };
   return {
+    AuthorizationResponseError,
+    ResponseBodyError,
     config,
     dynamicClientRegistration: vi.fn(async () => config),
     discovery: vi.fn(async () => config),
@@ -51,6 +65,8 @@ const callbackMocks = vi.hoisted(() => {
 });
 
 vi.mock('openid-client', () => ({
+  AuthorizationResponseError: oauthMocks.AuthorizationResponseError,
+  ResponseBodyError: oauthMocks.ResponseBodyError,
   customFetch: Symbol.for('openid-client.customFetch'),
   allowInsecureRequests: vi.fn(),
   None: vi.fn(() => vi.fn()),
@@ -131,6 +147,81 @@ describe('OAuth service', () => {
       },
       client: { clientId: 'client_123' },
     });
+    expect(callbackMocks.close).toHaveBeenCalledOnce();
+  });
+
+  it('re-registers once when a cached client is rejected', async () => {
+    oauthMocks.authorizationCodeGrant
+      .mockRejectedValueOnce(
+        new oauthMocks.AuthorizationResponseError('invalid_client'),
+      )
+      .mockResolvedValueOnce({
+        access_token: 'access_123',
+        refresh_token: 'refresh_123',
+        expires_in: 3_600,
+        scope: 'account:read project:read file:write',
+      });
+    const onClientRegistered = vi.fn(async () => undefined);
+    const openUrl = vi.fn(async () => undefined);
+    const service = new DefaultOAuthService(async () =>
+      Response.json({
+        resource: 'https://api.example.test/v2',
+        authorization_servers: ['https://dashboard.example.test'],
+        scopes_supported: ['account:read'],
+      }),
+    );
+
+    const result = await service.login({
+      apiOrigin: 'https://api.example.test',
+      resource: 'https://api.example.test/v2',
+      client: {
+        version: 1,
+        clientId: 'stale_client',
+        issuer: 'https://dashboard.example.test',
+        redirectUri: 'http://127.0.0.1:45678/oauth/callback',
+      },
+      signal: new AbortController().signal,
+      openUrl,
+      onClientRegistered,
+    });
+
+    expect(oauthMocks.discovery).toHaveBeenCalledOnce();
+    expect(oauthMocks.dynamicClientRegistration).toHaveBeenCalledOnce();
+    expect(onClientRegistered).toHaveBeenCalledOnce();
+    expect(openUrl).toHaveBeenCalledTimes(2);
+    expect(callbackMocks.close).toHaveBeenCalledTimes(2);
+    expect(result.client.clientId).toBe('client_123');
+  });
+
+  it('does not re-register when authorization is denied', async () => {
+    oauthMocks.authorizationCodeGrant.mockRejectedValueOnce(
+      new oauthMocks.AuthorizationResponseError('access_denied'),
+    );
+    const service = new DefaultOAuthService(async () =>
+      Response.json({
+        resource: 'https://api.example.test/v2',
+        authorization_servers: ['https://dashboard.example.test'],
+        scopes_supported: ['account:read'],
+      }),
+    );
+
+    await expect(
+      service.login({
+        apiOrigin: 'https://api.example.test',
+        resource: 'https://api.example.test/v2',
+        client: {
+          version: 1,
+          clientId: 'client_123',
+          issuer: 'https://dashboard.example.test',
+          redirectUri: 'http://127.0.0.1:45678/oauth/callback',
+        },
+        signal: new AbortController().signal,
+        openUrl: vi.fn(async () => undefined),
+      }),
+    ).rejects.toMatchObject({ code: 'oauth_login_failed' });
+
+    expect(oauthMocks.dynamicClientRegistration).not.toHaveBeenCalled();
+    expect(callbackMocks.open).toHaveBeenCalledOnce();
     expect(callbackMocks.close).toHaveBeenCalledOnce();
   });
 

--- a/packages/cli/src/core/oauth.test.ts
+++ b/packages/cli/src/core/oauth.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OAuthCredential } from './credentials';
+import { DefaultOAuthService } from './oauth';
+
+const oauthMocks = vi.hoisted(() => {
+  const config = {
+    clientMetadata: () => ({ client_id: 'client_123' }),
+  };
+  return {
+    config,
+    dynamicClientRegistration: vi.fn(async () => config),
+    discovery: vi.fn(async () => config),
+    buildAuthorizationUrl: vi.fn(
+      (_config: unknown, parameters: Record<string, string>) => {
+        const url = new URL('https://dashboard.example.test/oauth/authorize');
+        url.search = new URLSearchParams(parameters).toString();
+        return url;
+      },
+    ),
+    authorizationCodeGrant: vi.fn(async () => ({
+      access_token: 'access_123',
+      refresh_token: 'refresh_123',
+      expires_in: 3_600,
+      scope: 'account:read project:read file:write',
+    })),
+    refreshTokenGrant: vi.fn(async () => ({
+      access_token: 'access_456',
+      refresh_token: 'refresh_456',
+      expires_in: 3_600,
+      scope: 'account:read project:read file:write',
+    })),
+    tokenRevocation: vi.fn(async () => undefined),
+  };
+});
+
+const callbackMocks = vi.hoisted(() => {
+  const close = vi.fn(async () => undefined);
+  return {
+    close,
+    open: vi.fn(async (state: string) => {
+      const callbackUrl = new URL('http://127.0.0.1:45678/oauth/callback');
+      callbackUrl.searchParams.set('state', state);
+      callbackUrl.searchParams.set('code', 'code_123');
+      return {
+        redirectUri: 'http://127.0.0.1:45678/oauth/callback',
+        callback: Promise.resolve(callbackUrl),
+        close,
+      };
+    }),
+  };
+});
+
+vi.mock('openid-client', () => ({
+  customFetch: Symbol.for('openid-client.customFetch'),
+  allowInsecureRequests: vi.fn(),
+  None: vi.fn(() => vi.fn()),
+  randomState: vi.fn(() => 'state_123'),
+  randomPKCECodeVerifier: vi.fn(() => 'verifier_123'),
+  calculatePKCECodeChallenge: vi.fn(async () => 'challenge_123'),
+  dynamicClientRegistration: oauthMocks.dynamicClientRegistration,
+  discovery: oauthMocks.discovery,
+  buildAuthorizationUrl: oauthMocks.buildAuthorizationUrl,
+  authorizationCodeGrant: oauthMocks.authorizationCodeGrant,
+  refreshTokenGrant: oauthMocks.refreshTokenGrant,
+  tokenRevocation: oauthMocks.tokenRevocation,
+}));
+
+vi.mock('./oauthCallback', () => ({
+  isReusableOAuthRedirectUri: vi.fn(() => true),
+  openOAuthCallbackServer: callbackMocks.open,
+}));
+
+describe('OAuth service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers a native client and requests the advertised API access', async () => {
+    const fetchImplementation: typeof fetch = async () =>
+      Response.json({
+        resource: 'https://api.example.test/v2',
+        authorization_servers: ['https://dashboard.example.test'],
+        scopes_supported: ['account:read', 'project:read', 'file:write'],
+        bearer_methods_supported: ['header'],
+      });
+    const openUrl = vi.fn(async (_url: string) => undefined);
+    const onClientRegistered = vi.fn(async () => undefined);
+    const service = new DefaultOAuthService(fetchImplementation);
+
+    const result = await service.login({
+      apiOrigin: 'https://api.example.test',
+      resource: 'https://api.example.test/v2',
+      signal: new AbortController().signal,
+      openUrl,
+      onClientRegistered,
+    });
+
+    expect(oauthMocks.dynamicClientRegistration).toHaveBeenCalledWith(
+      new URL('https://dashboard.example.test'),
+      expect.objectContaining({
+        application_type: 'native',
+        redirect_uris: ['http://127.0.0.1:45678/oauth/callback'],
+        token_endpoint_auth_method: 'none',
+      }),
+      expect.any(Function),
+      expect.objectContaining({ algorithm: 'oauth2' }),
+    );
+    const authorizationUrl = new URL(openUrl.mock.calls[0]![0]);
+    expect(authorizationUrl.searchParams.get('resource')).toBe(
+      'https://api.example.test/v2',
+    );
+    expect(authorizationUrl.searchParams.get('scope')).toBe(
+      'account:read project:read file:write',
+    );
+    expect(oauthMocks.authorizationCodeGrant).toHaveBeenCalledWith(
+      oauthMocks.config,
+      expect.any(URL),
+      { pkceCodeVerifier: 'verifier_123', expectedState: 'state_123' },
+      { resource: 'https://api.example.test/v2' },
+    );
+    expect(onClientRegistered).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: 'client_123' }),
+    );
+    expect(onClientRegistered.mock.invocationCallOrder[0]).toBeLessThan(
+      openUrl.mock.invocationCallOrder[0]!,
+    );
+    expect(result).toMatchObject({
+      credential: {
+        accessToken: 'access_123',
+        refreshToken: 'refresh_123',
+      },
+      client: { clientId: 'client_123' },
+    });
+    expect(callbackMocks.close).toHaveBeenCalledOnce();
+  });
+
+  it('keeps rotated refresh tokens and revokes the latest grant', async () => {
+    const service = new DefaultOAuthService();
+    const credential = oauthCredential();
+
+    const refreshed = await service.refresh(
+      credential,
+      new AbortController().signal,
+    );
+    await service.revoke(refreshed, new AbortController().signal);
+
+    expect(oauthMocks.refreshTokenGrant).toHaveBeenCalledWith(
+      oauthMocks.config,
+      'refresh_123',
+      { resource: 'https://api.example.test/v2' },
+    );
+    expect(refreshed.refreshToken).toBe('refresh_456');
+    expect(oauthMocks.tokenRevocation).toHaveBeenCalledWith(
+      oauthMocks.config,
+      'refresh_456',
+      { token_type_hint: 'refresh_token' },
+    );
+  });
+});
+
+function oauthCredential(): OAuthCredential {
+  return {
+    version: 1,
+    kind: 'oauth',
+    accessToken: 'access_123',
+    refreshToken: 'refresh_123',
+    expiresAt: Date.now() + 60 * 60 * 1_000,
+    clientId: 'client_123',
+    issuer: 'https://dashboard.example.test',
+    resource: 'https://api.example.test/v2',
+  };
+}

--- a/packages/cli/src/core/oauth.ts
+++ b/packages/cli/src/core/oauth.ts
@@ -47,12 +47,23 @@ export class DefaultOAuthService implements OAuthService {
 
   async login(input: BrowserOAuthLoginInput): Promise<BrowserOAuthLoginResult> {
     try {
-      return await this.performLogin(input);
+      return await this.performLoginWithRecovery(input);
     } catch (error) {
       if (input.signal.aborted || error instanceof CliError) throw error;
       throw new CliError('oauth_login_failed', oauthErrorMessage(error), {
         suggestions: ['edgestore login', 'edgestore login --token'],
       });
+    }
+  }
+
+  private async performLoginWithRecovery(
+    input: BrowserOAuthLoginInput,
+  ): Promise<BrowserOAuthLoginResult> {
+    try {
+      return await this.performLogin(input);
+    } catch (error) {
+      if (!input.client || !isInvalidClientError(error)) throw error;
+      return await this.performLogin({ ...input, client: undefined });
     }
   }
 
@@ -346,6 +357,14 @@ function credentialFromTokens(
 
 function normalizeUrl(value: string) {
   return new URL(value).toString().replace(/\/$/, '');
+}
+
+function isInvalidClientError(error: unknown): boolean {
+  return (
+    (error instanceof oauth.AuthorizationResponseError ||
+      error instanceof oauth.ResponseBodyError) &&
+    error.error === 'invalid_client'
+  );
 }
 
 function isLoopback(url: URL) {

--- a/packages/cli/src/core/oauth.ts
+++ b/packages/cli/src/core/oauth.ts
@@ -1,0 +1,364 @@
+import * as oauth from 'openid-client';
+import { z } from 'zod';
+import type { OAuthClientRegistration, OAuthCredential } from './credentials';
+import { CliError } from './errors';
+import {
+  isReusableOAuthRedirectUri,
+  openOAuthCallbackServer,
+  type OAuthCallbackServer,
+} from './oauthCallback';
+
+const resourceMetadataSchema = z
+  .object({
+    resource: z.string().url(),
+    authorization_servers: z.array(z.string().url()).min(1),
+    scopes_supported: z.array(z.string().min(1)).min(1),
+    bearer_methods_supported: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+export type BrowserOAuthLoginResult = {
+  credential: OAuthCredential;
+  client: OAuthClientRegistration;
+};
+
+export type BrowserOAuthLoginInput = {
+  apiOrigin: string;
+  resource: string;
+  client?: OAuthClientRegistration;
+  signal: AbortSignal;
+  openUrl(url: string): Promise<void>;
+  onAuthorizationUrl?(url: string): void;
+  onBrowserOpenFailed?(url: string, error: unknown): void;
+  onClientRegistered?(client: OAuthClientRegistration): Promise<void>;
+};
+
+export interface OAuthService {
+  login(input: BrowserOAuthLoginInput): Promise<BrowserOAuthLoginResult>;
+  refresh(
+    credential: OAuthCredential,
+    signal: AbortSignal,
+  ): Promise<OAuthCredential>;
+  revoke(credential: OAuthCredential, signal: AbortSignal): Promise<void>;
+}
+
+export class DefaultOAuthService implements OAuthService {
+  constructor(private readonly fetchImplementation: typeof fetch = fetch) {}
+
+  async login(input: BrowserOAuthLoginInput): Promise<BrowserOAuthLoginResult> {
+    try {
+      return await this.performLogin(input);
+    } catch (error) {
+      if (input.signal.aborted || error instanceof CliError) throw error;
+      throw new CliError('oauth_login_failed', oauthErrorMessage(error), {
+        suggestions: ['edgestore login', 'edgestore login --token'],
+      });
+    }
+  }
+
+  async refresh(
+    credential: OAuthCredential,
+    signal: AbortSignal,
+  ): Promise<OAuthCredential> {
+    try {
+      const config = await this.discover(new URL(credential.issuer), {
+        clientId: credential.clientId,
+        signal,
+      });
+      const tokens = await oauth.refreshTokenGrant(
+        config,
+        credential.refreshToken,
+        { resource: credential.resource },
+      );
+      return credentialFromTokens(tokens, {
+        clientId: credential.clientId,
+        issuer: credential.issuer,
+        resource: credential.resource,
+        fallbackRefreshToken: credential.refreshToken,
+        fallbackScope: credential.scope,
+      });
+    } catch (error) {
+      if (signal.aborted || error instanceof CliError) throw error;
+      throw new CliError(
+        'oauth_refresh_failed',
+        'The browser login could not be refreshed.',
+        {
+          details: oauthErrorMessage(error),
+          suggestions: ['edgestore login', 'edgestore login --token'],
+        },
+      );
+    }
+  }
+
+  async revoke(
+    credential: OAuthCredential,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const config = await this.discover(new URL(credential.issuer), {
+      clientId: credential.clientId,
+      signal,
+    });
+    await oauth.tokenRevocation(config, credential.refreshToken, {
+      token_type_hint: 'refresh_token',
+    });
+  }
+
+  private async performLogin(
+    input: BrowserOAuthLoginInput,
+  ): Promise<BrowserOAuthLoginResult> {
+    const metadata = await this.protectedResourceMetadata(
+      input.apiOrigin,
+      input.resource,
+      input.signal,
+    );
+    const issuer = new URL(metadata.authorization_servers[0]!);
+    const issuerIdentifier = normalizeUrl(issuer.toString());
+    const reusableClient = reusableClientRegistration(input.client, issuer);
+    const state = oauth.randomState();
+    const callback = await openCallback(
+      state,
+      input.signal,
+      reusableClient?.redirectUri,
+    );
+    const clientForCallback =
+      callback.redirectUri === reusableClient?.redirectUri
+        ? reusableClient
+        : undefined;
+
+    try {
+      const config = clientForCallback
+        ? await this.discover(issuer, {
+            clientId: clientForCallback.clientId,
+            redirectUri: callback.redirectUri,
+            signal: input.signal,
+          })
+        : await this.register(issuer, callback.redirectUri, input.signal);
+      const clientId = config.clientMetadata().client_id;
+      if (!clientId) {
+        throw new CliError(
+          'oauth_registration_failed',
+          'The OAuth server did not return a client ID.',
+        );
+      }
+      const clientRegistration: OAuthClientRegistration = {
+        version: 1,
+        clientId,
+        issuer: issuerIdentifier,
+        redirectUri: callback.redirectUri,
+      };
+      if (!clientForCallback) {
+        await input.onClientRegistered?.(clientRegistration);
+      }
+
+      const verifier = oauth.randomPKCECodeVerifier();
+      const authorizationUrl = oauth.buildAuthorizationUrl(config, {
+        response_type: 'code',
+        redirect_uri: callback.redirectUri,
+        resource: metadata.resource,
+        scope: [...new Set(metadata.scopes_supported)].join(' '),
+        code_challenge: await oauth.calculatePKCECodeChallenge(verifier),
+        code_challenge_method: 'S256',
+        state,
+      });
+      input.onAuthorizationUrl?.(authorizationUrl.toString());
+      try {
+        await input.openUrl(authorizationUrl.toString());
+      } catch (error) {
+        input.onBrowserOpenFailed?.(authorizationUrl.toString(), error);
+      }
+
+      const callbackUrl = await callback.callback;
+      const tokens = await oauth.authorizationCodeGrant(
+        config,
+        callbackUrl,
+        { pkceCodeVerifier: verifier, expectedState: state },
+        { resource: metadata.resource },
+      );
+      return {
+        credential: credentialFromTokens(tokens, {
+          clientId,
+          issuer: issuerIdentifier,
+          resource: metadata.resource,
+        }),
+        client: clientRegistration,
+      };
+    } finally {
+      await callback.close();
+    }
+  }
+
+  private async protectedResourceMetadata(
+    apiOrigin: string,
+    expectedResource: string,
+    signal: AbortSignal,
+  ) {
+    const metadataUrl = new URL(
+      '/.well-known/oauth-protected-resource/v2',
+      apiOrigin,
+    );
+    const response = await this.fetchImplementation(metadataUrl, { signal });
+    if (!response.ok) {
+      throw new CliError(
+        'oauth_metadata_unavailable',
+        `The EdgeStore API does not advertise browser login (${response.status}).`,
+        { suggestions: ['edgestore login --token'] },
+      );
+    }
+
+    const result = resourceMetadataSchema.safeParse(await response.json());
+    if (!result.success) {
+      throw new CliError(
+        'invalid_oauth_metadata',
+        'The EdgeStore API returned invalid OAuth metadata.',
+        { details: result.error },
+      );
+    }
+    if (normalizeUrl(result.data.resource) !== normalizeUrl(expectedResource)) {
+      throw new CliError(
+        'invalid_oauth_resource',
+        'The OAuth metadata does not match the selected EdgeStore API.',
+      );
+    }
+    return result.data;
+  }
+
+  private async register(
+    issuer: URL,
+    redirectUri: string,
+    signal: AbortSignal,
+  ) {
+    return await oauth.dynamicClientRegistration(
+      issuer,
+      {
+        application_type: 'native',
+        client_name: 'EdgeStore CLI',
+        redirect_uris: [redirectUri],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+      },
+      oauth.None(),
+      this.discoveryOptions(issuer, signal),
+    );
+  }
+
+  private async discover(
+    issuer: URL,
+    options: {
+      clientId: string;
+      redirectUri?: string;
+      signal: AbortSignal;
+    },
+  ) {
+    return await oauth.discovery(
+      issuer,
+      options.clientId,
+      {
+        token_endpoint_auth_method: 'none',
+        ...(options.redirectUri
+          ? { redirect_uris: [options.redirectUri] }
+          : {}),
+      },
+      oauth.None(),
+      this.discoveryOptions(issuer, options.signal),
+    );
+  }
+
+  private discoveryOptions(issuer: URL, signal: AbortSignal) {
+    const fetchWithSignal: oauth.CustomFetch = (url, options) => {
+      const body =
+        options.body instanceof Uint8Array
+          ? Uint8Array.from(options.body)
+          : options.body;
+      const requestSignal = options.signal
+        ? AbortSignal.any([signal, options.signal])
+        : signal;
+      return this.fetchImplementation(
+        new Request(url, { ...options, body, signal: requestSignal }),
+      );
+    };
+    return {
+      algorithm: 'oauth2' as const,
+      [oauth.customFetch]: fetchWithSignal,
+      ...(issuer.protocol === 'http:' && isLoopback(issuer)
+        ? { execute: [oauth.allowInsecureRequests] }
+        : {}),
+    };
+  }
+}
+
+async function openCallback(
+  state: string,
+  signal: AbortSignal,
+  preferredRedirectUri?: string,
+): Promise<OAuthCallbackServer> {
+  if (!preferredRedirectUri) {
+    return await openOAuthCallbackServer(state, signal);
+  }
+  try {
+    return await openOAuthCallbackServer(state, signal, preferredRedirectUri);
+  } catch (error) {
+    if (!isAddressInUse(error)) throw error;
+    return await openOAuthCallbackServer(state, signal);
+  }
+}
+
+function reusableClientRegistration(
+  client: OAuthClientRegistration | undefined,
+  issuer: URL,
+) {
+  return client &&
+    normalizeUrl(client.issuer) === normalizeUrl(issuer.toString()) &&
+    isReusableOAuthRedirectUri(client.redirectUri)
+    ? client
+    : undefined;
+}
+
+function credentialFromTokens(
+  tokens: oauth.TokenEndpointResponse,
+  context: {
+    clientId: string;
+    issuer: string;
+    resource: string;
+    fallbackRefreshToken?: string;
+    fallbackScope?: string;
+  },
+): OAuthCredential {
+  const refreshToken = tokens.refresh_token ?? context.fallbackRefreshToken;
+  if (!tokens.access_token || !refreshToken) {
+    throw new CliError(
+      'invalid_oauth_token_response',
+      'The OAuth server did not return the required access and refresh tokens.',
+    );
+  }
+  return {
+    version: 1,
+    kind: 'oauth',
+    accessToken: tokens.access_token,
+    refreshToken,
+    expiresAt: Date.now() + (tokens.expires_in ?? 60 * 60) * 1_000,
+    clientId: context.clientId,
+    issuer: context.issuer,
+    resource: context.resource,
+    scope: tokens.scope ?? context.fallbackScope,
+  };
+}
+
+function normalizeUrl(value: string) {
+  return new URL(value).toString().replace(/\/$/, '');
+}
+
+function isLoopback(url: URL) {
+  return url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+}
+
+function isAddressInUse(error: unknown): boolean {
+  return (
+    error instanceof Error && 'code' in error && error.code === 'EADDRINUSE'
+  );
+}
+
+function oauthErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return 'Browser login failed.';
+}

--- a/packages/cli/src/core/oauthCallback.test.ts
+++ b/packages/cli/src/core/oauthCallback.test.ts
@@ -23,8 +23,32 @@ describe('OAuth loopback callback', () => {
       const received = await callback.callback;
 
       expect(response.status).toBe(200);
-      expect(await response.text()).toContain('Logged in to EdgeStore');
+      expect(await response.text()).toContain('Authorization received');
       expect(received.searchParams.get('code')).toBe('code_123');
+    } finally {
+      await callback.close();
+    }
+  });
+
+  it('shows a neutral page for OAuth error callbacks', async () => {
+    const callback = await openOAuthCallbackServer(
+      'expected-state',
+      new AbortController().signal,
+    );
+
+    try {
+      const failed = new URL(callback.redirectUri);
+      failed.searchParams.set('state', 'expected-state');
+      failed.searchParams.set('error', 'access_denied');
+      failed.searchParams.set('error_description', 'untrusted details');
+      const response = await fetch(failed);
+      const received = await callback.callback;
+      const page = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(page).toContain('Login was not completed');
+      expect(page).not.toContain('untrusted details');
+      expect(received.searchParams.get('error')).toBe('access_denied');
     } finally {
       await callback.close();
     }

--- a/packages/cli/src/core/oauthCallback.test.ts
+++ b/packages/cli/src/core/oauthCallback.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isReusableOAuthRedirectUri,
+  openOAuthCallbackServer,
+} from './oauthCallback';
+
+describe('OAuth loopback callback', () => {
+  it('accepts the expected state and ignores mismatched callbacks', async () => {
+    const callback = await openOAuthCallbackServer(
+      'expected-state',
+      new AbortController().signal,
+    );
+
+    try {
+      const invalid = new URL(callback.redirectUri);
+      invalid.searchParams.set('state', 'wrong-state');
+      expect((await fetch(invalid)).status).toBe(400);
+
+      const valid = new URL(callback.redirectUri);
+      valid.searchParams.set('state', 'expected-state');
+      valid.searchParams.set('code', 'code_123');
+      const response = await fetch(valid);
+      const received = await callback.callback;
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain('Logged in to EdgeStore');
+      expect(received.searchParams.get('code')).toBe('code_123');
+    } finally {
+      await callback.close();
+    }
+  });
+
+  it('only reuses explicit IPv4 loopback callback ports', () => {
+    expect(
+      isReusableOAuthRedirectUri('http://127.0.0.1:45678/oauth/callback'),
+    ).toBe(true);
+    expect(isReusableOAuthRedirectUri('http://localhost:45678/callback')).toBe(
+      false,
+    );
+    expect(isReusableOAuthRedirectUri('http://127.0.0.1/callback')).toBe(false);
+  });
+
+  it('cancels the pending callback when the server closes early', async () => {
+    const callback = await openOAuthCallbackServer(
+      'expected-state',
+      new AbortController().signal,
+    );
+
+    await callback.close();
+
+    await expect(callback.callback).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+  });
+});

--- a/packages/cli/src/core/oauthCallback.ts
+++ b/packages/cli/src/core/oauthCallback.ts
@@ -1,0 +1,198 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import { CliError } from './errors';
+
+const LOOPBACK_HOST = '127.0.0.1';
+const CALLBACK_PATH = '/oauth/callback';
+const CALLBACK_TIMEOUT_MS = 10 * 60 * 1_000;
+
+export type OAuthCallbackServer = {
+  redirectUri: string;
+  callback: Promise<URL>;
+  close(): Promise<void>;
+};
+
+export async function openOAuthCallbackServer(
+  expectedState: string,
+  signal: AbortSignal,
+  preferredRedirectUri?: string,
+): Promise<OAuthCallbackServer> {
+  const preferred = preferredRedirectUri
+    ? reusableRedirectUrl(preferredRedirectUri)
+    : undefined;
+  const server = createServer();
+  await listen(server, preferred?.port ? Number(preferred.port) : 0);
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await closeServer(server);
+    throw new CliError(
+      'oauth_callback_unavailable',
+      'Could not start the local OAuth callback server.',
+    );
+  }
+
+  const redirectUrl = new URL(
+    preferred?.pathname ?? CALLBACK_PATH,
+    `http://${LOOPBACK_HOST}:${address.port}`,
+  );
+  const pendingCallback = waitForCallback(server, redirectUrl, {
+    expectedState,
+    signal,
+  });
+  void pendingCallback.promise.catch(() => undefined);
+
+  return {
+    redirectUri: redirectUrl.toString(),
+    callback: pendingCallback.promise,
+    async close() {
+      pendingCallback.cancel();
+      await closeServer(server);
+    },
+  };
+}
+
+export function isReusableOAuthRedirectUri(value: string): boolean {
+  return reusableRedirectUrl(value) !== undefined;
+}
+
+function reusableRedirectUrl(value: string): URL | undefined {
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== 'http:' ||
+      url.hostname !== LOOPBACK_HOST ||
+      !url.port ||
+      url.search ||
+      url.hash
+    ) {
+      return undefined;
+    }
+    return url;
+  } catch {
+    return undefined;
+  }
+}
+
+function listen(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off('listening', onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen({ host: LOOPBACK_HOST, port });
+  });
+}
+
+function waitForCallback(
+  server: Server,
+  redirectUrl: URL,
+  options: { expectedState: string; signal: AbortSignal },
+): { promise: Promise<URL>; cancel(): void } {
+  let cancel: () => void = () => undefined;
+  const promise = new Promise<URL>((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      finish(
+        new CliError(
+          'oauth_login_timeout',
+          'Browser login timed out before authorization completed.',
+          { suggestions: ['edgestore login', 'edgestore login --token'] },
+        ),
+      );
+    }, CALLBACK_TIMEOUT_MS);
+    const onAbort = () =>
+      finish(
+        options.signal.reason instanceof Error
+          ? options.signal.reason
+          : abortError(),
+      );
+
+    const finish = (error?: unknown, callbackUrl?: URL) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      options.signal.removeEventListener('abort', onAbort);
+      server.removeListener('request', onRequest);
+      if (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      } else resolve(callbackUrl!);
+    };
+    cancel = () => finish(abortError());
+
+    const onRequest = (request: IncomingMessage, response: ServerResponse) => {
+      const callbackUrl = new URL(request.url ?? '/', redirectUrl);
+      if (
+        request.method !== 'GET' ||
+        callbackUrl.pathname !== redirectUrl.pathname
+      ) {
+        response.writeHead(404, {
+          'content-type': 'text/plain; charset=utf-8',
+        });
+        response.end('Not found');
+        return;
+      }
+      if (callbackUrl.searchParams.get('state') !== options.expectedState) {
+        response.writeHead(400, {
+          'content-type': 'text/plain; charset=utf-8',
+        });
+        response.end(
+          'Invalid OAuth state. Return to the terminal and try again.',
+        );
+        return;
+      }
+
+      response.writeHead(200, {
+        connection: 'close',
+        'content-type': 'text/html; charset=utf-8',
+      });
+      response.end(successPage);
+      finish(undefined, callbackUrl);
+    };
+
+    server.on('request', onRequest);
+    if (options.signal.aborted) onAbort();
+    else options.signal.addEventListener('abort', onAbort, { once: true });
+  });
+  return { promise, cancel };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function abortError() {
+  return new DOMException('The operation was aborted.', 'AbortError');
+}
+
+const successPage = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>EdgeStore login complete</title>
+    <style>
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; font: 16px/1.5 system-ui, sans-serif; color: #18181b; background: #fafafa; }
+      main { width: min(32rem, calc(100% - 3rem)); }
+      h1 { margin: 0 0 .5rem; font-size: 1.75rem; letter-spacing: 0; }
+      p { margin: 0; color: #52525b; }
+    </style>
+  </head>
+  <body><main><h1>Logged in to EdgeStore</h1><p>You can close this window and return to the terminal.</p></main></body>
+</html>`;

--- a/packages/cli/src/core/oauthCallback.ts
+++ b/packages/cli/src/core/oauthCallback.ts
@@ -156,7 +156,11 @@ function waitForCallback(
         connection: 'close',
         'content-type': 'text/html; charset=utf-8',
       });
-      response.end(successPage);
+      response.end(
+        callbackUrl.searchParams.has('error')
+          ? authorizationFailedPage
+          : authorizationReceivedPage,
+      );
       finish(undefined, callbackUrl);
     };
 
@@ -181,12 +185,25 @@ function abortError() {
   return new DOMException('The operation was aborted.', 'AbortError');
 }
 
-const successPage = `<!doctype html>
+const authorizationReceivedPage = callbackPage(
+  'EdgeStore authorization received',
+  'Authorization received',
+  'Return to the terminal to finish logging in.',
+);
+
+const authorizationFailedPage = callbackPage(
+  'EdgeStore login not completed',
+  'Login was not completed',
+  'Return to the terminal for details or to try again.',
+);
+
+function callbackPage(title: string, heading: string, message: string): string {
+  return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>EdgeStore login complete</title>
+    <title>${title}</title>
     <style>
       body { margin: 0; min-height: 100vh; display: grid; place-items: center; font: 16px/1.5 system-ui, sans-serif; color: #18181b; background: #fafafa; }
       main { width: min(32rem, calc(100% - 3rem)); }
@@ -194,5 +211,6 @@ const successPage = `<!doctype html>
       p { margin: 0; color: #52525b; }
     </style>
   </head>
-  <body><main><h1>Logged in to EdgeStore</h1><p>You can close this window and return to the terminal.</p></main></body>
+  <body><main><h1>${heading}</h1><p>${message}</p></main></body>
 </html>`;
+}

--- a/packages/cli/src/core/runtime.ts
+++ b/packages/cli/src/core/runtime.ts
@@ -20,6 +20,7 @@ import {
   type ResolvedCredential,
 } from './credentials';
 import { usageError } from './errors';
+import { DefaultOAuthService, type OAuthService } from './oauth';
 import { CliOutput, type OutputMode } from './output';
 import { DefaultCliPrompts, type CliPrompts } from './prompts';
 
@@ -102,6 +103,7 @@ export type CliRuntime = {
     remove(): Promise<string | undefined>;
   };
   credentials: CredentialStore;
+  oauth: OAuthService;
   prompts: CliPrompts;
   sdkFactory: SdkFactory;
   openUrl(url: string): Promise<void>;
@@ -137,6 +139,7 @@ export function createDefaultRuntime(signal: AbortSignal): CliRuntime {
     globalConfig: new GlobalConfigStore(path.join(paths.config, 'config.json')),
     repoConfig: new RepoConfigStore(process.cwd()),
     credentials: new KeyringCredentialStore(),
+    oauth: new DefaultOAuthService(),
     prompts: new DefaultCliPrompts(),
     sdkFactory: ({ token, baseUrl }) =>
       createEdgeStoreSdk({ credentials: { token }, apiUrl: baseUrl }),
@@ -172,10 +175,15 @@ export async function credentialFor(
   const credential = await resolveCredential(
     runtime.env.EDGESTORE_TOKEN,
     runtime.credentials,
-    apiUrl.displayUrl,
+    {
+      apiOrigin: apiUrl.displayUrl,
+      oauth: runtime.oauth,
+      signal: runtime.signal,
+    },
   );
   if (!credential) {
     throw usageError('authentication_required', 'Not logged in.', [
+      'edgestore login',
       'edgestore login --token',
     ]);
   }

--- a/packages/cli/src/core/runtime.ts
+++ b/packages/cli/src/core/runtime.ts
@@ -5,6 +5,7 @@ import {
   type ManagementEdgeStoreSdk,
 } from '@edgestore/sdk';
 import envPaths from 'env-paths';
+import open from 'open';
 import { resolveApiUrl, type ResolvedApiUrl } from './apiUrl';
 import {
   GlobalConfigStore,
@@ -225,14 +226,8 @@ function getOutputMode(flags: GlobalFlags): OutputMode {
   return 'human';
 }
 
-function openUrl(url: string): Promise<void> {
-  if (process.platform === 'darwin') {
-    return runCommand('open', [url]);
-  }
-  if (process.platform === 'win32') {
-    return runCommand('cmd', ['/c', 'start', '', url]);
-  }
-  return runCommand('xdg-open', [url]);
+async function openUrl(url: string): Promise<void> {
+  await open(url);
 }
 
 function runCommand(

--- a/packages/cli/src/testFixture.ts
+++ b/packages/cli/src/testFixture.ts
@@ -179,7 +179,7 @@ type CliTestFixture = {
   readRepoConfig: Mock;
   credentials: CredentialStore;
   setCredential: Mock;
-  setOAuthClient: Mock;
+  setCachedOAuthClient: Mock;
   oauthLogin: Mock<OAuthService['login']>;
   oauthRefresh: Mock<OAuthService['refresh']>;
   oauthRevoke: Mock<OAuthService['revoke']>;
@@ -258,7 +258,7 @@ export function createFixture(): CliTestFixture {
   const setCredential = vi.fn(async (apiOrigin: string, token: string) => {
     credentialValues.set(apiOrigin, token);
   });
-  const setOAuthClient = vi.fn(
+  const setCachedOAuthClient = vi.fn(
     async (apiOrigin: string, client: OAuthClientRegistration) => {
       oauthClientValues.set(apiOrigin, client);
     },
@@ -320,10 +320,10 @@ export function createFixture(): CliTestFixture {
     delete: vi.fn(async (apiOrigin) => {
       return credentialValues.delete(apiOrigin);
     }),
-    getOAuthClient: vi.fn(async (apiOrigin) =>
+    getCachedOAuthClient: vi.fn(async (apiOrigin) =>
       oauthClientValues.get(apiOrigin),
     ),
-    setOAuthClient,
+    setCachedOAuthClient,
     available: vi.fn(async () => true),
   };
   const oauthCredential: OAuthCredential = {
@@ -659,7 +659,7 @@ export function createFixture(): CliTestFixture {
     readRepoConfig,
     credentials,
     setCredential,
-    setOAuthClient,
+    setCachedOAuthClient,
     oauthLogin,
     oauthRefresh,
     oauthRevoke,

--- a/packages/cli/src/testFixture.ts
+++ b/packages/cli/src/testFixture.ts
@@ -6,7 +6,12 @@ import type {
   LocatedRepoConfig,
   RepoConfig,
 } from './core/config';
-import type { CredentialStore } from './core/credentials';
+import type {
+  CredentialStore,
+  OAuthClientRegistration,
+  OAuthCredential,
+} from './core/credentials';
+import type { OAuthService } from './core/oauth';
 import type { CliRuntime, CliSdk } from './core/runtime';
 
 type ManagementClient = ManagementEdgeStoreSdk['management'];
@@ -174,6 +179,11 @@ type CliTestFixture = {
   readRepoConfig: Mock;
   credentials: CredentialStore;
   setCredential: Mock;
+  setOAuthClient: Mock;
+  oauthLogin: Mock<OAuthService['login']>;
+  oauthRefresh: Mock<OAuthService['refresh']>;
+  oauthRevoke: Mock<OAuthService['revoke']>;
+  whoami: Mock<ManagementClient['whoami']>;
   readToken: Mock;
   confirmTyped: Mock;
   createAccountToken: Mock;
@@ -243,10 +253,16 @@ export function createFixture(): CliTestFixture {
     ['https://api.edgestore.dev', 'stored_token'],
     ['https://api-dev.edgestore.dev', 'stored_dev_token'],
   ]);
+  const oauthClientValues = new Map<string, OAuthClientRegistration>();
   const readToken = vi.fn(async () => 'mgmt_test');
   const setCredential = vi.fn(async (apiOrigin: string, token: string) => {
     credentialValues.set(apiOrigin, token);
   });
+  const setOAuthClient = vi.fn(
+    async (apiOrigin: string, client: OAuthClientRegistration) => {
+      oauthClientValues.set(apiOrigin, client);
+    },
+  );
   const confirmTyped = vi.fn(async () => undefined);
   const availableAccounts: (typeof account | typeof teamAccount)[] = [account];
   const listAccounts = vi.fn(async () => ({
@@ -304,8 +320,43 @@ export function createFixture(): CliTestFixture {
     delete: vi.fn(async (apiOrigin) => {
       return credentialValues.delete(apiOrigin);
     }),
+    getOAuthClient: vi.fn(async (apiOrigin) =>
+      oauthClientValues.get(apiOrigin),
+    ),
+    setOAuthClient,
     available: vi.fn(async () => true),
   };
+  const oauthCredential: OAuthCredential = {
+    version: 1,
+    kind: 'oauth',
+    accessToken: 'oauth_access',
+    refreshToken: 'oauth_refresh',
+    expiresAt: Date.now() + 60 * 60 * 1_000,
+    clientId: 'oauth_client',
+    issuer: 'https://dashboard.edgestore.dev',
+    resource: 'https://api.edgestore.dev/v2',
+    scope: 'account:read project:read',
+  };
+  const oauthClient: OAuthClientRegistration = {
+    version: 1,
+    clientId: 'oauth_client',
+    issuer: 'https://dashboard.edgestore.dev',
+    redirectUri: 'http://127.0.0.1:45678/oauth/callback',
+  };
+  const oauthLogin = vi.fn<OAuthService['login']>(async (input) => {
+    const authorizationUrl =
+      'https://dashboard.edgestore.dev/oauth/authorize?client_id=oauth_client';
+    input.onAuthorizationUrl?.(authorizationUrl);
+    await input.openUrl(authorizationUrl);
+    return { credential: oauthCredential, client: oauthClient };
+  });
+  const oauthRefresh = vi.fn<OAuthService['refresh']>(async (credential) => ({
+    ...credential,
+    accessToken: 'oauth_access_refreshed',
+    refreshToken: 'oauth_refresh_rotated',
+    expiresAt: Date.now() + 60 * 60 * 1_000,
+  }));
+  const oauthRevoke = vi.fn<OAuthService['revoke']>(async () => undefined);
 
   const createAccountToken = vi.fn<ManagementClient['tokens']['createAccount']>(
     async () => ({
@@ -441,6 +492,23 @@ export function createFixture(): CliTestFixture {
     upload: { id: input.uploadId, status: 'processing' },
   }));
   const deleteProject = vi.fn(async () => ({}));
+  const whoami = vi.fn<ManagementClient['whoami']>(async () => ({
+    actor: {
+      kind: 'user_token',
+      tokenId: 'tok_123',
+      scopes: ['account:read', 'project:read'],
+      user: {
+        id: 'user_123',
+        clerkUserId: 'clerk_123',
+        accountId: account.id,
+        email: 'ravi@example.com',
+        username: 'ravi',
+        firstName: 'Ravi',
+        lastName: null,
+        picture: 'https://example.com/ravi.png',
+      },
+    },
+  }));
   const sdk = {
     system: {
       health: vi.fn<ManagementEdgeStoreSdk['system']['health']>(async () => ({
@@ -449,23 +517,7 @@ export function createFixture(): CliTestFixture {
       })),
     },
     management: {
-      whoami: vi.fn<ManagementClient['whoami']>(async () => ({
-        actor: {
-          kind: 'user_token',
-          tokenId: 'tok_123',
-          scopes: ['account:read', 'project:read'],
-          user: {
-            id: 'user_123',
-            clerkUserId: 'clerk_123',
-            accountId: account.id,
-            email: 'ravi@example.com',
-            username: 'ravi',
-            firstName: 'Ravi',
-            lastName: null,
-            picture: 'https://example.com/ravi.png',
-          },
-        },
-      })),
+      whoami,
       accounts: {
         list: listAccounts,
         get: vi.fn(async ({ account: accountId }: { account: string }) => ({
@@ -573,6 +625,11 @@ export function createFixture(): CliTestFixture {
       }),
     },
     credentials,
+    oauth: {
+      login: oauthLogin,
+      refresh: oauthRefresh,
+      revoke: oauthRevoke,
+    },
     prompts: {
       readToken,
       confirmTyped,
@@ -597,6 +654,11 @@ export function createFixture(): CliTestFixture {
     readRepoConfig,
     credentials,
     setCredential,
+    setOAuthClient,
+    oauthLogin,
+    oauthRefresh,
+    oauthRevoke,
+    whoami,
     readToken,
     confirmTyped,
     createAccountToken,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -893,6 +893,9 @@ importers:
       env-paths:
         specifier: 4.0.0
         version: 4.0.0
+      openid-client:
+        specifier: 6.8.4
+        version: 6.8.4
       package-manager-detector:
         specifier: 1.8.0
         version: 1.8.0
@@ -7779,6 +7782,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -7855,6 +7861,9 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: ^5.x
+
+  openid-client@6.8.4:
+    resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -16627,6 +16636,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  oauth4webapi@3.8.6: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -16707,6 +16718,11 @@ snapshots:
       supports-color: 9.4.0
       typescript: 6.0.3
       yargs-parser: 21.1.1
+
+  openid-client@6.8.4:
+    dependencies:
+      jose: 6.2.3
+      oauth4webapi: 3.8.6
 
   optionator@0.9.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,6 +896,9 @@ importers:
       env-paths:
         specifier: 4.0.0
         version: 4.0.0
+      open:
+        specifier: 11.0.0
+        version: 11.0.0
       openid-client:
         specifier: 6.8.4
         version: 6.8.4


### PR DESCRIPTION
## Summary

- make `edgestore login` use dashboard OAuth while preserving `login --token`
- discover the authorization server from API protected-resource metadata
- use public dynamic client registration, an IPv4 loopback callback, PKCE, state validation, and resource indicators
- store versioned OAuth credentials in the OS credential store and refresh expiring access tokens automatically
- revoke refresh tokens on logout while retaining reusable client registration metadata
- keep the active account within the accounts authorized by the OAuth grant

## UX

`edgestore login` opens the dashboard and waits for the local callback. If the browser cannot be opened automatically, the authorization URL is printed for the user. Existing raw management tokens remain compatible, and `EDGESTORE_TOKEN` still takes precedence for automation.

## Dependencies

- stacked on #214 for the typed `oauth_user` actor contract
- requires edgestorejs/edge-store-app#273 so each API environment advertises its OAuth issuer and scopes

## Changeset

This PR updates `.changeset/calm-clouds-guide.md`, the existing comprehensive changeset for the initial unreleased CLI. It intentionally does not add a second CLI changeset for the same initial release.

## Validation

- `pnpm --filter @edgestore/cli test` (19 files, 159 tests)
- `pnpm --filter @edgestore/cli typecheck`
- `pnpm --filter @edgestore/cli lint`
- `pnpm --filter @edgestore/cli build`
- `pnpm format --check`
