### PR TITLE
[Blog 01] feat: add blog foundation

### DIFF
--- a/docs/content/blog/next-major-release.mdx
+++ b/docs/content/blog/next-major-release.mdx
@@ -1,0 +1,22 @@
+---
+title: Previewing the next major EdgeStore release
+description: A first look at the release and the path to upgrading.
+author: EdgeStore Team
+date: '2026-08-11'
+---
+
+The next major EdgeStore release is in progress. This post will cover the final
+changes, migration steps, and release timeline.
+
+## What is changing
+
+We’ll add the confirmed API and configuration changes here before publishing.
+
+## Migration
+
+The final post will include a step-by-step migration guide and note any breaking
+changes.
+
+## Timeline
+
+Release dates and preview versions will be added when they are confirmed.

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -7,7 +7,6 @@ import {
   metaSchema,
 } from 'fumadocs-mdx/config';
 import { transformerTwoslash } from 'fumadocs-twoslash';
-import { z } from 'zod';
 
 // Options: https://fumadocs.vercel.app/docs/mdx/collections#define-docs
 export const docs = defineDocs({
@@ -27,9 +26,12 @@ export const blogPosts = defineCollections({
   type: 'doc',
   dir: 'content/blog',
   schema: frontmatterSchema.extend({
-    description: z.string(),
-    author: z.string(),
-    date: z.string().date(),
+    description: frontmatterSchema.shape.title,
+    author: frontmatterSchema.shape.title,
+    date: frontmatterSchema.shape.title.regex(
+      /^\d{4}-\d{2}-\d{2}$/,
+      'Expected a date in YYYY-MM-DD format',
+    ),
   }),
 });
 

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,11 +1,13 @@
 import { rehypeCodeDefaultOptions } from 'fumadocs-core/mdx-plugins';
 import {
+  defineCollections,
   defineConfig,
   defineDocs,
   frontmatterSchema,
   metaSchema,
 } from 'fumadocs-mdx/config';
 import { transformerTwoslash } from 'fumadocs-twoslash';
+import { z } from 'zod';
 
 // Options: https://fumadocs.vercel.app/docs/mdx/collections#define-docs
 export const docs = defineDocs({
@@ -19,6 +21,16 @@ export const docs = defineDocs({
   meta: {
     schema: metaSchema,
   },
+});
+
+export const blogPosts = defineCollections({
+  type: 'doc',
+  dir: 'content/blog',
+  schema: frontmatterSchema.extend({
+    description: z.string(),
+    author: z.string(),
+    date: z.string().date(),
+  }),
 });
 
 export default defineConfig({

--- a/docs/src/app/(main)/blog/[slug]/page.tsx
+++ b/docs/src/app/(main)/blog/[slug]/page.tsx
@@ -1,0 +1,88 @@
+import { blog } from '@/lib/source';
+import { getMDXComponents } from '@/mdx-components';
+import { InlineTOC } from 'fumadocs-ui/components/inline-toc';
+import { ArrowLeftIcon } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+const dateFormatter = new Intl.DateTimeFormat('en', {
+  dateStyle: 'long',
+  timeZone: 'UTC',
+});
+
+type BlogPostPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  const { slug } = await params;
+  const page = blog.getPage([slug]);
+  if (!page) notFound();
+
+  const MDXContent = page.data.body;
+
+  return (
+    <main className="container w-full max-w-4xl flex-1 py-12 sm:py-20">
+      <Link
+        href="/blog"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeftIcon className="size-4" />
+        Back to blog
+      </Link>
+
+      <article className="mt-12">
+        <header className="border-b pb-10 sm:pb-12">
+          <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-6xl">
+            {page.data.title}
+          </h1>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground sm:text-xl">
+            {page.data.description}
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+            <span>{page.data.author}</span>
+            <span aria-hidden="true">·</span>
+            <time dateTime={page.data.date}>
+              {dateFormatter.format(new Date(page.data.date))}
+            </time>
+          </div>
+        </header>
+
+        <div className="prose mt-10 max-w-none sm:mt-12">
+          <InlineTOC items={page.data.toc} />
+          <MDXContent components={getMDXComponents()} />
+        </div>
+      </article>
+    </main>
+  );
+}
+
+export function generateStaticParams(): { slug: string }[] {
+  return blog.getPages().map((page) => ({
+    slug: page.slugs[0]!,
+  }));
+}
+
+export async function generateMetadata({
+  params,
+}: BlogPostPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const page = blog.getPage([slug]);
+  if (!page) notFound();
+
+  return {
+    title: page.data.title,
+    description: page.data.description,
+    authors: [{ name: page.data.author }],
+    openGraph: {
+      type: 'article',
+      title: page.data.title,
+      description: page.data.description,
+      publishedTime: page.data.date,
+      authors: [page.data.author],
+    },
+  };
+}
+
+export const dynamicParams = false;

--- a/docs/src/app/(main)/blog/page.tsx
+++ b/docs/src/app/(main)/blog/page.tsx
@@ -21,20 +21,16 @@ export default function BlogPage() {
   return (
     <main className="container w-full max-w-5xl flex-1 py-16 sm:py-24">
       <header className="max-w-2xl">
-        <p className="mb-4 text-sm font-medium tracking-wide text-primary uppercase">
-          EdgeStore Blog
-        </p>
-        <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-6xl">
-          Building better file uploads, one release at a time.
+        <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+          Blog
         </h1>
-        <p className="mt-6 text-lg leading-8 text-muted-foreground">
-          Product news, release notes, and practical guides from the team behind
-          EdgeStore.
+        <p className="mt-4 text-lg text-muted-foreground">
+          Release notes and technical updates from EdgeStore.
         </p>
       </header>
 
       {posts.length > 0 ? (
-        <div className="mt-16 grid gap-5 sm:mt-20 sm:grid-cols-2">
+        <div className="mt-12 grid gap-5 sm:grid-cols-2">
           {posts.map((post) => (
             <Link
               key={post.url}

--- a/docs/src/app/(main)/blog/page.tsx
+++ b/docs/src/app/(main)/blog/page.tsx
@@ -1,0 +1,83 @@
+import { blog } from '@/lib/source';
+import { ArrowRightIcon } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: 'News, release notes, and technical articles from EdgeStore.',
+};
+
+const dateFormatter = new Intl.DateTimeFormat('en', {
+  dateStyle: 'long',
+  timeZone: 'UTC',
+});
+
+export default function BlogPage() {
+  const posts = blog
+    .getPages()
+    .toSorted((a, b) => b.data.date.localeCompare(a.data.date));
+
+  return (
+    <main className="container w-full max-w-5xl flex-1 py-16 sm:py-24">
+      <header className="max-w-2xl">
+        <p className="mb-4 text-sm font-medium tracking-wide text-primary uppercase">
+          EdgeStore Blog
+        </p>
+        <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-6xl">
+          Building better file uploads, one release at a time.
+        </h1>
+        <p className="mt-6 text-lg leading-8 text-muted-foreground">
+          Product news, release notes, and practical guides from the team behind
+          EdgeStore.
+        </p>
+      </header>
+
+      {posts.length > 0 ? (
+        <div className="mt-16 grid gap-5 sm:mt-20 sm:grid-cols-2">
+          {posts.map((post) => (
+            <Link
+              key={post.url}
+              href={post.url}
+              className="group flex min-h-64 flex-col rounded-2xl border bg-card p-6 transition-colors hover:border-primary/40 hover:bg-accent/40 sm:p-8"
+            >
+              <time
+                dateTime={post.data.date}
+                className="text-sm text-muted-foreground"
+              >
+                {dateFormatter.format(new Date(post.data.date))}
+              </time>
+              <h2 className="mt-5 text-2xl font-semibold tracking-tight text-balance">
+                {post.data.title}
+              </h2>
+              <p className="mt-3 leading-7 text-muted-foreground">
+                {post.data.description}
+              </p>
+              <span className="mt-auto inline-flex items-center gap-2 pt-8 text-sm font-medium text-primary">
+                Read article
+                <ArrowRightIcon className="size-4 transition-transform group-hover:translate-x-1" />
+              </span>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <section className="mt-16 rounded-2xl border border-dashed p-8 sm:mt-20 sm:p-12">
+          <h2 className="text-xl font-semibold">
+            The first post is on its way.
+          </h2>
+          <p className="mt-2 max-w-xl leading-7 text-muted-foreground">
+            We’ll start with a look at the next major EdgeStore release. In the
+            meantime, the documentation has everything you need to get started.
+          </p>
+          <Link
+            href="/docs/quick-start"
+            className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-primary"
+          >
+            Read the quick start
+            <ArrowRightIcon className="size-4" />
+          </Link>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/docs/src/app/layout.config.tsx
+++ b/docs/src/app/layout.config.tsx
@@ -17,6 +17,13 @@ export const linkItems: LinkItemType[] = [
         >
           Docs
         </Link>
+        <Link
+          className="inline-flex items-center gap-1 p-2 text-sm text-fd-muted-foreground transition-colors hover:text-fd-accent-foreground data-[active=true]:text-fd-primary [&_svg]:size-4"
+          href="/blog"
+          aria-label="Go to blog"
+        >
+          Blog
+        </Link>
         <div className="grow max-sm:hidden" />
         <Link
           className="inline-flex items-center gap-1 p-2 text-sm text-fd-muted-foreground transition-colors hover:text-fd-accent-foreground data-[active=true]:text-fd-primary [&_svg]:size-4"

--- a/docs/src/lib/source.ts
+++ b/docs/src/lib/source.ts
@@ -1,6 +1,7 @@
 import { loader, type InferPageType } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
-import { docs } from 'fumadocs-mdx:collections/server';
+import { blogPosts, docs } from 'fumadocs-mdx:collections/server';
+import { toFumadocsSource } from 'fumadocs-mdx/runtime/server';
 
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
@@ -8,6 +9,11 @@ export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
   plugins: [lucideIconsPlugin()],
+});
+
+export const blog = loader({
+  baseUrl: '/blog',
+  source: toFumadocsSource(blogPosts, []),
 });
 
 export type Page = InferPageType<typeof source>;


### PR DESCRIPTION
## What changed

- add a typed Fumadocs MDX collection for blog posts
- add the `/blog` index and statically generated article route
- add article metadata, navigation, empty-state copy, and shared MDX rendering
- create the blog content directory for the upcoming first post

## Why

EdgeStore needs a first-party place for release announcements and technical writing. This foundation follows Fumadocs' recommended blog architecture and reuses the existing docs content pipeline.

## User impact

Visitors can discover the new Blog section. Until the first article is added, the index presents an intentional coming-soon state.

## Before review

This PR intentionally remains a draft. The first post about the next major EdgeStore release will be added here before it is marked ready.

## Validation

- production package build
- docs production build
- TypeScript
- focused ESLint
- formatting and diff checks