### PR TITLE
chore: build packages during Codex environment setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -28,6 +28,7 @@ done
 node --version
 pnpm --version
 pnpm install --frozen-lockfile --prefer-offline
+pnpm build
 '''
 
 [[actions]]


### PR DESCRIPTION
## What changed

- Run `pnpm build` after dependency installation in the Codex environment setup.

## Why

The docs consume generated type declarations from the local `@edgestore/*` packages. In a fresh worktree those declarations may not exist yet, which can produce misleading type-aware ESLint errors when a docs command is run directly instead of through Turbo.

Building the packages during setup gives every Codex worktree a valid starting state for docs development and direct linting. The measured cost is about 9 seconds without a Turbo cache and less than one second with a warm cache.

## Validation

- `pnpm install --frozen-lockfile --prefer-offline`
- `CI=true pnpm build`
- `git diff --check`
