### PR TITLE
test(cli): make zsh validation portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
       - name: Build CLI
         run: pnpm --filter @edgestore/cli build
 
+      - name: Validate zsh completion
+        if: runner.os == 'macOS'
+        run: pnpm --filter @edgestore/cli exec vitest run src/utility.test.ts
+
       - name: Load native credential store module
         run: pnpm --filter @edgestore/cli exec node -e "import('@napi-rs/keyring')"
 

--- a/packages/cli/src/utility.test.ts
+++ b/packages/cli/src/utility.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -77,9 +78,12 @@ describe('utility', () => {
     const zshFixture = createFixture();
     await runCli(['completion', 'zsh', '--plain'], zshFixture.runtime, '0.0.0');
     const zshScript = zshFixture.stdout();
-    expect(() =>
-      execFileSync('/bin/zsh', ['-n'], { input: zshScript }),
-    ).not.toThrow();
+    const zshPath = ['/bin/zsh', '/usr/bin/zsh'].find(existsSync);
+    if (zshPath) {
+      expect(() =>
+        execFileSync(zshPath, ['-n'], { input: zshScript }),
+      ).not.toThrow();
+    }
     expect(zshScript).toContain("':project') command_path='project'");
     expect(zshScript).toContain(
       "'project:key') candidate_string='--json --plain",


### PR DESCRIPTION
Avoids assuming /bin/zsh exists in the shared Ubuntu test job while preserving zsh syntax validation in the macOS package-smoke job.