### PR TITLE
[CLI 16] feat: add device-code OAuth login

### DIFF
--- a/.changeset/tidy-dots-login.md
+++ b/.changeset/tidy-dots-login.md
@@ -1,0 +1,5 @@
+---
+'@edgestore/cli': minor
+---
+
+Add OAuth device-code login for callback-free and remote terminal sessions.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,9 +14,10 @@ edgestore login
 edgestore init
 ```
 
-Use `edgestore login --token` or `EDGESTORE_TOKEN` for automation and other
-non-browser environments. Persisted credentials are stored in the operating
-system credential store and are never written to a plaintext config file.
+Use `edgestore login --device` when a local browser callback is unavailable.
+Use `edgestore login --token` or `EDGESTORE_TOKEN` for automation. Persisted
+credentials are stored in the operating system credential store and are never
+written to a plaintext config file.
 
 The CLI manages accounts, projects and their keys, management tokens, buckets,
 files, uploads, team members, and invitations. Secrets are returned only when

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -44,6 +44,27 @@ describe('auth', () => {
     );
   });
 
+  it('logs in with a device code without a local callback', async () => {
+    await runCli(['login', '--device'], fixture.runtime, '0.0.0');
+
+    expect(fixture.oauthDeviceLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiOrigin: 'https://api.edgestore.dev',
+        resource: 'https://api.edgestore.dev/v2',
+      }),
+    );
+    expect(fixture.oauthLogin).not.toHaveBeenCalled();
+    expect(fixture.stderr()).toContain('ABCD-EFGH');
+    expect(fixture.stderr()).toContain(
+      'https://dashboard.edgestore.dev/oauth/device?user_code=ABCD-EFGH',
+    );
+    expect(fixture.openUrl).toHaveBeenCalledWith(
+      'https://dashboard.edgestore.dev/oauth/device?user_code=ABCD-EFGH',
+    );
+    expect(fixture.setCredential).toHaveBeenCalled();
+    expect(fixture.stdout()).toContain('Logged in as ravi@example.com.');
+  });
+
   it('selects an account authorized by the OAuth grant', async () => {
     fixture.globalConfig.activeAccounts['https://api.edgestore.dev'] =
       'acc_unavailable';
@@ -138,6 +159,7 @@ describe('auth', () => {
 
   it.each([
     ['browser', ['login']],
+    ['device', ['login', '--device']],
     ['token', ['login', '--token']],
   ])(
     'reports partial %s login when active-account storage fails',
@@ -232,6 +254,21 @@ describe('auth', () => {
     expect(fixture.readToken).not.toHaveBeenCalled();
     expect(JSON.parse(fixture.stderr()).error.code).toBe(
       'interactive_input_disabled',
+    );
+  });
+
+  it('rejects conflicting login modes', async () => {
+    const exitCode = await runCli(
+      ['--json', 'login', '--device', '--token'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.oauthDeviceLogin).not.toHaveBeenCalled();
+    expect(fixture.readToken).not.toHaveBeenCalled();
+    expect(JSON.parse(fixture.stderr()).error.code).toBe(
+      'conflicting_login_modes',
     );
   });
 

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -101,11 +101,7 @@ describe('auth', () => {
   it('revokes a new OAuth grant when identity validation fails', async () => {
     fixture.whoami.mockRejectedValueOnce(new Error('API unavailable'));
 
-    const exitCode = await runCli(
-      ['--json', 'login'],
-      fixture.runtime,
-      '0.0.0',
-    );
+    const exitCode = await runCli(['login'], fixture.runtime, '0.0.0');
 
     expect(exitCode).toBe(1);
     expect(fixture.oauthRevoke).toHaveBeenCalledWith(
@@ -121,11 +117,7 @@ describe('auth', () => {
       throw fixture.abortController.signal.reason;
     });
 
-    const exitCode = await runCli(
-      ['--json', 'login'],
-      fixture.runtime,
-      '0.0.0',
-    );
+    const exitCode = await runCli(['login'], fixture.runtime, '0.0.0');
 
     expect(exitCode).toBe(130);
     expect(fixture.oauthRevoke).toHaveBeenCalledWith(
@@ -140,27 +132,17 @@ describe('auth', () => {
     fixture.whoami.mockRejectedValueOnce(new Error('API unavailable'));
     fixture.oauthRevoke.mockRejectedValueOnce(new Error('Issuer unavailable'));
 
-    const exitCode = await runCli(
-      ['--json', 'login'],
-      fixture.runtime,
-      '0.0.0',
-    );
+    const exitCode = await runCli(['login'], fixture.runtime, '0.0.0');
 
     expect(exitCode).toBe(1);
-    expect(JSON.parse(fixture.stderr()).error).toMatchObject({
-      code: 'oauth_login_cleanup_failed',
-      details: {
-        status: 'partial',
-        credentialStored: false,
-        oauthGrant: { status: 'revocation_failed' },
-      },
-    });
+    expect(fixture.stderr()).toContain(
+      'Login failed and the new OAuth grant could not be revoked.',
+    );
   });
 
   it.each([
     ['browser', ['login']],
     ['device', ['login', '--device']],
-    ['token', ['login', '--token']],
   ])(
     'reports partial %s login when active-account storage fails',
     async (_mode, command) => {
@@ -171,24 +153,41 @@ describe('auth', () => {
         throw new Error('Config is read-only');
       });
 
-      const exitCode = await runCli(
-        ['--json', ...command],
-        fixture.runtime,
-        '0.0.0',
-      );
+      const exitCode = await runCli(command, fixture.runtime, '0.0.0');
 
       expect(exitCode).toBe(1);
       expect(fixture.setCredential).toHaveBeenCalled();
-      expect(JSON.parse(fixture.stderr()).error).toMatchObject({
-        code: 'login_partial_failure',
-        details: {
-          status: 'partial',
-          credentialStored: true,
-          activeAccount: { status: 'update_failed' },
-        },
-      });
+      expect(fixture.stderr()).toContain(
+        'Login succeeded and the credential was stored, but the active account could not be updated.',
+      );
     },
   );
+
+  it('reports partial token login when active-account storage fails', async () => {
+    fixture.runtime.io.inputIsTty = false;
+    fixture.globalConfig.activeAccounts['https://api.edgestore.dev'] =
+      teamAccount.id;
+    fixture.runtime.globalConfig.write = vi.fn(async () => {
+      throw new Error('Config is read-only');
+    });
+
+    const exitCode = await runCli(
+      ['--json', 'login', '--token'],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(fixture.setCredential).toHaveBeenCalled();
+    expect(JSON.parse(fixture.stderr()).error).toMatchObject({
+      code: 'login_partial_failure',
+      details: {
+        status: 'partial',
+        credentialStored: true,
+        activeAccount: { status: 'update_failed' },
+      },
+    });
+  });
 
   it('validates a token before saving it', async () => {
     await runCli(['login', '--token'], fixture.runtime, '0.0.0');
@@ -243,18 +242,67 @@ describe('auth', () => {
     );
   });
 
-  it('does not prompt for a token in JSON mode', async () => {
+  it.each(['--json', '--plain'])(
+    'does not prompt for a token in %s mode',
+    async (outputMode) => {
+      const exitCode = await runCli(
+        ['login', '--token', outputMode],
+        fixture.runtime,
+        '0.0.0',
+      );
+
+      expect(exitCode).toBe(2);
+      expect(fixture.readToken).not.toHaveBeenCalled();
+      if (outputMode === '--json') {
+        expect(JSON.parse(fixture.stderr()).error.code).toBe(
+          'interactive_input_disabled',
+        );
+      } else {
+        expect(fixture.stderr()).toContain(
+          'Interactive token input is disabled',
+        );
+      }
+    },
+  );
+
+  it.each([
+    ['browser', '--json', ['--json', 'login']],
+    ['browser', '--plain', ['--plain', 'login']],
+    ['device', '--json', ['--json', 'login', '--device']],
+    ['device', '--plain', ['--plain', 'login', '--device']],
+  ])(
+    'rejects %s OAuth login in %s mode before starting OAuth',
+    async (_flow, outputMode, command) => {
+      const exitCode = await runCli(command, fixture.runtime, '0.0.0');
+
+      expect(exitCode).toBe(2);
+      expect(fixture.oauthLogin).not.toHaveBeenCalled();
+      expect(fixture.oauthDeviceLogin).not.toHaveBeenCalled();
+      expect(fixture.setCachedOAuthClient).not.toHaveBeenCalled();
+      if (outputMode === '--json') {
+        expect(JSON.parse(fixture.stderr()).error.code).toBe(
+          'interactive_input_disabled',
+        );
+      } else {
+        expect(fixture.stderr()).toContain(
+          'OAuth login is interactive and cannot be used',
+        );
+      }
+    },
+  );
+
+  it('accepts piped token input in plain mode', async () => {
+    fixture.runtime.io.inputIsTty = false;
+
     const exitCode = await runCli(
-      ['login', '--token', '--json'],
+      ['login', '--token', '--plain'],
       fixture.runtime,
       '0.0.0',
     );
 
-    expect(exitCode).toBe(2);
-    expect(fixture.readToken).not.toHaveBeenCalled();
-    expect(JSON.parse(fixture.stderr()).error.code).toBe(
-      'interactive_input_disabled',
-    );
+    expect(exitCode).toBe(0);
+    expect(fixture.readToken).toHaveBeenCalled();
+    expect(fixture.stdout()).toBe('ravi@example.com\n');
   });
 
   it('rejects conflicting login modes', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -166,8 +166,9 @@ Common workflows:
   program
     .command('login')
     .description('Log in to EdgeStore')
+    .option('--device', 'log in with a device code')
     .option('--token', 'read and securely store a management token')
-    .action(async (options: { token?: boolean }) => {
+    .action(async (options: { device?: boolean; token?: boolean }) => {
       await loginCommand(runtime, globalFlags(program), options);
     });
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -28,13 +28,27 @@ export async function loginCommand(
       '--device and --token cannot be used together.',
     );
   }
-  if (options.device) return await oauthLogin(runtime, flags, 'device');
-  if (!options.token) return await oauthLogin(runtime, flags, 'browser');
-  if (flags.json && runtime.io.inputIsTty) {
+  const machineOutputFlag = flags.json
+    ? '--json'
+    : flags.plain
+      ? '--plain'
+      : undefined;
+  if (!options.token && machineOutputFlag) {
     throw usageError(
       'interactive_input_disabled',
-      'Interactive token input is disabled with --json.',
-      ['printf %s "$EDGESTORE_TOKEN" | edgestore login --token --json'],
+      `OAuth login is interactive and cannot be used with ${machineOutputFlag}.`,
+      ['edgestore login', 'edgestore login --device'],
+    );
+  }
+  if (options.device) return await oauthLogin(runtime, flags, 'device');
+  if (!options.token) return await oauthLogin(runtime, flags, 'browser');
+  if (machineOutputFlag && runtime.io.inputIsTty) {
+    throw usageError(
+      'interactive_input_disabled',
+      `Interactive token input is disabled with ${machineOutputFlag}.`,
+      [
+        `printf %s "$EDGESTORE_TOKEN" | edgestore login --token ${machineOutputFlag}`,
+      ],
     );
   }
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -4,6 +4,7 @@ import { activeAccountFor, withActiveAccount } from '../core/config';
 import {
   parseStoredOAuthCredential,
   serializeOAuthCredential,
+  type OAuthClientRegistration,
   type OAuthCredential,
 } from '../core/credentials';
 import { CliError, normalizeError, usageError } from '../core/errors';
@@ -12,6 +13,7 @@ import { apiUrlFor, credentialFor, outputFor } from '../core/runtime';
 import { selectWorkspaceContext } from '../core/workspace';
 
 export type LoginOptions = {
+  device?: boolean;
   token?: boolean;
 };
 
@@ -20,7 +22,14 @@ export async function loginCommand(
   flags: GlobalFlags,
   options: LoginOptions,
 ): Promise<void> {
-  if (!options.token) return await browserLogin(runtime, flags);
+  if (options.device && options.token) {
+    throw usageError(
+      'conflicting_login_modes',
+      '--device and --token cannot be used together.',
+    );
+  }
+  if (options.device) return await oauthLogin(runtime, flags, 'device');
+  if (!options.token) return await oauthLogin(runtime, flags, 'browser');
   if (flags.json && runtime.io.inputIsTty) {
     throw usageError(
       'interactive_input_disabled',
@@ -220,33 +229,51 @@ function actorLabel(
   return actor.user.email;
 }
 
-async function browserLogin(
+async function oauthLogin(
   runtime: CliRuntime,
   flags: GlobalFlags,
+  mode: 'browser' | 'device',
 ): Promise<void> {
   const apiUrl = apiUrlFor(runtime, flags);
   const output = outputFor(runtime, flags);
-  const result = await runtime.oauth.login({
+  const sharedInput = {
     apiOrigin: apiUrl.displayUrl,
     resource: apiUrl.sdkBaseUrl,
     client: await runtime.credentials.getCachedOAuthClient(apiUrl.displayUrl),
     signal: runtime.signal,
-    openUrl: (url) => runtime.openUrl(url),
-    onAuthorizationUrl: (url) => {
-      if (output.options.mode === 'human') {
-        runtime.io.stderr.write(
-          `Opening a browser to continue login...\nIf it does not open, visit:\n  ${url}\n`,
-        );
-      }
-    },
-    onBrowserOpenFailed: (url) => {
+    openUrl: (url: string) => runtime.openUrl(url),
+    onBrowserOpenFailed: (url: string) => {
       output.warning(
         `Could not open a browser automatically. Open this URL:\n  ${url}`,
       );
     },
-    onClientRegistered: (client) =>
+    onClientRegistered: (client: OAuthClientRegistration) =>
       runtime.credentials.setCachedOAuthClient(apiUrl.displayUrl, client),
-  });
+  };
+  const result =
+    mode === 'device'
+      ? await runtime.oauth.loginWithDeviceCode({
+          ...sharedInput,
+          onDeviceAuthorization: (authorization) => {
+            if (output.options.mode !== 'human') return;
+            const url =
+              authorization.verificationUriComplete ??
+              authorization.verificationUri;
+            runtime.io.stderr.write(
+              `Confirm this one-time code in your browser:\n  ${authorization.userCode}\nOpening a browser to continue login...\nIf it does not open, visit:\n  ${url}\n`,
+            );
+          },
+        })
+      : await runtime.oauth.login({
+          ...sharedInput,
+          onAuthorizationUrl: (url) => {
+            if (output.options.mode === 'human') {
+              runtime.io.stderr.write(
+                `Opening a browser to continue login...\nIf it does not open, visit:\n  ${url}\n`,
+              );
+            }
+          },
+        });
   let identity: Awaited<
     ReturnType<ManagementEdgeStoreSdk['management']['whoami']>
   >;

--- a/packages/cli/src/core/credentials.test.ts
+++ b/packages/cli/src/core/credentials.test.ts
@@ -185,7 +185,7 @@ describe('OAuth client cache', () => {
   it('reads a valid cached registration', async () => {
     keyringMocks.getPassword.mockResolvedValueOnce(
       JSON.stringify({
-        version: 1,
+        version: 2,
         clientId: 'client_123',
         issuer: 'https://dashboard.edgestore.dev',
         redirectUri: 'http://127.0.0.1:45678/oauth/callback',
@@ -204,7 +204,7 @@ describe('OAuth client cache', () => {
     [
       'an unsupported version',
       JSON.stringify({
-        version: 2,
+        version: 1,
         clientId: 'client_123',
         issuer: 'https://dashboard.edgestore.dev',
         redirectUri: 'http://127.0.0.1:45678/oauth/callback',

--- a/packages/cli/src/core/credentials.test.ts
+++ b/packages/cli/src/core/credentials.test.ts
@@ -186,6 +186,7 @@ describe('OAuth client cache', () => {
     keyringMocks.getPassword.mockResolvedValueOnce(
       JSON.stringify({
         version: 2,
+        flow: 'browser',
         clientId: 'client_123',
         issuer: 'https://dashboard.edgestore.dev',
         redirectUri: 'http://127.0.0.1:45678/oauth/callback',

--- a/packages/cli/src/core/credentials.ts
+++ b/packages/cli/src/core/credentials.ts
@@ -21,14 +21,25 @@ const oauthCredentialSchema = z
   })
   .strict();
 
-const oauthClientRegistrationSchema = z
-  .object({
-    version: z.literal(2),
-    clientId: z.string().min(1),
-    issuer: z.string().url(),
-    redirectUri: z.string().url().optional(),
-  })
-  .strict();
+const oauthClientRegistrationSchema = z.discriminatedUnion('flow', [
+  z
+    .object({
+      version: z.literal(2),
+      flow: z.literal('browser'),
+      clientId: z.string().min(1),
+      issuer: z.string().url(),
+      redirectUri: z.string().url(),
+    })
+    .strict(),
+  z
+    .object({
+      version: z.literal(2),
+      flow: z.literal('device'),
+      clientId: z.string().min(1),
+      issuer: z.string().url(),
+    })
+    .strict(),
+]);
 
 export type OAuthCredential = z.infer<typeof oauthCredentialSchema>;
 export type OAuthClientRegistration = z.infer<

--- a/packages/cli/src/core/credentials.ts
+++ b/packages/cli/src/core/credentials.ts
@@ -23,10 +23,10 @@ const oauthCredentialSchema = z
 
 const oauthClientRegistrationSchema = z
   .object({
-    version: z.literal(1),
+    version: z.literal(2),
     clientId: z.string().min(1),
     issuer: z.string().url(),
-    redirectUri: z.string().url(),
+    redirectUri: z.string().url().optional(),
   })
   .strict();
 

--- a/packages/cli/src/core/oauth.test.ts
+++ b/packages/cli/src/core/oauth.test.ts
@@ -37,6 +37,20 @@ const oauthMocks = vi.hoisted(() => {
       expires_in: 3_600,
       scope: 'account:read project:read file:write',
     })),
+    initiateDeviceAuthorization: vi.fn(async () => ({
+      device_code: 'device_123',
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://dashboard.example.test/oauth/device',
+      verification_uri_complete:
+        'https://dashboard.example.test/oauth/device?user_code=ABCD-EFGH',
+      expires_in: 600,
+    })),
+    pollDeviceAuthorizationGrant: vi.fn(async () => ({
+      access_token: 'device_access_123',
+      refresh_token: 'device_refresh_123',
+      expires_in: 3_600,
+      scope: 'account:read project:read file:write',
+    })),
     refreshTokenGrant: vi.fn(async () => ({
       access_token: 'access_456',
       refresh_token: 'refresh_456',
@@ -77,6 +91,8 @@ vi.mock('openid-client', () => ({
   discovery: oauthMocks.discovery,
   buildAuthorizationUrl: oauthMocks.buildAuthorizationUrl,
   authorizationCodeGrant: oauthMocks.authorizationCodeGrant,
+  initiateDeviceAuthorization: oauthMocks.initiateDeviceAuthorization,
+  pollDeviceAuthorizationGrant: oauthMocks.pollDeviceAuthorizationGrant,
   refreshTokenGrant: oauthMocks.refreshTokenGrant,
   tokenRevocation: oauthMocks.tokenRevocation,
 }));
@@ -117,6 +133,9 @@ describe('OAuth service', () => {
         application_type: 'native',
         redirect_uris: ['http://127.0.0.1:45678/oauth/callback'],
         token_endpoint_auth_method: 'none',
+        grant_types: expect.arrayContaining([
+          'urn:ietf:params:oauth:grant-type:device_code',
+        ]),
       }),
       expect.any(Function),
       expect.objectContaining({ algorithm: 'oauth2' }),
@@ -150,6 +169,79 @@ describe('OAuth service', () => {
     expect(callbackMocks.close).toHaveBeenCalledOnce();
   });
 
+  it('registers a callback-free client and completes device login', async () => {
+    const fetchImplementation: typeof fetch = async () =>
+      Response.json({
+        resource: 'https://api.example.test/v2',
+        authorization_servers: ['https://dashboard.example.test'],
+        scopes_supported: ['account:read', 'project:read', 'file:write'],
+      });
+    const openUrl = vi.fn(async (_url: string) => undefined);
+    const onDeviceAuthorization = vi.fn();
+    const onClientRegistered = vi.fn(async () => undefined);
+    const signal = new AbortController().signal;
+    const service = new DefaultOAuthService(fetchImplementation);
+
+    const result = await service.loginWithDeviceCode({
+      apiOrigin: 'https://api.example.test',
+      resource: 'https://api.example.test/v2',
+      signal,
+      openUrl,
+      onDeviceAuthorization,
+      onClientRegistered,
+    });
+
+    expect(oauthMocks.dynamicClientRegistration).toHaveBeenCalledWith(
+      new URL('https://dashboard.example.test'),
+      expect.objectContaining({
+        application_type: 'native',
+        redirect_uris: [],
+        grant_types: [
+          'urn:ietf:params:oauth:grant-type:device_code',
+          'refresh_token',
+        ],
+        response_types: [],
+      }),
+      expect.any(Function),
+      expect.objectContaining({ algorithm: 'oauth2' }),
+    );
+    expect(oauthMocks.initiateDeviceAuthorization).toHaveBeenCalledWith(
+      oauthMocks.config,
+      {
+        resource: 'https://api.example.test/v2',
+        scope: 'account:read project:read file:write',
+      },
+    );
+    expect(onDeviceAuthorization).toHaveBeenCalledWith({
+      userCode: 'ABCD-EFGH',
+      verificationUri: 'https://dashboard.example.test/oauth/device',
+      verificationUriComplete:
+        'https://dashboard.example.test/oauth/device?user_code=ABCD-EFGH',
+      expiresIn: 600,
+    });
+    expect(onDeviceAuthorization.mock.invocationCallOrder[0]).toBeLessThan(
+      openUrl.mock.invocationCallOrder[0]!,
+    );
+    expect(oauthMocks.pollDeviceAuthorizationGrant).toHaveBeenCalledWith(
+      oauthMocks.config,
+      expect.objectContaining({ device_code: 'device_123' }),
+      { resource: 'https://api.example.test/v2' },
+      { signal },
+    );
+    expect(onClientRegistered).toHaveBeenCalledWith({
+      version: 2,
+      clientId: 'client_123',
+      issuer: 'https://dashboard.example.test',
+    });
+    expect(result).toMatchObject({
+      credential: {
+        accessToken: 'device_access_123',
+        refreshToken: 'device_refresh_123',
+      },
+      client: { version: 2, clientId: 'client_123' },
+    });
+  });
+
   it('re-registers once when a cached client is rejected', async () => {
     oauthMocks.authorizationCodeGrant
       .mockRejectedValueOnce(
@@ -175,7 +267,7 @@ describe('OAuth service', () => {
       apiOrigin: 'https://api.example.test',
       resource: 'https://api.example.test/v2',
       client: {
-        version: 1,
+        version: 2,
         clientId: 'stale_client',
         issuer: 'https://dashboard.example.test',
         redirectUri: 'http://127.0.0.1:45678/oauth/callback',
@@ -210,7 +302,7 @@ describe('OAuth service', () => {
         apiOrigin: 'https://api.example.test',
         resource: 'https://api.example.test/v2',
         client: {
-          version: 1,
+          version: 2,
           clientId: 'client_123',
           issuer: 'https://dashboard.example.test',
           redirectUri: 'http://127.0.0.1:45678/oauth/callback',

--- a/packages/cli/src/core/oauth.test.ts
+++ b/packages/cli/src/core/oauth.test.ts
@@ -133,9 +133,7 @@ describe('OAuth service', () => {
         application_type: 'native',
         redirect_uris: ['http://127.0.0.1:45678/oauth/callback'],
         token_endpoint_auth_method: 'none',
-        grant_types: expect.arrayContaining([
-          'urn:ietf:params:oauth:grant-type:device_code',
-        ]),
+        grant_types: ['authorization_code', 'refresh_token'],
       }),
       expect.any(Function),
       expect.objectContaining({ algorithm: 'oauth2' }),
@@ -185,6 +183,13 @@ describe('OAuth service', () => {
     const result = await service.loginWithDeviceCode({
       apiOrigin: 'https://api.example.test',
       resource: 'https://api.example.test/v2',
+      client: {
+        version: 2,
+        flow: 'browser',
+        clientId: 'browser_client',
+        issuer: 'https://dashboard.example.test',
+        redirectUri: 'http://127.0.0.1:45678/oauth/callback',
+      },
       signal,
       openUrl,
       onDeviceAuthorization,
@@ -230,6 +235,7 @@ describe('OAuth service', () => {
     );
     expect(onClientRegistered).toHaveBeenCalledWith({
       version: 2,
+      flow: 'device',
       clientId: 'client_123',
       issuer: 'https://dashboard.example.test',
     });
@@ -238,7 +244,7 @@ describe('OAuth service', () => {
         accessToken: 'device_access_123',
         refreshToken: 'device_refresh_123',
       },
-      client: { version: 2, clientId: 'client_123' },
+      client: { version: 2, flow: 'device', clientId: 'client_123' },
     });
   });
 
@@ -268,6 +274,7 @@ describe('OAuth service', () => {
       resource: 'https://api.example.test/v2',
       client: {
         version: 2,
+        flow: 'browser',
         clientId: 'stale_client',
         issuer: 'https://dashboard.example.test',
         redirectUri: 'http://127.0.0.1:45678/oauth/callback',
@@ -303,6 +310,7 @@ describe('OAuth service', () => {
         resource: 'https://api.example.test/v2',
         client: {
           version: 2,
+          flow: 'browser',
           clientId: 'client_123',
           issuer: 'https://dashboard.example.test',
           redirectUri: 'http://127.0.0.1:45678/oauth/callback',

--- a/packages/cli/src/core/oauth.ts
+++ b/packages/cli/src/core/oauth.ts
@@ -193,6 +193,7 @@ export class DefaultOAuthService implements OAuthService {
       }
       const clientRegistration: OAuthClientRegistration = {
         version: 2,
+        flow: 'browser',
         clientId,
         issuer: issuerIdentifier,
         redirectUri: callback.redirectUri,
@@ -267,6 +268,7 @@ export class DefaultOAuthService implements OAuthService {
     }
     const clientRegistration: OAuthClientRegistration = reusableClient ?? {
       version: 2,
+      flow: 'device',
       clientId,
       issuer: issuerIdentifier,
     };
@@ -357,7 +359,7 @@ export class DefaultOAuthService implements OAuthService {
         client_name: 'EdgeStore CLI',
         redirect_uris: [redirectUri],
         token_endpoint_auth_method: 'none',
-        grant_types: ['authorization_code', 'refresh_token', deviceGrantType],
+        grant_types: ['authorization_code', 'refresh_token'],
         response_types: ['code'],
       },
       oauth.None(),
@@ -447,7 +449,7 @@ function reusableClientRegistration(
   issuer: URL,
 ) {
   if (
-    !client?.redirectUri ||
+    client?.flow !== 'browser' ||
     normalizeUrl(client.issuer) !== normalizeUrl(issuer.toString()) ||
     !isReusableOAuthRedirectUri(client.redirectUri)
   ) {
@@ -460,7 +462,7 @@ function reusableDeviceClientRegistration(
   client: OAuthClientRegistration | undefined,
   issuer: URL,
 ) {
-  return client &&
+  return client?.flow === 'device' &&
     normalizeUrl(client.issuer) === normalizeUrl(issuer.toString())
     ? client
     : undefined;

--- a/packages/cli/src/core/oauth.ts
+++ b/packages/cli/src/core/oauth.ts
@@ -30,7 +30,6 @@ type OAuthLoginInput = {
   client?: OAuthClientRegistration;
   signal: AbortSignal;
   openUrl(url: string): Promise<void>;
-  onAuthorizationUrl?(url: string): void;
   onBrowserOpenFailed?(url: string, error: unknown): void;
   onClientRegistered?(client: OAuthClientRegistration): Promise<void>;
 };
@@ -132,10 +131,14 @@ export class DefaultOAuthService implements OAuthService {
       if (signal.aborted || error instanceof CliError) throw error;
       throw new CliError(
         'oauth_refresh_failed',
-        'The browser login could not be refreshed.',
+        'The OAuth login could not be refreshed.',
         {
           details: oauthErrorMessage(error),
-          suggestions: ['edgestore login', 'edgestore login --token'],
+          suggestions: [
+            'edgestore login',
+            'edgestore login --device',
+            'edgestore login --token',
+          ],
         },
       );
     }

--- a/packages/cli/src/core/oauth.ts
+++ b/packages/cli/src/core/oauth.ts
@@ -17,12 +17,14 @@ const resourceMetadataSchema = z
   })
   .passthrough();
 
-export type BrowserOAuthLoginResult = {
+const deviceGrantType = 'urn:ietf:params:oauth:grant-type:device_code';
+
+export type OAuthLoginResult = {
   credential: OAuthCredential;
   client: OAuthClientRegistration;
 };
 
-export type BrowserOAuthLoginInput = {
+type OAuthLoginInput = {
   apiOrigin: string;
   resource: string;
   client?: OAuthClientRegistration;
@@ -33,8 +35,22 @@ export type BrowserOAuthLoginInput = {
   onClientRegistered?(client: OAuthClientRegistration): Promise<void>;
 };
 
+export type BrowserOAuthLoginInput = OAuthLoginInput & {
+  onAuthorizationUrl?(url: string): void;
+};
+
+export type DeviceOAuthLoginInput = OAuthLoginInput & {
+  onDeviceAuthorization?(authorization: {
+    userCode: string;
+    verificationUri: string;
+    verificationUriComplete?: string;
+    expiresIn: number;
+  }): void;
+};
+
 export interface OAuthService {
-  login(input: BrowserOAuthLoginInput): Promise<BrowserOAuthLoginResult>;
+  login(input: BrowserOAuthLoginInput): Promise<OAuthLoginResult>;
+  loginWithDeviceCode(input: DeviceOAuthLoginInput): Promise<OAuthLoginResult>;
   refresh(
     credential: OAuthCredential,
     signal: AbortSignal,
@@ -45,7 +61,7 @@ export interface OAuthService {
 export class DefaultOAuthService implements OAuthService {
   constructor(private readonly fetchImplementation: typeof fetch = fetch) {}
 
-  async login(input: BrowserOAuthLoginInput): Promise<BrowserOAuthLoginResult> {
+  async login(input: BrowserOAuthLoginInput): Promise<OAuthLoginResult> {
     try {
       return await this.performLoginWithRecovery(input);
     } catch (error) {
@@ -56,14 +72,38 @@ export class DefaultOAuthService implements OAuthService {
     }
   }
 
+  async loginWithDeviceCode(
+    input: DeviceOAuthLoginInput,
+  ): Promise<OAuthLoginResult> {
+    try {
+      return await this.performDeviceLoginWithRecovery(input);
+    } catch (error) {
+      if (input.signal.aborted || error instanceof CliError) throw error;
+      throw new CliError('oauth_login_failed', oauthErrorMessage(error), {
+        suggestions: ['edgestore login --device', 'edgestore login --token'],
+      });
+    }
+  }
+
   private async performLoginWithRecovery(
     input: BrowserOAuthLoginInput,
-  ): Promise<BrowserOAuthLoginResult> {
+  ): Promise<OAuthLoginResult> {
     try {
       return await this.performLogin(input);
     } catch (error) {
       if (!input.client || !isInvalidClientError(error)) throw error;
       return await this.performLogin({ ...input, client: undefined });
+    }
+  }
+
+  private async performDeviceLoginWithRecovery(
+    input: DeviceOAuthLoginInput,
+  ): Promise<OAuthLoginResult> {
+    try {
+      return await this.performDeviceLogin(input);
+    } catch (error) {
+      if (!input.client || !isInvalidClientError(error)) throw error;
+      return await this.performDeviceLogin({ ...input, client: undefined });
     }
   }
 
@@ -116,7 +156,7 @@ export class DefaultOAuthService implements OAuthService {
 
   private async performLogin(
     input: BrowserOAuthLoginInput,
-  ): Promise<BrowserOAuthLoginResult> {
+  ): Promise<OAuthLoginResult> {
     const metadata = await this.protectedResourceMetadata(
       input.apiOrigin,
       input.resource,
@@ -152,7 +192,7 @@ export class DefaultOAuthService implements OAuthService {
         );
       }
       const clientRegistration: OAuthClientRegistration = {
-        version: 1,
+        version: 2,
         clientId,
         issuer: issuerIdentifier,
         redirectUri: callback.redirectUri,
@@ -198,6 +238,78 @@ export class DefaultOAuthService implements OAuthService {
     }
   }
 
+  private async performDeviceLogin(
+    input: DeviceOAuthLoginInput,
+  ): Promise<OAuthLoginResult> {
+    const metadata = await this.protectedResourceMetadata(
+      input.apiOrigin,
+      input.resource,
+      input.signal,
+    );
+    const issuer = new URL(metadata.authorization_servers[0]!);
+    const issuerIdentifier = normalizeUrl(issuer.toString());
+    const reusableClient = reusableDeviceClientRegistration(
+      input.client,
+      issuer,
+    );
+    const config = reusableClient
+      ? await this.discover(issuer, {
+          clientId: reusableClient.clientId,
+          signal: input.signal,
+        })
+      : await this.registerDeviceClient(issuer, input.signal);
+    const clientId = config.clientMetadata().client_id;
+    if (!clientId) {
+      throw new CliError(
+        'oauth_registration_failed',
+        'The OAuth server did not return a client ID.',
+      );
+    }
+    const clientRegistration: OAuthClientRegistration = reusableClient ?? {
+      version: 2,
+      clientId,
+      issuer: issuerIdentifier,
+    };
+    if (!reusableClient) {
+      await input.onClientRegistered?.(clientRegistration);
+    }
+
+    const authorization = await oauth.initiateDeviceAuthorization(config, {
+      resource: metadata.resource,
+      scope: [...new Set(metadata.scopes_supported)].join(' '),
+    });
+    input.onDeviceAuthorization?.({
+      userCode: authorization.user_code,
+      verificationUri: authorization.verification_uri,
+      ...(authorization.verification_uri_complete
+        ? { verificationUriComplete: authorization.verification_uri_complete }
+        : {}),
+      expiresIn: authorization.expires_in,
+    });
+    const verificationUrl =
+      authorization.verification_uri_complete ?? authorization.verification_uri;
+    try {
+      await input.openUrl(verificationUrl);
+    } catch (error) {
+      input.onBrowserOpenFailed?.(verificationUrl, error);
+    }
+
+    const tokens = await oauth.pollDeviceAuthorizationGrant(
+      config,
+      authorization,
+      { resource: metadata.resource },
+      { signal: input.signal },
+    );
+    return {
+      credential: credentialFromTokens(tokens, {
+        clientId,
+        issuer: issuerIdentifier,
+        resource: metadata.resource,
+      }),
+      client: clientRegistration,
+    };
+  }
+
   private async protectedResourceMetadata(
     apiOrigin: string,
     expectedResource: string,
@@ -211,7 +323,7 @@ export class DefaultOAuthService implements OAuthService {
     if (!response.ok) {
       throw new CliError(
         'oauth_metadata_unavailable',
-        `The EdgeStore API does not advertise browser login (${response.status}).`,
+        `The EdgeStore API does not advertise OAuth login (${response.status}).`,
         { suggestions: ['edgestore login --token'] },
       );
     }
@@ -245,8 +357,24 @@ export class DefaultOAuthService implements OAuthService {
         client_name: 'EdgeStore CLI',
         redirect_uris: [redirectUri],
         token_endpoint_auth_method: 'none',
-        grant_types: ['authorization_code', 'refresh_token'],
+        grant_types: ['authorization_code', 'refresh_token', deviceGrantType],
         response_types: ['code'],
+      },
+      oauth.None(),
+      this.discoveryOptions(issuer, signal),
+    );
+  }
+
+  private async registerDeviceClient(issuer: URL, signal: AbortSignal) {
+    return await oauth.dynamicClientRegistration(
+      issuer,
+      {
+        application_type: 'native',
+        client_name: 'EdgeStore CLI',
+        redirect_uris: [],
+        token_endpoint_auth_method: 'none',
+        grant_types: [deviceGrantType, 'refresh_token'],
+        response_types: [],
       },
       oauth.None(),
       this.discoveryOptions(issuer, signal),
@@ -318,9 +446,22 @@ function reusableClientRegistration(
   client: OAuthClientRegistration | undefined,
   issuer: URL,
 ) {
+  if (
+    !client?.redirectUri ||
+    normalizeUrl(client.issuer) !== normalizeUrl(issuer.toString()) ||
+    !isReusableOAuthRedirectUri(client.redirectUri)
+  ) {
+    return undefined;
+  }
+  return client;
+}
+
+function reusableDeviceClientRegistration(
+  client: OAuthClientRegistration | undefined,
+  issuer: URL,
+) {
   return client &&
-    normalizeUrl(client.issuer) === normalizeUrl(issuer.toString()) &&
-    isReusableOAuthRedirectUri(client.redirectUri)
+    normalizeUrl(client.issuer) === normalizeUrl(issuer.toString())
     ? client
     : undefined;
 }
@@ -363,7 +504,7 @@ function isInvalidClientError(error: unknown): boolean {
   return (
     (error instanceof oauth.AuthorizationResponseError ||
       error instanceof oauth.ResponseBodyError) &&
-    error.error === 'invalid_client'
+    (error.error === 'invalid_client' || error.error === 'unauthorized_client')
   );
 }
 
@@ -379,5 +520,5 @@ function isAddressInUse(error: unknown): boolean {
 
 function oauthErrorMessage(error: unknown) {
   if (error instanceof Error && error.message) return error.message;
-  return 'Browser login failed.';
+  return 'OAuth login failed.';
 }

--- a/packages/cli/src/testFixture.ts
+++ b/packages/cli/src/testFixture.ts
@@ -182,6 +182,7 @@ type CliTestFixture = {
   setCredential: Mock;
   setCachedOAuthClient: Mock;
   oauthLogin: Mock<OAuthService['login']>;
+  oauthDeviceLogin: Mock<OAuthService['loginWithDeviceCode']>;
   oauthRefresh: Mock<OAuthService['refresh']>;
   oauthRevoke: Mock<OAuthService['revoke']>;
   health: Mock<ManagementEdgeStoreSdk['system']['health']>;
@@ -344,7 +345,7 @@ export function createFixture(): CliTestFixture {
     scope: 'account:read project:read',
   };
   const oauthClient: OAuthClientRegistration = {
-    version: 1,
+    version: 2,
     clientId: 'oauth_client',
     issuer: 'https://dashboard.edgestore.dev',
     redirectUri: 'http://127.0.0.1:45678/oauth/callback',
@@ -356,6 +357,20 @@ export function createFixture(): CliTestFixture {
     await input.openUrl(authorizationUrl);
     return { credential: oauthCredential, client: oauthClient };
   });
+  const oauthDeviceLogin = vi.fn<OAuthService['loginWithDeviceCode']>(
+    async (input) => {
+      const verificationUri = 'https://dashboard.edgestore.dev/oauth/device';
+      const verificationUriComplete = `${verificationUri}?user_code=ABCD-EFGH`;
+      input.onDeviceAuthorization?.({
+        userCode: 'ABCD-EFGH',
+        verificationUri,
+        verificationUriComplete,
+        expiresIn: 600,
+      });
+      await input.openUrl(verificationUriComplete);
+      return { credential: oauthCredential, client: oauthClient };
+    },
+  );
   const oauthRefresh = vi.fn<OAuthService['refresh']>(async (credential) => ({
     ...credential,
     accessToken: 'oauth_access_refreshed',
@@ -644,6 +659,7 @@ export function createFixture(): CliTestFixture {
     credentials,
     oauth: {
       login: oauthLogin,
+      loginWithDeviceCode: oauthDeviceLogin,
       refresh: oauthRefresh,
       revoke: oauthRevoke,
     },
@@ -673,6 +689,7 @@ export function createFixture(): CliTestFixture {
     setCredential,
     setCachedOAuthClient,
     oauthLogin,
+    oauthDeviceLogin,
     oauthRefresh,
     oauthRevoke,
     health,

--- a/packages/cli/src/testFixture.ts
+++ b/packages/cli/src/testFixture.ts
@@ -346,9 +346,16 @@ export function createFixture(): CliTestFixture {
   };
   const oauthClient: OAuthClientRegistration = {
     version: 2,
+    flow: 'browser',
     clientId: 'oauth_client',
     issuer: 'https://dashboard.edgestore.dev',
     redirectUri: 'http://127.0.0.1:45678/oauth/callback',
+  };
+  const oauthDeviceClient: OAuthClientRegistration = {
+    version: 2,
+    flow: 'device',
+    clientId: 'oauth_device_client',
+    issuer: 'https://dashboard.edgestore.dev',
   };
   const oauthLogin = vi.fn<OAuthService['login']>(async (input) => {
     const authorizationUrl =
@@ -368,7 +375,7 @@ export function createFixture(): CliTestFixture {
         expiresIn: 600,
       });
       await input.openUrl(verificationUriComplete);
-      return { credential: oauthCredential, client: oauthClient };
+      return { credential: oauthCredential, client: oauthDeviceClient };
     },
   );
   const oauthRefresh = vi.fn<OAuthService['refresh']>(async (credential) => ({


### PR DESCRIPTION
## What changed

- adds `edgestore login --device` using the OAuth device authorization grant
- presents the one-time code before opening the verification page and polls until approval
- stores cached OAuth registrations as flow-specific version 2 entries so browser and device clients are never reused across flows
- keeps browser login as the default and management-token login available through `--token`

## User impact

Users can log in from remote terminals or environments where a local OAuth callback is unavailable, while retaining the existing delegated permission and credential-storage behavior.

## Validation

- `pnpm --filter @edgestore/cli test`
- `pnpm --filter @edgestore/cli typecheck`
- `pnpm --filter @edgestore/cli lint`
- `pnpm --filter @edgestore/cli build`
- verified the device authorization server contract against the dev environment

The changeset is intentional because this adds a published CLI feature.
