### PR TITLE
[CLI 18] feat: upload files concurrently

### DIFF
--- a/.changeset/quick-files-upload.md
+++ b/.changeset/quick-files-upload.md
@@ -1,0 +1,6 @@
+---
+'@edgestore/cli': minor
+---
+
+Upload up to three files concurrently and report all file-level failures after
+the active batch settles.

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -62,6 +62,10 @@ export async function fileUploadCommand(
       '--path must end in / when uploading multiple files.',
     );
   }
+  validateUniqueUploadDestinations(localFiles, {
+    destinationPath: input.path,
+    keepName: input.keepName,
+  });
 
   const project = await resolvedProjectRef(runtime, flags, input.project);
   const sdk = await sdkFor(runtime, flags);
@@ -209,6 +213,13 @@ function batchUploadError(input: {
   notAttemptedPaths: string[];
 }): CliError {
   const firstFailure = input.failures[0]?.cause;
+  const suggestions = Array.from(
+    new Set(
+      input.failures.flatMap(
+        (failure) => failure.cause.options.suggestions ?? [],
+      ),
+    ),
+  );
   const lines = [
     `Upload batch finished with ${input.failures.length} failure${input.failures.length === 1 ? '' : 's'}.`,
     `Completed (${input.results.length}):`,
@@ -237,9 +248,50 @@ function batchUploadError(input: {
       notAttemptedPaths: input.notAttemptedPaths,
     },
     requestId: firstFailure?.options.requestId,
-    suggestions: firstFailure?.options.suggestions,
+    ...(suggestions.length ? { suggestions } : {}),
     exitCode: firstFailure?.exitCode,
   });
+}
+
+function validateUniqueUploadDestinations(
+  localFiles: string[],
+  options: { destinationPath?: string; keepName?: boolean },
+): void {
+  const filesByDestination = new Map<string, string[]>();
+  for (const localFile of localFiles) {
+    const destination = resolveUploadDestination(options.destinationPath, {
+      fileName: path.basename(localFile),
+      keepName: options.keepName,
+    });
+    if (!destination.fileName) continue;
+    const remotePath = path.posix.join(
+      destination.path ?? '',
+      destination.fileName,
+    );
+    const files = filesByDestination.get(remotePath) ?? [];
+    files.push(localFile);
+    filesByDestination.set(remotePath, files);
+  }
+
+  const conflicts = [...filesByDestination.entries()].filter(
+    ([, files]) => files.length > 1,
+  );
+  if (!conflicts.length) return;
+
+  throw usageError(
+    'upload_destination_conflict',
+    [
+      'Multiple files resolve to the same upload destination:',
+      ...conflicts.flatMap(([remotePath, files]) => [
+        `  ${remotePath}`,
+        ...files.map((file) => `    ${file}`),
+      ]),
+    ].join('\n'),
+    [
+      'Rename the local files so each destination is unique.',
+      'Omit --keep-name to let EdgeStore generate unique file names.',
+    ],
+  );
 }
 
 function resolveUploadDestination(

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -4,10 +4,23 @@ import path from 'node:path';
 import { EdgeStoreUploadCleanupError } from '@edgestore/sdk';
 import { renderCliCommand } from '../core/command';
 import { CliError, normalizeError, usageError } from '../core/errors';
-import type { CliRuntime, GlobalFlags } from '../core/runtime';
+import type { CliRuntime, CliSdk, GlobalFlags } from '../core/runtime';
 import { isInteractive, outputFor, sdkFor } from '../core/runtime';
-import { createUploadProgressDisplay } from '../core/uploadProgress';
+import {
+  createUploadProgressDisplay,
+  type UploadProgressDisplay,
+} from '../core/uploadProgress';
 import { resolvedProjectRef } from './project';
+
+const FILE_UPLOAD_CONCURRENCY = 3;
+
+type CompletedUpload = Awaited<
+  ReturnType<CliSdk['management']['uploads']['upload']>
+> & { localPath: string };
+
+type UploadOutcome =
+  | { status: 'completed'; result: CompletedUpload }
+  | { status: 'failed'; localPath: string; cause: CliError };
 
 export async function fileUploadCommand(
   runtime: CliRuntime,
@@ -52,79 +65,61 @@ export async function fileUploadCommand(
 
   const project = await resolvedProjectRef(runtime, flags, input.project);
   const sdk = await sdkFor(runtime, flags);
-  const results = [];
   const progressDisplay = createUploadProgressDisplay(runtime, flags);
+  let outcomes: (UploadOutcome | undefined)[];
   try {
-    for (const [index, localFile] of localFiles.entries()) {
+    const upload = async (
+      localFile: string,
+      index: number,
+    ): Promise<UploadOutcome> => {
       try {
-        const fileName = path.basename(localFile);
-        const mimeType = mimeTypeFor(fileName);
-        const destination = resolveUploadDestination(input.path, {
-          fileName,
-          keepName: input.keepName,
-        });
-        const source = await openAsBlob(
-          localFile,
-          mimeType ? { type: mimeType } : undefined,
-        );
-        progressDisplay?.start(index, fileName, source.size);
-        try {
-          const completed = await sdk.management.uploads.upload({
+        return {
+          status: 'completed',
+          result: await uploadLocalFile({
+            runtime,
+            flags,
+            sdk,
+            progressDisplay,
+            index,
+            localFile,
             project,
             bucket: input.bucket,
-            source,
-            signedReadUrl: {},
-            ...(destination.fileName ? { fileName: destination.fileName } : {}),
-            ...(destination.path ? { path: destination.path } : {}),
-            mimeType,
-            signal: runtime.signal,
-            ...(progressDisplay
-              ? {
-                  onProgress: (progress) =>
-                    progressDisplay.update(index, progress),
-                }
-              : {}),
-          });
-          progressDisplay?.succeed(index);
-          results.push({ localPath: localFile, ...completed });
-        } catch (error) {
-          progressDisplay?.fail(index, runtime.signal.aborted);
-          throw normalizeUploadError(error, { runtime, flags, project });
-        }
+            destinationPath: input.path,
+            keepName: input.keepName,
+          }),
+        };
       } catch (error) {
-        if (localFiles.length === 1) throw error;
-        const cause = normalizeError(error);
-        const notAttemptedPaths = localFiles.slice(index + 1);
-        throw new CliError(
-          'file_upload_incomplete',
-          [
-            `Upload batch stopped while processing ${localFile}: ${cause.message}`,
-            `Completed (${results.length}):`,
-            ...results.map(
-              (result) =>
-                `  ${result.localPath} -> ${result.signedReadUrl?.signedUrl ?? result.file.url} (${result.file.id})`,
-            ),
-            `Interrupted: ${localFile}`,
-            `Not attempted (${notAttemptedPaths.length}):`,
-            ...notAttemptedPaths.map((file) => `  ${file}`),
-          ].join('\n'),
-          {
-            details: {
-              completed: results,
-              interruptedPath: localFile,
-              notAttemptedPaths,
-              cause: errorDetails(cause),
-            },
-            requestId: cause.options.requestId,
-            suggestions: cause.options.suggestions,
-            exitCode: cause.exitCode,
-          },
-        );
+        return {
+          status: 'failed',
+          localPath: localFile,
+          cause: normalizeError(error),
+        };
       }
-    }
+    };
+    outcomes =
+      localFiles.length === 1
+        ? [await upload(localFiles[0]!, 0)]
+        : await mapConcurrent(localFiles, upload, {
+            concurrency: FILE_UPLOAD_CONCURRENCY,
+            signal: runtime.signal,
+          });
   } finally {
     progressDisplay?.close();
   }
+
+  const results = outcomes.flatMap((outcome) =>
+    outcome?.status === 'completed' ? [outcome.result] : [],
+  );
+  const failures = outcomes.flatMap((outcome) =>
+    outcome?.status === 'failed' ? [outcome] : [],
+  );
+  const notAttemptedPaths = localFiles.filter((_, index) => !outcomes[index]);
+  if (failures.length || notAttemptedPaths.length) {
+    if (localFiles.length === 1 && failures[0]) throw failures[0].cause;
+    if (runtime.signal.aborted && !failures.length) throw interruptedError();
+    throw batchUploadError({ results, failures, notAttemptedPaths });
+  }
+
   const human = results
     .map((result) => {
       const readUrl = result.signedReadUrl?.signedUrl ?? result.file.url;
@@ -132,6 +127,119 @@ export async function fileUploadCommand(
     })
     .join('\n');
   outputFor(runtime, flags).result({ uploads: results }, human);
+}
+
+async function uploadLocalFile(input: {
+  runtime: CliRuntime;
+  flags: GlobalFlags;
+  sdk: CliSdk;
+  progressDisplay?: UploadProgressDisplay;
+  index: number;
+  localFile: string;
+  project: string;
+  bucket: string;
+  destinationPath?: string;
+  keepName?: boolean;
+}): Promise<CompletedUpload> {
+  const { progressDisplay } = input;
+  const fileName = path.basename(input.localFile);
+  const mimeType = mimeTypeFor(fileName);
+  const destination = resolveUploadDestination(input.destinationPath, {
+    fileName,
+    keepName: input.keepName,
+  });
+  const source = await openAsBlob(
+    input.localFile,
+    mimeType ? { type: mimeType } : undefined,
+  );
+  progressDisplay?.start(input.index, fileName, source.size);
+  try {
+    const completed = await input.sdk.management.uploads.upload({
+      project: input.project,
+      bucket: input.bucket,
+      source,
+      signedReadUrl: {},
+      ...(destination.fileName ? { fileName: destination.fileName } : {}),
+      ...(destination.path ? { path: destination.path } : {}),
+      mimeType,
+      signal: input.runtime.signal,
+      ...(progressDisplay
+        ? {
+            onProgress: (progress) =>
+              progressDisplay.update(input.index, progress),
+          }
+        : {}),
+    });
+    progressDisplay?.succeed(input.index);
+    return { localPath: input.localFile, ...completed };
+  } catch (error) {
+    progressDisplay?.fail(input.index, input.runtime.signal.aborted);
+    throw normalizeUploadError(error, {
+      runtime: input.runtime,
+      flags: input.flags,
+      project: input.project,
+    });
+  }
+}
+
+async function mapConcurrent<TValue, TResult>(
+  values: TValue[],
+  mapper: (value: TValue, index: number) => Promise<TResult>,
+  options: { concurrency: number; signal: AbortSignal },
+): Promise<(TResult | undefined)[]> {
+  const results: (TResult | undefined)[] = Array(values.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(options.concurrency, values.length) },
+    async () => {
+      while (!options.signal.aborted) {
+        const index = nextIndex++;
+        if (index >= values.length) return;
+        results[index] = await mapper(values[index]!, index);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function batchUploadError(input: {
+  results: CompletedUpload[];
+  failures: Extract<UploadOutcome, { status: 'failed' }>[];
+  notAttemptedPaths: string[];
+}): CliError {
+  const firstFailure = input.failures[0]?.cause;
+  const lines = [
+    `Upload batch finished with ${input.failures.length} failure${input.failures.length === 1 ? '' : 's'}.`,
+    `Completed (${input.results.length}):`,
+    ...input.results.map(
+      (result) =>
+        `  ${result.localPath} -> ${result.signedReadUrl?.signedUrl ?? result.file.url} (${result.file.id})`,
+    ),
+    `Failed (${input.failures.length}):`,
+    ...input.failures.map(
+      (failure) => `  ${failure.localPath}: ${failure.cause.message}`,
+    ),
+    ...(input.notAttemptedPaths.length
+      ? [
+          `Not attempted (${input.notAttemptedPaths.length}):`,
+          ...input.notAttemptedPaths.map((file) => `  ${file}`),
+        ]
+      : []),
+  ];
+  return new CliError('file_upload_incomplete', lines.join('\n'), {
+    details: {
+      completed: input.results,
+      failures: input.failures.map((failure) => ({
+        localPath: failure.localPath,
+        cause: errorDetails(failure.cause),
+      })),
+      notAttemptedPaths: input.notAttemptedPaths,
+    },
+    requestId: firstFailure?.options.requestId,
+    suggestions: firstFailure?.options.suggestions,
+    exitCode: firstFailure?.exitCode,
+  });
 }
 
 function resolveUploadDestination(

--- a/packages/cli/src/core/uploadProgress.test.ts
+++ b/packages/cli/src/core/uploadProgress.test.ts
@@ -141,6 +141,26 @@ describe('UploadProgressDisplay', () => {
 
     expect(write).toHaveBeenCalled();
   });
+
+  it('keeps concurrent rows in input order', () => {
+    vi.useFakeTimers();
+    const { live } = fakeLiveOutput();
+    const display = new UploadProgressDisplay(live, false);
+
+    display.start(1, 'second.txt', 20);
+    display.start(0, 'first.txt', 10);
+
+    const frame = live.mock.calls.at(-1)?.[0] ?? '';
+    expect(frame.indexOf('first.txt')).toBeLessThan(
+      frame.indexOf('second.txt'),
+    );
+
+    display.succeed(0);
+    const completedFrame = String(live.mock.lastCall?.[0]).split('\n');
+    expect(completedFrame[0]).toBe('◆ first.txt uploaded · 10 B');
+    expect(completedFrame[1]).toContain('second.txt');
+    display.close();
+  });
 });
 
 function fakeLiveOutput() {

--- a/packages/cli/src/core/uploadProgress.ts
+++ b/packages/cli/src/core/uploadProgress.ts
@@ -103,8 +103,9 @@ export class UploadProgressDisplay {
     }
     const spinner = this.colors.magenta(SPINNER_FRAMES[this.frame] ?? '◒');
     this.live(
-      [...this.entries.values()]
-        .map((entry) => renderEntry(entry, spinner, this.colors))
+      [...this.entries.entries()]
+        .sort(([left], [right]) => left - right)
+        .map(([, entry]) => renderEntry(entry, spinner, this.colors))
         .join('\n'),
     );
   }

--- a/packages/cli/src/file.test.ts
+++ b/packages/cli/src/file.test.ts
@@ -420,6 +420,47 @@ describe('file', () => {
     });
   });
 
+  it('rejects multiple files that resolve to the same destination', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-upload-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    await Promise.all(
+      ['first', 'second'].map(async (directory) => {
+        const parent = path.join(temporaryDirectory!, directory);
+        await mkdir(parent);
+        await writeFile(path.join(parent, 'photo.jpg'), directory);
+      }),
+    );
+
+    const exitCode = await runCli(
+      [
+        '--json',
+        'file',
+        'upload',
+        'first/photo.jpg',
+        'second/photo.jpg',
+        '--bucket',
+        'publicFiles',
+        '--project',
+        project.basePath,
+        '--path',
+        'gallery/',
+        '--keep-name',
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(2);
+    expect(fixture.uploadFile).not.toHaveBeenCalled();
+    const error = JSON.parse(fixture.stderr()).error;
+    expect(error).toMatchObject({ code: 'upload_destination_conflict' });
+    expect(error.message).toContain('gallery/photo.jpg');
+    expect(error.message).toContain('first/photo.jpg');
+    expect(error.message).toContain('second/photo.jpg');
+  });
+
   it('reports every completed and failed file after a batch settles', async () => {
     temporaryDirectory = await mkdtemp(
       path.join(tmpdir(), 'edgestore-cli-upload-'),
@@ -650,6 +691,54 @@ describe('file', () => {
       },
       suggestions: [
         `edgestore --json --api-url https://api-dev.edgestore.dev file upload-cancel upload_123 --yes --project ${project.basePath}`,
+      ],
+    });
+  });
+
+  it('reports cleanup commands for every failed batch upload', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-upload-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    await Promise.all(
+      ['first.txt', 'second.txt'].map((file) =>
+        writeFile(path.join(temporaryDirectory!, file), file),
+      ),
+    );
+    fixture.uploadFile.mockImplementation(async (input) => {
+      const fileName = await (input.source as Blob).text();
+      throw new EdgeStoreUploadCleanupError({
+        message: 'Automatic cancellation failed.',
+        uploadId: `upload_${fileName}`,
+        uploadCause: new Error(`${fileName} transfer failed`),
+        cleanupCause: new Error('cleanup unavailable'),
+      });
+    });
+
+    const exitCode = await runCli(
+      [
+        '--json',
+        '--api-url',
+        'https://api-dev.edgestore.dev',
+        'file',
+        'upload',
+        'first.txt',
+        'second.txt',
+        '--bucket',
+        'publicFiles',
+        '--project',
+        project.basePath,
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(fixture.stderr()).error).toMatchObject({
+      code: 'file_upload_incomplete',
+      suggestions: [
+        `edgestore --json --api-url https://api-dev.edgestore.dev file upload-cancel upload_first.txt --yes --project ${project.basePath}`,
+        `edgestore --json --api-url https://api-dev.edgestore.dev file upload-cancel upload_second.txt --yes --project ${project.basePath}`,
       ],
     });
   });

--- a/packages/cli/src/file.test.ts
+++ b/packages/cli/src/file.test.ts
@@ -333,6 +333,57 @@ describe('file', () => {
     }
   });
 
+  it('uploads at most three files concurrently', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-upload-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    const paths = Array.from({ length: 5 }, (_, index) => `file-${index}.txt`);
+    await Promise.all(
+      paths.map((file) =>
+        writeFile(path.join(temporaryDirectory!, file), file),
+      ),
+    );
+    const releases: (() => void)[] = [];
+    let activeUploads = 0;
+    let maximumActiveUploads = 0;
+    fixture.uploadFile.mockImplementation(async () => {
+      activeUploads += 1;
+      maximumActiveUploads = Math.max(maximumActiveUploads, activeUploads);
+      await new Promise<void>((resolve) => releases.push(resolve));
+      activeUploads -= 1;
+      return {
+        upload: { id: 'upload_completed', status: 'completed' as const },
+        file: uploadedFile,
+      };
+    });
+
+    const command = runCli(
+      [
+        '--json',
+        'file',
+        'upload',
+        ...paths,
+        '--bucket',
+        'publicFiles',
+        '--project',
+        project.basePath,
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    await vi.waitFor(() => expect(fixture.uploadFile).toHaveBeenCalledTimes(3));
+    expect(maximumActiveUploads).toBe(3);
+    for (const release of releases.splice(0)) release();
+    await vi.waitFor(() => expect(fixture.uploadFile).toHaveBeenCalledTimes(5));
+    for (const release of releases.splice(0)) release();
+
+    await expect(command).resolves.toBe(0);
+    expect(maximumActiveUploads).toBe(3);
+    expect(JSON.parse(fixture.stdout()).uploads).toHaveLength(5);
+  });
+
   it('rejects an exact destination for multiple files', async () => {
     temporaryDirectory = await mkdtemp(
       path.join(tmpdir(), 'edgestore-cli-upload-'),
@@ -369,7 +420,7 @@ describe('file', () => {
     });
   });
 
-  it('reports completed and unattempted files when a later upload fails', async () => {
+  it('reports every completed and failed file after a batch settles', async () => {
     temporaryDirectory = await mkdtemp(
       path.join(tmpdir(), 'edgestore-cli-upload-'),
     );
@@ -380,20 +431,21 @@ describe('file', () => {
         writeFile(path.join(temporaryDirectory!, file), file),
       ),
     );
-    let requestCount = 0;
-    fixture.uploadFile.mockImplementation(async () => {
-      requestCount += 1;
-      if (requestCount === 2) throw new Error('second upload request failed');
+    fixture.uploadFile.mockImplementation(async (input) => {
+      const fileName = await (input.source as Blob).text();
+      if (fileName === 'second.txt') {
+        throw new Error('second upload request failed');
+      }
       return {
-        upload: { id: 'upload_first', status: 'completed' as const },
+        upload: { id: `upload_${fileName}`, status: 'completed' as const },
         file: {
           ...uploadedFile,
-          id: 'upload_first',
-          url: 'https://files.example/first.txt',
+          id: `upload_${fileName}`,
+          url: `https://files.example/${fileName}`,
         },
         signedReadUrl: {
-          url: 'https://files.example/first.txt',
-          signedUrl: 'https://files.example/first.txt?signature=test',
+          url: `https://files.example/${fileName}`,
+          signedUrl: `https://files.example/${fileName}?signature=test`,
           expiresAt: '2026-08-08T12:00:00.000Z',
           expiresIn: 3600,
         },
@@ -417,20 +469,81 @@ describe('file', () => {
 
     expect(exitCode).toBe(1);
     expect(fixture.stdout()).toBe('');
-    expect(fixture.uploadFile).toHaveBeenCalledTimes(2);
+    expect(fixture.uploadFile).toHaveBeenCalledTimes(3);
     const error = JSON.parse(fixture.stderr()).error;
     expect(error).toMatchObject({
       code: 'file_upload_incomplete',
       details: {
-        completed: [{ localPath: path.join(temporaryDirectory, 'first.txt') }],
-        interruptedPath: path.join(temporaryDirectory, 'second.txt'),
-        notAttemptedPaths: [path.join(temporaryDirectory, 'third.txt')],
-        cause: { message: 'second upload request failed' },
+        completed: [
+          { localPath: path.join(temporaryDirectory, 'first.txt') },
+          { localPath: path.join(temporaryDirectory, 'third.txt') },
+        ],
+        failures: [
+          {
+            localPath: path.join(temporaryDirectory, 'second.txt'),
+            cause: { message: 'second upload request failed' },
+          },
+        ],
+        notAttemptedPaths: [],
       },
     });
     expect(error.message).toContain(
       'https://files.example/first.txt?signature=test',
     );
+  });
+
+  it('does not schedule more files after a batch is canceled', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'edgestore-cli-upload-'),
+    );
+    fixture.runtime.cwd = temporaryDirectory;
+    const paths = Array.from({ length: 5 }, (_, index) => `file-${index}.txt`);
+    await Promise.all(
+      paths.map((file) =>
+        writeFile(path.join(temporaryDirectory!, file), file),
+      ),
+    );
+    fixture.uploadFile.mockImplementation(
+      async (input) =>
+        await new Promise((_, reject) => {
+          input.signal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('aborted', 'AbortError')),
+            { once: true },
+          );
+        }),
+    );
+
+    const command = runCli(
+      [
+        '--json',
+        'file',
+        'upload',
+        ...paths,
+        '--bucket',
+        'publicFiles',
+        '--project',
+        project.basePath,
+      ],
+      fixture.runtime,
+      '0.0.0',
+    );
+
+    await vi.waitFor(() => expect(fixture.uploadFile).toHaveBeenCalledTimes(3));
+    fixture.abortController.abort();
+
+    await expect(command).resolves.toBe(130);
+    expect(fixture.uploadFile).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(fixture.stderr()).error).toMatchObject({
+      code: 'file_upload_incomplete',
+      details: {
+        failures: [{}, {}, {}],
+        notAttemptedPaths: [
+          path.join(temporaryDirectory, 'file-3.txt'),
+          path.join(temporaryDirectory, 'file-4.txt'),
+        ],
+      },
+    });
   });
 
   it('treats an existing upload path with glob characters literally', async () => {


### PR DESCRIPTION
## Summary

- upload up to three files concurrently while retaining input-ordered results
- render one stable live progress row per file, including after individual uploads finish
- continue scheduling after ordinary file failures and report all failures once the batch settles
- stop scheduling new files after cancellation while preserving active-upload cleanup

## Stack

1. #233 - upload progress reporting
2. **#234** - parallel file uploads

Depends on #233 and should be reviewed after it.

## Verification

- `pnpm --filter @edgestore/cli lint`
- `pnpm --filter @edgestore/cli build`
- `pnpm --filter @edgestore/cli test` (233 tests)

## Release

This PR intentionally includes `.changeset/quick-files-upload.md` for the
published CLI behavior change. The release workflow will consume the changeset.
