### PR TITLE
[CLI 17] feat: improve upload progress reporting

### DIFF
--- a/.changeset/bright-files-progress.md
+++ b/.changeset/bright-files-progress.md
@@ -1,0 +1,6 @@
+---
+'@edgestore/cli': patch
+---
+
+Render upload phase, byte, and percentage progress in place in interactive
+terminals instead of appending one line for every update.

--- a/.changeset/bright-files-progress.md
+++ b/.changeset/bright-files-progress.md
@@ -1,6 +1,7 @@
 ---
 '@edgestore/cli': patch
+'@edgestore/sdk': patch
 ---
 
-Render upload phase, byte, and percentage progress in place in interactive
-terminals instead of appending one line for every update.
+Report byte-level upload transfer progress and render stable, in-place upload
+rows in interactive terminals instead of appending one line for every update.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,7 @@
     "@napi-rs/keyring": "1.3.0",
     "commander": "15.0.0",
     "env-paths": "4.0.0",
+    "log-update": "8.0.0",
     "open": "11.0.0",
     "openid-client": "6.8.4",
     "package-manager-detector": "1.8.0",

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -67,7 +67,7 @@ export async function fileUploadCommand(
           localFile,
           mimeType ? { type: mimeType } : undefined,
         );
-        progressDisplay.start(index, fileName, source.size);
+        progressDisplay?.start(index, fileName, source.size);
         try {
           const completed = await sdk.management.uploads.upload({
             project,
@@ -78,12 +78,17 @@ export async function fileUploadCommand(
             ...(destination.path ? { path: destination.path } : {}),
             mimeType,
             signal: runtime.signal,
-            onProgress: (progress) => progressDisplay.update(index, progress),
+            ...(progressDisplay
+              ? {
+                  onProgress: (progress) =>
+                    progressDisplay.update(index, progress),
+                }
+              : {}),
           });
-          progressDisplay.succeed(index);
+          progressDisplay?.succeed(index);
           results.push({ localPath: localFile, ...completed });
         } catch (error) {
-          progressDisplay.fail(index, runtime.signal.aborted);
+          progressDisplay?.fail(index, runtime.signal.aborted);
           throw normalizeUploadError(error, { runtime, flags, project });
         }
       } catch (error) {
@@ -118,7 +123,7 @@ export async function fileUploadCommand(
       }
     }
   } finally {
-    progressDisplay.close();
+    progressDisplay?.close();
   }
   const human = results
     .map((result) => {

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -6,6 +6,7 @@ import { renderCliCommand } from '../core/command';
 import { CliError, normalizeError, usageError } from '../core/errors';
 import type { CliRuntime, GlobalFlags } from '../core/runtime';
 import { isInteractive, outputFor, sdkFor } from '../core/runtime';
+import { createUploadProgressDisplay } from '../core/uploadProgress';
 import { resolvedProjectRef } from './project';
 
 export async function fileUploadCommand(
@@ -52,68 +53,72 @@ export async function fileUploadCommand(
   const project = await resolvedProjectRef(runtime, flags, input.project);
   const sdk = await sdkFor(runtime, flags);
   const results = [];
-  for (const [index, localFile] of localFiles.entries()) {
-    try {
-      const fileName = path.basename(localFile);
-      const mimeType = mimeTypeFor(fileName);
-      const destination = resolveUploadDestination(input.path, {
-        fileName,
-        keepName: input.keepName,
-      });
-      const source = await openAsBlob(
-        localFile,
-        mimeType ? { type: mimeType } : undefined,
-      );
+  const progressDisplay = createUploadProgressDisplay(runtime, flags);
+  try {
+    for (const [index, localFile] of localFiles.entries()) {
       try {
-        const completed = await sdk.management.uploads.upload({
-          project,
-          bucket: input.bucket,
-          source,
-          signedReadUrl: {},
-          ...(destination.fileName ? { fileName: destination.fileName } : {}),
-          ...(destination.path ? { path: destination.path } : {}),
-          mimeType,
-          signal: runtime.signal,
-          onProgress: (progress) =>
-            reportProgress(runtime, flags, {
-              fileName,
-              percentage: progress.percentage,
-            }),
+        const fileName = path.basename(localFile);
+        const mimeType = mimeTypeFor(fileName);
+        const destination = resolveUploadDestination(input.path, {
+          fileName,
+          keepName: input.keepName,
         });
-        results.push({ localPath: localFile, ...completed });
+        const source = await openAsBlob(
+          localFile,
+          mimeType ? { type: mimeType } : undefined,
+        );
+        progressDisplay.start(index, fileName, source.size);
+        try {
+          const completed = await sdk.management.uploads.upload({
+            project,
+            bucket: input.bucket,
+            source,
+            signedReadUrl: {},
+            ...(destination.fileName ? { fileName: destination.fileName } : {}),
+            ...(destination.path ? { path: destination.path } : {}),
+            mimeType,
+            signal: runtime.signal,
+            onProgress: (progress) => progressDisplay.update(index, progress),
+          });
+          progressDisplay.succeed(index);
+          results.push({ localPath: localFile, ...completed });
+        } catch (error) {
+          progressDisplay.fail(index, runtime.signal.aborted);
+          throw normalizeUploadError(error, { runtime, flags, project });
+        }
       } catch (error) {
-        throw normalizeUploadError(error, { runtime, flags, project });
-      }
-    } catch (error) {
-      if (localFiles.length === 1) throw error;
-      const cause = normalizeError(error);
-      const notAttemptedPaths = localFiles.slice(index + 1);
-      throw new CliError(
-        'file_upload_incomplete',
-        [
-          `Upload batch stopped while processing ${localFile}: ${cause.message}`,
-          `Completed (${results.length}):`,
-          ...results.map(
-            (result) =>
-              `  ${result.localPath} -> ${result.signedReadUrl?.signedUrl ?? result.file.url} (${result.file.id})`,
-          ),
-          `Interrupted: ${localFile}`,
-          `Not attempted (${notAttemptedPaths.length}):`,
-          ...notAttemptedPaths.map((file) => `  ${file}`),
-        ].join('\n'),
-        {
-          details: {
-            completed: results,
-            interruptedPath: localFile,
-            notAttemptedPaths,
-            cause: errorDetails(cause),
+        if (localFiles.length === 1) throw error;
+        const cause = normalizeError(error);
+        const notAttemptedPaths = localFiles.slice(index + 1);
+        throw new CliError(
+          'file_upload_incomplete',
+          [
+            `Upload batch stopped while processing ${localFile}: ${cause.message}`,
+            `Completed (${results.length}):`,
+            ...results.map(
+              (result) =>
+                `  ${result.localPath} -> ${result.signedReadUrl?.signedUrl ?? result.file.url} (${result.file.id})`,
+            ),
+            `Interrupted: ${localFile}`,
+            `Not attempted (${notAttemptedPaths.length}):`,
+            ...notAttemptedPaths.map((file) => `  ${file}`),
+          ].join('\n'),
+          {
+            details: {
+              completed: results,
+              interruptedPath: localFile,
+              notAttemptedPaths,
+              cause: errorDetails(cause),
+            },
+            requestId: cause.options.requestId,
+            suggestions: cause.options.suggestions,
+            exitCode: cause.exitCode,
           },
-          requestId: cause.options.requestId,
-          suggestions: cause.options.suggestions,
-          exitCode: cause.exitCode,
-        },
-      );
+        );
+      }
     }
+  } finally {
+    progressDisplay.close();
   }
   const human = results
     .map((result) => {
@@ -200,18 +205,6 @@ function interruptedError(): CliError {
 
 function isFileBlobMutation(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'NotReadableError';
-}
-
-function reportProgress(
-  runtime: CliRuntime,
-  flags: GlobalFlags,
-  progress: { fileName: string; percentage: number },
-): void {
-  if (flags.progress && !flags.json && runtime.io.outputIsTty) {
-    runtime.io.stderr.write(
-      `${progress.fileName}: uploading ${progress.percentage}%\n`,
-    );
-  }
 }
 
 export async function fileUploadStatusCommand(

--- a/packages/cli/src/core/runtime.ts
+++ b/packages/cli/src/core/runtime.ts
@@ -40,6 +40,7 @@ export type RuntimeIo = {
   stderr: NodeJS.WritableStream;
   inputIsTty: boolean;
   outputIsTty: boolean;
+  stderrIsTty: boolean;
 };
 
 type ManagementClient = ManagementEdgeStoreSdk['management'];
@@ -135,6 +136,7 @@ export function createDefaultRuntime(signal: AbortSignal): CliRuntime {
       stderr: process.stderr,
       inputIsTty: Boolean(process.stdin.isTTY),
       outputIsTty: Boolean(process.stdout.isTTY),
+      stderrIsTty: Boolean(process.stderr.isTTY),
     },
     signal,
     setCwd(cwd) {

--- a/packages/cli/src/core/uploadProgress.test.ts
+++ b/packages/cli/src/core/uploadProgress.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  UploadProgressDisplay,
+  type UploadProgressOutput,
+} from './uploadProgress';
+
+describe('UploadProgressDisplay', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('redraws phase changes and ignores duplicate progress events', () => {
+    vi.useFakeTimers();
+    const { live, persist } = fakeLiveOutput();
+    const display = new UploadProgressDisplay(live, false);
+
+    display.start(0, 'archive.zip', 100);
+    display.update(0, {
+      transferredBytes: 0,
+      totalBytes: 100,
+      percentage: 0,
+      phase: 'preparing',
+    });
+    expect(live).toHaveBeenCalledTimes(1);
+
+    display.update(0, {
+      transferredBytes: 0,
+      totalBytes: 100,
+      percentage: 0,
+      phase: 'uploading',
+    });
+    display.update(0, {
+      transferredBytes: 50,
+      totalBytes: 100,
+      percentage: 50,
+      phase: 'uploading',
+    });
+    display.update(0, {
+      transferredBytes: 50,
+      totalBytes: 100,
+      percentage: 50,
+      phase: 'uploading',
+    });
+    display.update(0, {
+      transferredBytes: 100,
+      totalBytes: 100,
+      percentage: 100,
+      phase: 'processing',
+    });
+
+    expect(live).toHaveBeenCalledTimes(4);
+    expect(live.mock.calls[1]?.[0]).toContain('0 B / 100 B · uploading');
+    expect(live.mock.calls[2]?.[0]).toContain('50% · 50 B / 100 B');
+    expect(live.mock.calls[3]?.[0]).toContain('100 B / 100 B · processing');
+
+    display.succeed(0);
+    expect(persist).toHaveBeenCalledOnce();
+    expect(persist).toHaveBeenCalledWith('◆ archive.zip uploaded · 100 B');
+  });
+
+  it('clears an unfinished live row when the command closes', () => {
+    vi.useFakeTimers();
+    const { clear, live } = fakeLiveOutput();
+    const display = new UploadProgressDisplay(live, false);
+
+    display.start(0, 'archive.zip', 100);
+    display.close();
+
+    expect(clear).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+function fakeLiveOutput() {
+  const clear = vi.fn();
+  const persist = vi.fn();
+  const live = Object.assign(vi.fn(), {
+    clear,
+    done: vi.fn(),
+    persist,
+  }) as unknown as UploadProgressOutput & ReturnType<typeof vi.fn>;
+  return { clear, live, persist };
+}

--- a/packages/cli/src/core/uploadProgress.test.ts
+++ b/packages/cli/src/core/uploadProgress.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CliRuntime, GlobalFlags } from './runtime';
 import {
+  createUploadProgressDisplay,
   UploadProgressDisplay,
   type UploadProgressOutput,
 } from './uploadProgress';
@@ -93,6 +95,52 @@ describe('UploadProgressDisplay', () => {
 
     expect(live.mock.lastCall?.[0]).toBe('◆ archive.zip uploaded · 8 MB');
     display.close();
+  });
+
+  it('does not render live progress when stderr is redirected', () => {
+    const write = vi.fn(() => true);
+    const runtime = {
+      env: {},
+      io: {
+        stderr: { write },
+        outputIsTty: true,
+        stderrIsTty: false,
+      },
+    } as unknown as CliRuntime;
+    const flags: GlobalFlags = {
+      color: false,
+      progress: true,
+    };
+    const display = createUploadProgressDisplay(runtime, flags);
+
+    display.start(0, 'archive.zip', 100);
+    display.succeed(0);
+    display.close();
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('renders live progress when stdout is redirected but stderr is a TTY', () => {
+    const write = vi.fn(() => true);
+    const runtime = {
+      env: {},
+      io: {
+        stderr: { write },
+        outputIsTty: false,
+        stderrIsTty: true,
+      },
+    } as unknown as CliRuntime;
+    const flags: GlobalFlags = {
+      color: false,
+      progress: true,
+    };
+    const display = createUploadProgressDisplay(runtime, flags);
+
+    display.start(0, 'archive.zip', 100);
+    display.succeed(0);
+    display.close();
+
+    expect(write).toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/core/uploadProgress.test.ts
+++ b/packages/cli/src/core/uploadProgress.test.ts
@@ -113,10 +113,7 @@ describe('UploadProgressDisplay', () => {
     };
     const display = createUploadProgressDisplay(runtime, flags);
 
-    display.start(0, 'archive.zip', 100);
-    display.succeed(0);
-    display.close();
-
+    expect(display).toBeUndefined();
     expect(write).not.toHaveBeenCalled();
   });
 
@@ -135,6 +132,8 @@ describe('UploadProgressDisplay', () => {
       progress: true,
     };
     const display = createUploadProgressDisplay(runtime, flags);
+    expect(display).toBeDefined();
+    if (!display) throw new Error('Expected an upload progress display.');
 
     display.start(0, 'archive.zip', 100);
     display.succeed(0);

--- a/packages/cli/src/core/uploadProgress.test.ts
+++ b/packages/cli/src/core/uploadProgress.test.ts
@@ -82,6 +82,18 @@ describe('UploadProgressDisplay', () => {
     expect(done).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it('uses familiar labels for binary-scaled file sizes', () => {
+    vi.useFakeTimers();
+    const { live } = fakeLiveOutput();
+    const display = new UploadProgressDisplay(live, false);
+
+    display.start(0, 'archive.zip', 8 * 1024 * 1024);
+    display.succeed(0);
+
+    expect(live.mock.lastCall?.[0]).toBe('◆ archive.zip uploaded · 8 MB');
+    display.close();
+  });
 });
 
 function fakeLiveOutput() {

--- a/packages/cli/src/core/uploadProgress.test.ts
+++ b/packages/cli/src/core/uploadProgress.test.ts
@@ -9,7 +9,7 @@ describe('UploadProgressDisplay', () => {
 
   it('redraws phase changes and ignores duplicate progress events', () => {
     vi.useFakeTimers();
-    const { live, persist } = fakeLiveOutput();
+    const { done, live } = fakeLiveOutput();
     const display = new UploadProgressDisplay(live, false);
 
     display.start(0, 'archive.zip', 100);
@@ -27,12 +27,14 @@ describe('UploadProgressDisplay', () => {
       percentage: 0,
       phase: 'uploading',
     });
+    vi.advanceTimersByTime(80);
     display.update(0, {
       transferredBytes: 50,
       totalBytes: 100,
       percentage: 50,
       phase: 'uploading',
     });
+    vi.advanceTimersByTime(80);
     display.update(0, {
       transferredBytes: 50,
       totalBytes: 100,
@@ -45,6 +47,7 @@ describe('UploadProgressDisplay', () => {
       percentage: 100,
       phase: 'processing',
     });
+    vi.advanceTimersByTime(80);
 
     expect(live).toHaveBeenCalledTimes(4);
     expect(live.mock.calls[1]?.[0]).toContain('0 B / 100 B · uploading');
@@ -52,19 +55,31 @@ describe('UploadProgressDisplay', () => {
     expect(live.mock.calls[3]?.[0]).toContain('100 B / 100 B · processing');
 
     display.succeed(0);
-    expect(persist).toHaveBeenCalledOnce();
-    expect(persist).toHaveBeenCalledWith('◆ archive.zip uploaded · 100 B');
+    expect(live.mock.lastCall?.[0]).toBe('◆ archive.zip uploaded · 100 B');
+
+    display.close();
+    expect(done).toHaveBeenCalledOnce();
   });
 
-  it('clears an unfinished live row when the command closes', () => {
+  it('keeps rows in input order as uploads finish', () => {
     vi.useFakeTimers();
-    const { clear, live } = fakeLiveOutput();
+    const { done, live } = fakeLiveOutput();
     const display = new UploadProgressDisplay(live, false);
 
-    display.start(0, 'archive.zip', 100);
+    display.start(0, 'first.zip', 100);
+    display.start(1, 'second.zip', 200);
+    display.start(2, 'third.zip', 300);
+    display.succeed(2);
+    display.succeed(1);
+
+    const rows = String(live.mock.lastCall?.[0]).split('\n');
+    expect(rows[0]).toContain('first.zip');
+    expect(rows[1]).toBe('◆ second.zip uploaded · 200 B');
+    expect(rows[2]).toBe('◆ third.zip uploaded · 300 B');
+
     display.close();
 
-    expect(clear).toHaveBeenCalled();
+    expect(done).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
   });
 });
@@ -72,10 +87,11 @@ describe('UploadProgressDisplay', () => {
 function fakeLiveOutput() {
   const clear = vi.fn();
   const persist = vi.fn();
+  const done = vi.fn();
   const live = Object.assign(vi.fn(), {
     clear,
-    done: vi.fn(),
+    done,
     persist,
   }) as unknown as UploadProgressOutput & ReturnType<typeof vi.fn>;
-  return { clear, live, persist };
+  return { clear, done, live, persist };
 }

--- a/packages/cli/src/core/uploadProgress.ts
+++ b/packages/cli/src/core/uploadProgress.ts
@@ -117,7 +117,7 @@ export function createUploadProgressDisplay(
   flags: GlobalFlags,
 ): UploadProgressDisplay {
   const enabled =
-    flags.progress && !flags.json && !flags.plain && runtime.io.outputIsTty;
+    flags.progress && !flags.json && !flags.plain && runtime.io.stderrIsTty;
   return new UploadProgressDisplay(
     enabled
       ? createLogUpdate(runtime.io.stderr, {

--- a/packages/cli/src/core/uploadProgress.ts
+++ b/packages/cli/src/core/uploadProgress.ts
@@ -12,6 +12,7 @@ type UploadEntry = {
   fileName: string;
   totalBytes: number;
   progress: UploadProgress;
+  status: 'active' | 'succeeded' | 'failed' | 'canceled';
 };
 
 export class UploadProgressDisplay {
@@ -38,6 +39,7 @@ export class UploadProgressDisplay {
         percentage: 0,
         phase: 'preparing',
       },
+      status: 'active',
     });
     this.startTimer();
     this.render();
@@ -45,36 +47,30 @@ export class UploadProgressDisplay {
 
   update(id: number, progress: UploadProgress): void {
     const entry = this.entries.get(id);
-    if (!entry || sameProgress(entry.progress, progress)) return;
+    if (entry?.status !== 'active' || sameProgress(entry.progress, progress))
+      return;
     entry.progress = progress;
-    this.render();
   }
 
   succeed(id: number): void {
     const entry = this.entries.get(id);
     if (!entry || !this.live) return;
-    this.entries.delete(id);
-    this.live.persist(
-      `${this.colors.green('◆')} ${entry.fileName} ${this.colors.green('uploaded')} · ${formatBytes(entry.totalBytes)}`,
-    );
+    entry.status = 'succeeded';
     this.afterEntryFinished();
   }
 
   fail(id: number, canceled: boolean): void {
     const entry = this.entries.get(id);
     if (!entry || !this.live) return;
-    this.entries.delete(id);
-    const label = canceled ? 'canceled' : 'failed';
-    this.live.persist(
-      `${this.colors.red('■')} ${entry.fileName} ${this.colors.red(label)}`,
-    );
+    entry.status = canceled ? 'canceled' : 'failed';
     this.afterEntryFinished();
   }
 
   close(): void {
     this.stopTimer();
+    this.render();
+    this.live?.done();
     this.entries.clear();
-    this.live?.clear();
   }
 
   private startTimer(): void {
@@ -93,7 +89,11 @@ export class UploadProgressDisplay {
   }
 
   private afterEntryFinished(): void {
-    if (!this.entries.size) this.stopTimer();
+    if (
+      [...this.entries.values()].every((entry) => entry.status !== 'active')
+    ) {
+      this.stopTimer();
+    }
     this.render();
   }
 
@@ -134,6 +134,13 @@ function renderEntry(
   spinner: string,
   colors: ReturnType<typeof createColors>,
 ): string {
+  if (entry.status === 'succeeded') {
+    return `${colors.green('◆')} ${entry.fileName} ${colors.green('uploaded')} · ${formatBytes(entry.totalBytes)}`;
+  }
+  if (entry.status !== 'active') {
+    return `${colors.red('■')} ${entry.fileName} ${colors.red(entry.status)}`;
+  }
+
   const { progress } = entry;
   const percentage = Math.max(0, Math.min(100, progress.percentage));
   const completed = Math.round((percentage / 100) * BAR_WIDTH);

--- a/packages/cli/src/core/uploadProgress.ts
+++ b/packages/cli/src/core/uploadProgress.ts
@@ -1,0 +1,170 @@
+import type { UploadProgress } from '@edgestore/sdk';
+import { createLogUpdate } from 'log-update';
+import { createColors } from 'picocolors';
+import type { CliRuntime, GlobalFlags } from './runtime';
+
+const SPINNER_FRAMES = ['◒', '◐', '◓', '◑'];
+const BAR_WIDTH = 18;
+
+export type UploadProgressOutput = ReturnType<typeof createLogUpdate>;
+
+type UploadEntry = {
+  fileName: string;
+  totalBytes: number;
+  progress: UploadProgress;
+};
+
+export class UploadProgressDisplay {
+  private readonly entries = new Map<number, UploadEntry>();
+  private readonly colors;
+  private timer: NodeJS.Timeout | undefined;
+  private frame = 0;
+
+  constructor(
+    private readonly live: UploadProgressOutput | undefined,
+    color: boolean,
+  ) {
+    this.colors = createColors(color);
+  }
+
+  start(id: number, fileName: string, totalBytes: number): void {
+    if (!this.live) return;
+    this.entries.set(id, {
+      fileName,
+      totalBytes,
+      progress: {
+        transferredBytes: 0,
+        totalBytes,
+        percentage: 0,
+        phase: 'preparing',
+      },
+    });
+    this.startTimer();
+    this.render();
+  }
+
+  update(id: number, progress: UploadProgress): void {
+    const entry = this.entries.get(id);
+    if (!entry || sameProgress(entry.progress, progress)) return;
+    entry.progress = progress;
+    this.render();
+  }
+
+  succeed(id: number): void {
+    const entry = this.entries.get(id);
+    if (!entry || !this.live) return;
+    this.entries.delete(id);
+    this.live.persist(
+      `${this.colors.green('◆')} ${entry.fileName} ${this.colors.green('uploaded')} · ${formatBytes(entry.totalBytes)}`,
+    );
+    this.afterEntryFinished();
+  }
+
+  fail(id: number, canceled: boolean): void {
+    const entry = this.entries.get(id);
+    if (!entry || !this.live) return;
+    this.entries.delete(id);
+    const label = canceled ? 'canceled' : 'failed';
+    this.live.persist(
+      `${this.colors.red('■')} ${entry.fileName} ${this.colors.red(label)}`,
+    );
+    this.afterEntryFinished();
+  }
+
+  close(): void {
+    this.stopTimer();
+    this.entries.clear();
+    this.live?.clear();
+  }
+
+  private startTimer(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      this.frame = (this.frame + 1) % SPINNER_FRAMES.length;
+      this.render();
+    }, 80);
+    this.timer.unref();
+  }
+
+  private stopTimer(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  private afterEntryFinished(): void {
+    if (!this.entries.size) this.stopTimer();
+    this.render();
+  }
+
+  private render(): void {
+    if (!this.live) return;
+    if (!this.entries.size) {
+      this.live.clear();
+      return;
+    }
+    const spinner = this.colors.magenta(SPINNER_FRAMES[this.frame] ?? '◒');
+    this.live(
+      [...this.entries.values()]
+        .map((entry) => renderEntry(entry, spinner, this.colors))
+        .join('\n'),
+    );
+  }
+}
+
+export function createUploadProgressDisplay(
+  runtime: CliRuntime,
+  flags: GlobalFlags,
+): UploadProgressDisplay {
+  const enabled =
+    flags.progress && !flags.json && !flags.plain && runtime.io.outputIsTty;
+  return new UploadProgressDisplay(
+    enabled
+      ? createLogUpdate(runtime.io.stderr, {
+          showCursor: true,
+          defaultWidth: 80,
+        })
+      : undefined,
+    enabled && flags.color && runtime.env.NO_COLOR === undefined,
+  );
+}
+
+function renderEntry(
+  entry: UploadEntry,
+  spinner: string,
+  colors: ReturnType<typeof createColors>,
+): string {
+  const { progress } = entry;
+  const percentage = Math.max(0, Math.min(100, progress.percentage));
+  const completed = Math.round((percentage / 100) * BAR_WIDTH);
+  const bar = `${colors.magenta('━'.repeat(completed))}${colors.dim('─'.repeat(BAR_WIDTH - completed))}`;
+  const transfer = `${formatBytes(progress.transferredBytes)} / ${formatBytes(progress.totalBytes)}`;
+  return `${spinner} ${entry.fileName}  ${bar} ${formatPercentage(percentage)} · ${transfer} · ${progress.phase}`;
+}
+
+function sameProgress(left: UploadProgress, right: UploadProgress): boolean {
+  return (
+    left.transferredBytes === right.transferredBytes &&
+    left.totalBytes === right.totalBytes &&
+    left.percentage === right.percentage &&
+    left.phase === right.phase
+  );
+}
+
+function formatPercentage(percentage: number): string {
+  return `${Number(percentage.toFixed(2))}%`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes / 1024;
+  let unit = units[0] ?? 'KiB';
+  for (const candidate of units.slice(1)) {
+    if (value < 1024) break;
+    value /= 1024;
+    unit = candidate;
+  }
+  const precision = value >= 10 ? 0 : 1;
+  return `${Number(value.toFixed(precision))} ${unit}`;
+}

--- a/packages/cli/src/core/uploadProgress.ts
+++ b/packages/cli/src/core/uploadProgress.ts
@@ -164,9 +164,9 @@ function formatPercentage(percentage: number): string {
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
-  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  const units = ['KB', 'MB', 'GB', 'TB'];
   let value = bytes / 1024;
-  let unit = units[0] ?? 'KiB';
+  let unit = units[0] ?? 'KB';
   for (const candidate of units.slice(1)) {
     if (value < 1024) break;
     value /= 1024;

--- a/packages/cli/src/core/uploadProgress.ts
+++ b/packages/cli/src/core/uploadProgress.ts
@@ -22,14 +22,13 @@ export class UploadProgressDisplay {
   private frame = 0;
 
   constructor(
-    private readonly live: UploadProgressOutput | undefined,
+    private readonly live: UploadProgressOutput,
     color: boolean,
   ) {
     this.colors = createColors(color);
   }
 
   start(id: number, fileName: string, totalBytes: number): void {
-    if (!this.live) return;
     this.entries.set(id, {
       fileName,
       totalBytes,
@@ -54,14 +53,14 @@ export class UploadProgressDisplay {
 
   succeed(id: number): void {
     const entry = this.entries.get(id);
-    if (!entry || !this.live) return;
+    if (!entry) return;
     entry.status = 'succeeded';
     this.afterEntryFinished();
   }
 
   fail(id: number, canceled: boolean): void {
     const entry = this.entries.get(id);
-    if (!entry || !this.live) return;
+    if (!entry) return;
     entry.status = canceled ? 'canceled' : 'failed';
     this.afterEntryFinished();
   }
@@ -69,7 +68,7 @@ export class UploadProgressDisplay {
   close(): void {
     this.stopTimer();
     this.render();
-    this.live?.done();
+    this.live.done();
     this.entries.clear();
   }
 
@@ -98,7 +97,6 @@ export class UploadProgressDisplay {
   }
 
   private render(): void {
-    if (!this.live) return;
     if (!this.entries.size) {
       this.live.clear();
       return;
@@ -115,17 +113,16 @@ export class UploadProgressDisplay {
 export function createUploadProgressDisplay(
   runtime: CliRuntime,
   flags: GlobalFlags,
-): UploadProgressDisplay {
+): UploadProgressDisplay | undefined {
   const enabled =
     flags.progress && !flags.json && !flags.plain && runtime.io.stderrIsTty;
+  if (!enabled) return undefined;
   return new UploadProgressDisplay(
-    enabled
-      ? createLogUpdate(runtime.io.stderr, {
-          showCursor: true,
-          defaultWidth: 80,
-        })
-      : undefined,
-    enabled && flags.color && runtime.env.NO_COLOR === undefined,
+    createLogUpdate(runtime.io.stderr, {
+      showCursor: true,
+      defaultWidth: 80,
+    }),
+    flags.color && runtime.env.NO_COLOR === undefined,
   );
 }
 

--- a/packages/cli/src/file.test.ts
+++ b/packages/cli/src/file.test.ts
@@ -157,6 +157,9 @@ describe('file', () => {
     );
 
     expect(fixture.uploadFile).toHaveBeenCalledTimes(5);
+    for (const [input] of fixture.uploadFile.mock.calls) {
+      expect(input).not.toHaveProperty('onProgress');
+    }
     expect(fixture.uploadFile.mock.calls[0]?.[0]).toMatchObject({
       signedReadUrl: {},
     });

--- a/packages/cli/src/testFixture.ts
+++ b/packages/cli/src/testFixture.ts
@@ -633,6 +633,7 @@ export function createFixture(): CliTestFixture {
       stderr: stderrStream,
       inputIsTty: true,
       outputIsTty: false,
+      stderrIsTty: false,
     },
     signal: abortController.signal,
     setCwd(cwd) {

--- a/packages/sdk/src/internal/multipartUpload.test.ts
+++ b/packages/sdk/src/internal/multipartUpload.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { classifyCredentials } from '../credentials';
+import { MIN_MULTIPART_PART_SIZE_BYTES } from '../uploadTypes';
+import { uploadParts } from './multipartUpload';
+import { createTransport } from './transport';
+
+describe('uploadParts', () => {
+  it('aggregates interleaved part progress monotonically', async () => {
+    const totalBytes = MIN_MULTIPART_PART_SIZE_BYTES + 1;
+    const progress = vi.fn();
+    let releasePartOne: (() => void) | undefined;
+    let releasePartTwo: (() => void) | undefined;
+    const partOneStarted = new Promise<void>((resolve) => {
+      releasePartOne = resolve;
+    });
+    const partTwoStarted = new Promise<void>((resolve) => {
+      releasePartTwo = resolve;
+    });
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      const partNumber = request.url.endsWith('1') ? 1 : 2;
+      const reader = request.body?.getReader();
+      if (!reader) throw new Error('Expected a multipart request body.');
+
+      await reader.read();
+      if (partNumber === 1) {
+        releasePartOne?.();
+        await partTwoStarted;
+      } else {
+        releasePartTwo?.();
+        await partOneStarted;
+      }
+      while (!(await reader.read()).done) {
+        // Consume the remaining request body to drive progress updates.
+      }
+
+      return new Response(null, {
+        status: 200,
+        headers: { etag: `etag-${partNumber}` },
+      });
+    });
+    const transport = createTransport({
+      credentials: classifyCredentials({ token: 'management-token' }),
+      fetch,
+    });
+
+    const completed = await uploadParts(transport, {
+      body: new Blob([new Uint8Array(totalBytes)]),
+      uploadId: 'upload_123',
+      parts: [
+        { partNumber: 1, signedUrl: 'https://storage.example/part-1' },
+        { partNumber: 2, signedUrl: 'https://storage.example/part-2' },
+      ],
+      partSizeBytes: MIN_MULTIPART_PART_SIZE_BYTES,
+      concurrency: 2,
+      onProgress: progress,
+    });
+
+    expect(completed).toEqual([
+      { partNumber: 1, eTag: 'etag-1' },
+      { partNumber: 2, eTag: 'etag-2' },
+    ]);
+    const transferredBytes = progress.mock.calls.map(
+      ([event]) => event.transferredBytes,
+    );
+    expect(transferredBytes.at(-1)).toBe(totalBytes);
+    for (const [index, value] of transferredBytes.entries()) {
+      if (index === 0) continue;
+      expect(value).toBeGreaterThanOrEqual(transferredBytes[index - 1] ?? 0);
+    }
+  });
+});

--- a/packages/sdk/src/internal/multipartUpload.ts
+++ b/packages/sdk/src/internal/multipartUpload.ts
@@ -23,6 +23,7 @@ export async function uploadParts(
 ): Promise<CompletedUploadPart[]> {
   const completed: CompletedUploadPart[] = Array(options.parts.length);
   let nextIndex = 0;
+  const transferredByPart = Array<number>(options.parts.length).fill(0);
   let transferredBytes = 0;
   const workerCount = Math.min(options.concurrency, options.parts.length);
   const controller = new AbortController();
@@ -45,11 +46,28 @@ export async function uploadParts(
         url: part.signedUrl,
         body: chunk,
         signal,
+        onProgress: options.onProgress
+          ? (partBytes) => {
+              const previousPartBytes = transferredByPart[index] ?? 0;
+              const nextPartBytes = Math.max(previousPartBytes, partBytes);
+              transferredByPart[index] = nextPartBytes;
+              transferredBytes += nextPartBytes - previousPartBytes;
+              reportProgress(
+                options.onProgress,
+                transferredBytes,
+                options.body.size,
+              );
+            }
+          : undefined,
         requireETag: true,
       });
       completed[index] = { partNumber: part.partNumber, eTag };
-      transferredBytes += chunk.size;
-      reportProgress(options.onProgress, transferredBytes, options.body.size);
+      const previousPartBytes = transferredByPart[index] ?? 0;
+      if (previousPartBytes < chunk.size) {
+        transferredByPart[index] = chunk.size;
+        transferredBytes += chunk.size - previousPartBytes;
+        reportProgress(options.onProgress, transferredBytes, options.body.size);
+      }
     }
   });
 
@@ -94,16 +112,34 @@ export async function uploadStreamParts(
           options.uploadId,
         );
       }
+      let partTransferredBytes = 0;
       const eTag = await putWithRetry(transport, {
         uploadId: options.uploadId,
         url: part.signedUrl,
         body: new Blob([Uint8Array.from(chunk)]),
         signal: options.signal,
+        onProgress: options.onProgress
+          ? (partBytes) => {
+              partTransferredBytes = Math.max(partTransferredBytes, partBytes);
+              reportProgress(
+                options.onProgress,
+                transferredBytes +
+                  Math.min(partTransferredBytes, chunk.byteLength),
+                options.totalBytes,
+              );
+            }
+          : undefined,
         requireETag: true,
       });
       completed.push({ partNumber: part.partNumber, eTag });
       transferredBytes += chunk.byteLength;
-      reportProgress(options.onProgress, transferredBytes, options.totalBytes);
+      if (partTransferredBytes < chunk.byteLength) {
+        reportProgress(
+          options.onProgress,
+          transferredBytes,
+          options.totalBytes,
+        );
+      }
     }
 
     if (

--- a/packages/sdk/src/internal/uploadLifecycle.ts
+++ b/packages/sdk/src/internal/uploadLifecycle.ts
@@ -84,11 +84,14 @@ export async function executeUploadLifecycle<
         url: requested.upload.signedUrl,
         body: prepared.body,
         signal,
-      });
-      reportUploadProgress(onProgress, {
-        transferredBytes: totalBytes,
-        totalBytes,
-        phase: 'uploading',
+        onProgress: onProgress
+          ? (transferredBytes) =>
+              reportUploadProgress(onProgress, {
+                transferredBytes,
+                totalBytes,
+                phase: 'uploading',
+              })
+          : undefined,
       });
     } else {
       if (requested.upload.kind !== 'multipart' || !multipartPlan) {

--- a/packages/sdk/src/internal/uploadTransfer.test.ts
+++ b/packages/sdk/src/internal/uploadTransfer.test.ts
@@ -6,17 +6,7 @@ import { putWithRetry } from './uploadTransfer';
 describe('putWithRetry', () => {
   it('reports uploaded bytes while preserving Blob request headers', async () => {
     const onProgress = vi.fn();
-    const body = new Blob(['hello'], { type: 'text/plain' });
-    Object.defineProperty(body, 'stream', {
-      value: () =>
-        new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode('he'));
-            controller.enqueue(new TextEncoder().encode('llo'));
-            controller.close();
-          },
-        }),
-    });
+    const body = chunkedBlob();
     const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
       const request = new Request(input, init);
       expect(request.headers.get('content-length')).toBe('5');
@@ -36,6 +26,35 @@ describe('putWithRetry', () => {
       onProgress,
     });
 
+    expect(onProgress.mock.calls).toEqual([[2], [5]]);
+  });
+
+  it('keeps progress monotonic across retry attempts', async () => {
+    const onProgress = vi.fn();
+    const body = chunkedBlob();
+    let attempts = 0;
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      await expect(request.text()).resolves.toBe('hello');
+      attempts++;
+      return new Response(null, {
+        status: attempts === 1 ? 503 : 200,
+        headers: { 'retry-after': '0' },
+      });
+    });
+    const transport = createTransport({
+      credentials: classifyCredentials({ token: 'management-token' }),
+      fetch,
+    });
+
+    await putWithRetry(transport, {
+      url: 'https://storage.example/upload',
+      body,
+      uploadId: 'upload_123',
+      onProgress,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
     expect(onProgress.mock.calls).toEqual([[2], [5]]);
   });
 
@@ -62,3 +81,18 @@ describe('putWithRetry', () => {
     expect(fetch).toHaveBeenCalledOnce();
   });
 });
+
+function chunkedBlob(): Blob {
+  const body = new Blob(['hello'], { type: 'text/plain' });
+  Object.defineProperty(body, 'stream', {
+    value: () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('he'));
+          controller.enqueue(new TextEncoder().encode('llo'));
+          controller.close();
+        },
+      }),
+  });
+  return body;
+}

--- a/packages/sdk/src/internal/uploadTransfer.test.ts
+++ b/packages/sdk/src/internal/uploadTransfer.test.ts
@@ -4,6 +4,41 @@ import { createTransport } from './transport';
 import { putWithRetry } from './uploadTransfer';
 
 describe('putWithRetry', () => {
+  it('reports uploaded bytes while preserving Blob request headers', async () => {
+    const onProgress = vi.fn();
+    const body = new Blob(['hello'], { type: 'text/plain' });
+    Object.defineProperty(body, 'stream', {
+      value: () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('he'));
+            controller.enqueue(new TextEncoder().encode('llo'));
+            controller.close();
+          },
+        }),
+    });
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(request.headers.get('content-length')).toBe('5');
+      expect(request.headers.get('content-type')).toBe('text/plain');
+      await expect(request.text()).resolves.toBe('hello');
+      return new Response(null, { status: 200 });
+    });
+    const transport = createTransport({
+      credentials: classifyCredentials({ token: 'management-token' }),
+      fetch,
+    });
+
+    await putWithRetry(transport, {
+      url: 'https://storage.example/upload',
+      body,
+      uploadId: 'upload_123',
+      onProgress,
+    });
+
+    expect(onProgress.mock.calls).toEqual([[2], [5]]);
+  });
+
   it('preserves nested Blob read errors without retrying', async () => {
     const blobReadError = new DOMException(
       'The source changed while being read.',

--- a/packages/sdk/src/internal/uploadTransfer.test.ts
+++ b/packages/sdk/src/internal/uploadTransfer.test.ts
@@ -58,6 +58,33 @@ describe('putWithRetry', () => {
     expect(onProgress.mock.calls).toEqual([[2], [5]]);
   });
 
+  it('preserves progress callback errors without retrying', async () => {
+    const progressError = new Error('Progress handler failed.');
+    const onProgress = vi.fn(() => {
+      throw progressError;
+    });
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      await request.text();
+      return new Response(null, { status: 200 });
+    });
+    const transport = createTransport({
+      credentials: classifyCredentials({ token: 'management-token' }),
+      fetch,
+    });
+
+    await expect(
+      putWithRetry(transport, {
+        url: 'https://storage.example/upload',
+        body: chunkedBlob(),
+        uploadId: 'upload_123',
+        onProgress,
+      }),
+    ).rejects.toBe(progressError);
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(onProgress).toHaveBeenCalledOnce();
+  });
+
   it('preserves nested Blob read errors without retrying', async () => {
     const blobReadError = new DOMException(
       'The source changed while being read.',

--- a/packages/sdk/src/internal/uploadTransfer.ts
+++ b/packages/sdk/src/internal/uploadTransfer.ts
@@ -49,12 +49,18 @@ export async function putWithRetry(
   },
 ): Promise<string | undefined> {
   let reportedBytes = 0;
+  let progressFailure: { error: unknown } | undefined;
   const onProgress = options.onProgress
     ? (transferredBytes: number) => {
         const nextBytes = Math.max(reportedBytes, transferredBytes);
         if (nextBytes === reportedBytes) return;
-        reportedBytes = nextBytes;
-        options.onProgress?.(reportedBytes);
+        try {
+          options.onProgress?.(nextBytes);
+          reportedBytes = nextBytes;
+        } catch (error) {
+          progressFailure = { error };
+          throw error;
+        }
       }
     : undefined;
 
@@ -89,10 +95,12 @@ export async function putWithRetry(
       {
         signal: options.signal,
         isRetryable: (error) =>
-          error instanceof SignedUploadResponseError
-            ? isRetryableStatus(error.status)
-            : !findBlobReadError(error) &&
-              !(error instanceof EdgeStoreUploadError),
+          progressFailure
+            ? false
+            : error instanceof SignedUploadResponseError
+              ? isRetryableStatus(error.status)
+              : !findBlobReadError(error) &&
+                !(error instanceof EdgeStoreUploadError),
         getRetryDelayMs: (error) =>
           error instanceof SignedUploadResponseError
             ? error.retryAfterMs
@@ -100,6 +108,7 @@ export async function putWithRetry(
       },
     );
   } catch (error) {
+    if (progressFailure) throw progressFailure.error;
     if (error instanceof EdgeStoreAbortError) throw error;
     if (error instanceof EdgeStoreUploadError) throw error;
     const blobReadError = findBlobReadError(error);

--- a/packages/sdk/src/internal/uploadTransfer.ts
+++ b/packages/sdk/src/internal/uploadTransfer.ts
@@ -22,6 +22,7 @@ export function putWithRetry(
     body: Blob;
     uploadId: string;
     signal?: AbortSignal;
+    onProgress?: (transferredBytes: number) => void;
     requireETag: true;
   },
 ): Promise<string>;
@@ -32,6 +33,7 @@ export function putWithRetry(
     body: Blob;
     uploadId: string;
     signal?: AbortSignal;
+    onProgress?: (transferredBytes: number) => void;
     requireETag?: false;
   },
 ): Promise<string | undefined>;
@@ -42,17 +44,17 @@ export async function putWithRetry(
     body: Blob;
     uploadId: string;
     signal?: AbortSignal;
+    onProgress?: (transferredBytes: number) => void;
     requireETag?: boolean;
   },
 ): Promise<string | undefined> {
   try {
     return await retry(
       async (signal) => {
-        const response = await transport.fetch(options.url, {
-          method: 'PUT',
-          body: options.body,
-          signal,
-        });
+        const response = await transport.fetch(
+          options.url,
+          createUploadRequest(options.body, signal, options.onProgress),
+        );
 
         try {
           if (!response.ok) {
@@ -100,6 +102,37 @@ export async function putWithRetry(
       { cause: error },
     );
   }
+}
+
+function createUploadRequest(
+  body: Blob,
+  signal: AbortSignal | undefined,
+  onProgress: ((transferredBytes: number) => void) | undefined,
+): RequestInit {
+  if (!onProgress) {
+    return { method: 'PUT', body, signal };
+  }
+
+  let transferredBytes = 0;
+  const stream = body.stream().pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        transferredBytes += chunk.byteLength;
+        onProgress(Math.min(transferredBytes, body.size));
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+  const headers = new Headers({ 'content-length': String(body.size) });
+  if (body.type) headers.set('content-type', body.type);
+
+  return {
+    method: 'PUT',
+    body: stream,
+    headers,
+    signal,
+    duplex: 'half',
+  } as RequestInit & { duplex: 'half' };
 }
 
 function findBlobReadError(error: unknown): DOMException | undefined {

--- a/packages/sdk/src/internal/uploadTransfer.ts
+++ b/packages/sdk/src/internal/uploadTransfer.ts
@@ -48,12 +48,22 @@ export async function putWithRetry(
     requireETag?: boolean;
   },
 ): Promise<string | undefined> {
+  let reportedBytes = 0;
+  const onProgress = options.onProgress
+    ? (transferredBytes: number) => {
+        const nextBytes = Math.max(reportedBytes, transferredBytes);
+        if (nextBytes === reportedBytes) return;
+        reportedBytes = nextBytes;
+        options.onProgress?.(reportedBytes);
+      }
+    : undefined;
+
   try {
     return await retry(
       async (signal) => {
         const response = await transport.fetch(
           options.url,
-          createUploadRequest(options.body, signal, options.onProgress),
+          createUploadRequest(options.body, signal, onProgress),
         );
 
         try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,6 +896,9 @@ importers:
       env-paths:
         specifier: 4.0.0
         version: 4.0.0
+      log-update:
+        specifier: 8.0.0
+        version: 8.0.0
       open:
         specifier: 11.0.0
         version: 11.0.0
@@ -5358,6 +5361,10 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -5373,6 +5380,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
@@ -6045,6 +6056,10 @@ packages:
         optional: true
       wrangler:
         optional: true
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -6906,6 +6921,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -7311,6 +7330,10 @@ packages:
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
+
+  log-update@8.0.0:
+    resolution: {integrity: sha512-lddSgOt3bPASrylL54ZSpy8nBHns+vBVSoILlVOx+dei300pnLRN958rj/EdlVLKuWlSESU3qdnDZdAI7FXYGg==}
+    engines: {node: '>=22'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -8678,6 +8701,10 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
@@ -8754,6 +8781,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -9531,6 +9562,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@10.0.1:
+    resolution: {integrity: sha512-M0N4xzyzosiIok3svYlEo1sdLZts/8FPgYH/GPC3wvlmPoRvnoManGMrE54waYj3tISA8w6lsdesfVv67qSr8Q==}
+    engines: {node: '>=20'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -13801,6 +13836,10 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -13810,6 +13849,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   ansis@4.3.1: {}
 
@@ -14446,6 +14487,8 @@ snapshots:
       exsolve: 1.1.0
       httpxy: 0.5.5
       srvx: 0.11.22
+
+  environment@1.1.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -15581,6 +15624,10 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -15895,6 +15942,15 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
+
+  log-update@8.0.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 9.0.0
+      string-width: 8.2.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 10.0.1
 
   longest-streak@3.1.0: {}
 
@@ -17687,6 +17743,11 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smol-toml@1.7.0: {}
 
   sonic-boom@4.2.1:
@@ -17750,6 +17811,11 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
@@ -18289,6 +18355,11 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@10.0.1:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.2
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- report byte-level progress while each signed upload request body is consumed
- aggregate multipart progress monotonically across concurrent parts and retries
- replace append-only CLI progress logs with stable, in-place rows that do not move when uploads complete
- show the upload phase, progress bar, percentage, and transferred bytes
- keep JSON, plain, redirected, and `--no-progress` output unchanged

## Stack

1. **#233** - upload progress reporting
2. #234 - parallel file uploads

## Verification

- `pnpm --filter @edgestore/sdk lint`
- `pnpm --filter @edgestore/sdk build`
- `pnpm --filter @edgestore/sdk test` (52 tests)
- `pnpm --filter @edgestore/cli lint`
- `pnpm --filter @edgestore/cli build`
- `pnpm --filter @edgestore/cli test` (230 tests)

## Release

This PR intentionally includes `.changeset/bright-files-progress.md` for the
published SDK and CLI behavior changes. The release workflow will consume the
changeset.
