### PR TITLE
ci: allow manual normal releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
         required: true
         type: choice
         options:
+          - release
           - maintenance
           - canary
       npm-tag:
@@ -25,7 +26,7 @@ concurrency:
 
 jobs:
   release:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.operation == 'release')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -56,8 +57,13 @@ jobs:
             jq -e \
               '.mode == "pre" and (.tag == "next" or .tag == "rc")' \
               .changeset/pre.json
-          elif [[ -f .changeset/pre.json ]]; then
-            echo 'main must not contain a Changesets prerelease state'
+          elif [[ "$GITHUB_REF_NAME" == "main" ]]; then
+            if [[ -f .changeset/pre.json ]]; then
+              echo 'main must not contain a Changesets prerelease state'
+              exit 1
+            fi
+          else
+            echo 'Normal releases must run from main or next.'
             exit 1
           fi
 


### PR DESCRIPTION
Adds a guarded manual release operation for main and next so a release can be recovered when GitHub does not schedule a push event.