### PR TITLE
[CLI 14] fix: close OAuth callback connections

### DIFF
--- a/.changeset/quick-callback-shutdown.md
+++ b/.changeset/quick-callback-shutdown.md
@@ -1,0 +1,6 @@
+---
+'@edgestore/cli': patch
+---
+
+Close lingering browser connections when browser login finishes so the CLI can
+exit promptly after receiving the OAuth callback.

--- a/packages/cli/src/core/oauthCallback.test.ts
+++ b/packages/cli/src/core/oauthCallback.test.ts
@@ -1,3 +1,5 @@
+import { once } from 'node:events';
+import { connect } from 'node:net';
 import { describe, expect, it } from 'vitest';
 import {
   isReusableOAuthRedirectUri,
@@ -75,5 +77,31 @@ describe('OAuth loopback callback', () => {
     await expect(callback.callback).rejects.toMatchObject({
       name: 'AbortError',
     });
+  });
+
+  it('closes idle browser connections without blocking shutdown', async () => {
+    const callback = await openOAuthCallbackServer(
+      'expected-state',
+      new AbortController().signal,
+    );
+    const redirectUri = new URL(callback.redirectUri);
+    const socket = connect(Number(redirectUri.port), redirectUri.hostname);
+
+    try {
+      await once(socket, 'connect');
+      const disconnected = new Promise<void>((resolve) => {
+        socket.once('close', resolve);
+        socket.once('error', () => resolve());
+      });
+
+      await callback.close();
+      await disconnected;
+
+      await expect(callback.callback).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+    } finally {
+      socket.destroy();
+    }
   });
 });

--- a/packages/cli/src/core/oauthCallback.ts
+++ b/packages/cli/src/core/oauthCallback.ts
@@ -178,6 +178,7 @@ function closeServer(server: Server): Promise<void> {
       return;
     }
     server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections();
   });
 }
 


### PR DESCRIPTION
## What changed

- force-close lingering HTTP connections when the loopback OAuth callback server shuts down
- add regression coverage for an idle browser connection during shutdown
- include a patch changeset for `@edgestore/cli`

## Why

Arc can keep the loopback callback connection alive after rendering the authorization result. Node's `server.close()` waits for active connections, which left `edgestore login` hanging until the browser popup was closed manually. Closing all remaining server connections lets login exit promptly after authorization completes.

## Validation

- `pnpm --filter @edgestore/cli test` (219 tests)
- `pnpm --filter @edgestore/cli typecheck`
- `pnpm --filter @edgestore/cli lint`
- `pnpm --filter @edgestore/cli build`
- live dev CLI smoke suite (108 scenarios)
