### PR TITLE
[Ask AI 01] feat: switch docs assistant to Luna

### DIFF
--- a/docs/src/app/api/chat/route.ts
+++ b/docs/src/app/api/chat/route.ts
@@ -15,6 +15,7 @@ import {
   type UIMessage,
 } from 'ai';
 import { after } from 'next/server';
+import type { z } from 'zod';
 import {
   GetDocsToolSchema,
   ProvideLinksToolSchema,
@@ -90,10 +91,15 @@ Guidelines:
 - Never invent API methods, configuration options, or features that aren't documented.
 - If a feature doesn't exist in EdgeStore, say so clearly.
 
-After providing your answer, use the "provideLinks" tool to share relevant documentation links with the user. Include links to the documentation pages you referenced in your answer.`;
+Before writing your final answer, call the "provideLinks" tool exactly once with the documentation pages you referenced. After the tool returns, write a complete, non-empty answer to the user. Do not call "provideLinks" again, and do not treat the tool call as the answer.`;
 
   const result = streamText({
-    model: 'openai/gpt-4.1-mini',
+    model: 'openai/gpt-5.6-luna',
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'none',
+      },
+    },
     system: systemPrompt,
     tools: {
       getDocs: {
@@ -105,6 +111,9 @@ After providing your answer, use the "provideLinks" tool to share relevant docum
       },
       provideLinks: {
         inputSchema: ProvideLinksToolSchema,
+        execute: ({ links }: z.infer<typeof ProvideLinksToolSchema>) => ({
+          links,
+        }),
       },
     },
     messages: await convertToModelMessages(reqJson.messages, {


### PR DESCRIPTION
## Change

- Switch Ask AI from GPT-4.1 mini to GPT-5.6 Luna with reasoning disabled.
- Tell the model to call `provideLinks` before it writes the final answer.
- Execute `provideLinks` so the model can continue after the tool call.

Without the executor, Luna could stop at the link call and return no answer text.

## Benchmark

The benchmark asked five documentation questions twice for each configuration. Every run used the same EdgeStore pages, tool schemas, and prompt. Quality is the percentage of question-specific checks passed. Cost uses estimated OpenAI token pricing.

| Model | Complete answers | One `provideLinks` call | Quality | Median first event | Median total time | Estimated cost per request |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| GPT-4.1 mini | 10/10 | 10/10 | 90% | 1.24 s | 9.48 s | $0.006283 |
| Luna, no reasoning | 10/10 | 10/10 | 87.5% | 1.33 s | 6.36 s | $0.001417 |
| Luna, low reasoning | 10/10 | 10/10 | 85% | 1.44 s | 7.49 s | $0.001910 |

Luna with no reasoning cut estimated cost by 77% and median total time by 33%. Its quality score was 2.5 percentage points lower, and its first event arrived 92 ms later. Low reasoning cost more, took longer, and scored lower in this run.

## Checks

- Targeted Prettier and ESLint checks pass.
- `pnpm build` passes.
- `pnpm --filter docs exec tsc --noEmit --pretty false` passes after rebuilding the workspace packages.
